### PR TITLE
Split ItemId into several id types

### DIFF
--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -2,12 +2,12 @@ use std::fmt::{Debug, Display, Error, Formatter};
 
 use super::*;
 
-impl Debug for ItemId {
+impl Debug for RawId {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         tls::with_current_program(|p| match p {
-            Some(prog) => prog.debug_item_id(*self, fmt),
+            Some(prog) => prog.debug_raw_id(*self, fmt),
             None => fmt
-                .debug_struct("ItemId")
+                .debug_struct("RawId")
                 .field("index", &self.index)
                 .finish(),
         })

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -4,12 +4,45 @@ use super::*;
 
 impl Debug for RawId {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        fmt.debug_struct("RawId")
+            .field("index", &self.index)
+            .finish()
+    }
+}
+
+impl Debug for TypeKindId {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        match self {
+            TypeKindId::TypeId(id) => write!(fmt, "{:?}", id),
+            TypeKindId::TraitId(id) => write!(fmt, "{:?}", id),
+            TypeKindId::StructId(id) => write!(fmt, "{:?}", id),
+        }
+    }
+}
+
+impl Debug for TypeId {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         tls::with_current_program(|p| match p {
-            Some(prog) => prog.debug_raw_id(*self, fmt),
-            None => fmt
-                .debug_struct("RawId")
-                .field("index", &self.index)
-                .finish(),
+            Some(prog) => prog.debug_type_kind_id(TypeKindId::TypeId(*self), fmt),
+            None => write!(fmt, "{:?}", self.0),
+        })
+    }
+}
+
+impl Debug for TraitId {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        tls::with_current_program(|p| match p {
+            Some(prog) => prog.debug_type_kind_id(TypeKindId::TraitId(*self), fmt),
+            None => write!(fmt, "{:?}", self.0),
+        })
+    }
+}
+
+impl Debug for StructId {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        tls::with_current_program(|p| match p {
+            Some(prog) => prog.debug_type_kind_id(TypeKindId::StructId(*self), fmt),
+            None => write!(fmt, "{:?}", self.0),
         })
     }
 }
@@ -32,6 +65,18 @@ impl Debug for TypeName {
             TypeName::ItemId(id) => write!(fmt, "{:?}", id),
             TypeName::Placeholder(index) => write!(fmt, "{:?}", index),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
+        }
+    }
+}
+
+impl Debug for ItemId {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        match self {
+            ItemId::StructId(id @ StructId(_)) => write!(fmt, "{:?}", TypeKindId::StructId(*id)),
+            ItemId::TraitId(id @ TraitId(_)) => write!(fmt, "{:?}", TypeKindId::TraitId(*id)),
+            ItemId::TypeId(id @ TypeId(_)) => write!(fmt, "{:?}", TypeKindId::TypeId(*id)),
+            ItemId::ImplId(ImplId(id)) => write!(fmt, "{:?}", id),
+            ItemId::ClauseId(ClauseId(id)) => write!(fmt, "{:?}", id),
         }
     }
 }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -62,7 +62,7 @@ impl Debug for UniverseIndex {
 impl Debug for TypeName {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
-            TypeName::ItemId(id) => write!(fmt, "{:?}", id),
+            TypeName::TypeKindId(id) => write!(fmt, "{:?}", id),
             TypeName::Placeholder(index) => write!(fmt, "{:?}", index),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
         }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -482,6 +482,9 @@ macro_rules! copy_fold {
 copy_fold!(Identifier);
 copy_fold!(UniverseIndex);
 copy_fold!(ItemId);
+copy_fold!(StructId);
+copy_fold!(TraitId);
+copy_fold!(TypeId);
 copy_fold!(usize);
 copy_fold!(QuantifierKind);
 copy_fold!(chalk_engine::TableIndex);

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -358,7 +358,7 @@ pub fn super_fold_ty(folder: &mut dyn Folder, ty: &Ty, binders: usize) -> Fallib
                     folder.fold_free_placeholder_ty(ui, binders)
                 }
 
-                TypeName::ItemId(_) | TypeName::AssociatedType(_) => {
+                TypeName::TypeKindId(_) | TypeName::AssociatedType(_) => {
                     let parameters = parameters.fold_with(folder, binders)?;
                     Ok(ApplicationTy { name, parameters }.cast())
                 }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -485,6 +485,7 @@ copy_fold!(ItemId);
 copy_fold!(StructId);
 copy_fold!(TraitId);
 copy_fold!(TypeId);
+copy_fold!(TypeKindId);
 copy_fold!(usize);
 copy_fold!(QuantifierKind);
 copy_fold!(chalk_engine::TableIndex);

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1,3 +1,15 @@
+macro_rules! impl_froms {
+    ($e:ident: $($v:ident), *) => {
+        $(
+            impl From<$v> for $e {
+                fn from(it: $v) -> $e {
+                    $e::$v(it)
+                }
+            }
+        )*
+    }
+}
+
 use crate::cast::Cast;
 use crate::fold::shift::Shift;
 use crate::fold::{
@@ -33,7 +45,7 @@ pub type Identifier = InternedString;
 pub struct ProgramEnvironment {
     /// Indicates whether a given trait has coinductive semantics --
     /// at present, this is true only for auto traits.
-    pub coinductive_traits: BTreeSet<ItemId>,
+    pub coinductive_traits: BTreeSet<TraitId>,
 
     /// Compiled forms of the above:
     pub program_clauses: Vec<ProgramClause>,
@@ -98,7 +110,7 @@ pub enum TypeName {
     Placeholder(PlaceholderIndex),
 
     /// an associated type like `Iterator::Item`; see `AssociatedType` for details
-    AssociatedType(ItemId),
+    AssociatedType(TypeId),
 }
 
 /// An universe index is how a universally quantified parameter is
@@ -131,9 +143,55 @@ impl UniverseIndex {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StructId(pub RawId);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TraitId(pub RawId);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ImplId(pub RawId);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ClauseId(pub RawId);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TypeId(pub RawId);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ItemId {
+    StructId(StructId),
+    TraitId(TraitId),
+    ImplId(ImplId),
+    ClauseId(ClauseId),
+    TypeId(TypeId),
+}
+
+impl_froms!(ItemId: StructId, TraitId, ImplId, ClauseId, TypeId);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TypeKindId {
+    TypeId(TypeId),
+    TraitId(TraitId),
+    StructId(StructId),
+}
+
+impl_froms!(TypeKindId: TypeId, TraitId, StructId);
+
+impl From<TypeKindId> for ItemId {
+    fn from(type_kind_id: TypeKindId) -> ItemId {
+        match type_kind_id {
+            TypeKindId::TypeId(id) => ItemId::TypeId(id),
+            TypeKindId::TraitId(id) => ItemId::TraitId(id),
+            TypeKindId::StructId(id) => ItemId::StructId(id),
+        }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ItemId {
-    pub index: usize,
+#[allow(non_camel_case_types)]
+pub struct RawId {
+    pub index: u32,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -411,7 +469,7 @@ impl Parameter {
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ProjectionTy {
-    pub associated_ty_id: ItemId,
+    pub associated_ty_id: TypeId,
     pub parameters: Vec<Parameter>,
 }
 
@@ -431,7 +489,7 @@ pub type ProjectionTyRefEnum<'a> = ProjectionTyEnum<&'a ProjectionTy, &'a Unsele
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TraitRef {
-    pub trait_id: ItemId,
+    pub trait_id: TraitId,
     pub parameters: Vec<Parameter>,
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -114,7 +114,7 @@ impl<G> InEnvironment<G> {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TypeName {
     /// a type like `Vec<T>`
-    ItemId(ItemId),
+    TypeKindId(TypeKindId),
 
     /// instantiated form a universally quantified type, e.g., from
     /// `forall<T> { .. }`. Stands in as a representative of "some
@@ -606,7 +606,7 @@ pub enum DomainGoal {
     Normalize(Normalize),
     UnselectedNormalize(UnselectedNormalize),
 
-    InScope(ItemId),
+    InScope(TypeKindId),
 
     /// Whether a type can deref into another. Right now this is just:
     /// ```notrust

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -10,6 +10,18 @@ macro_rules! impl_froms {
     }
 }
 
+macro_rules! impl_debugs {
+    ($($id:ident), *) => {
+        $(
+            impl std::fmt::Debug for $id {
+                fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+                    write!(fmt, "{:?}", self.0)
+                }
+            }
+        )*
+    };
+}
+
 use crate::cast::Cast;
 use crate::fold::shift::Shift;
 use crate::fold::{
@@ -143,22 +155,22 @@ impl UniverseIndex {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StructId(pub RawId);
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TraitId(pub RawId);
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImplId(pub RawId);
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClauseId(pub RawId);
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TypeId(pub RawId);
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ItemId {
     StructId(StructId),
     TraitId(TraitId),
@@ -168,12 +180,23 @@ pub enum ItemId {
 }
 
 impl_froms!(ItemId: StructId, TraitId, ImplId, ClauseId, TypeId);
+impl_debugs!(ImplId, ClauseId);
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TypeKindId {
     TypeId(TypeId),
     TraitId(TraitId),
     StructId(StructId),
+}
+
+impl TypeKindId {
+    pub fn raw_id(&self) -> RawId {
+        match self {
+            TypeKindId::TypeId(id) => id.0,
+            TypeKindId::TraitId(id) => id.0,
+            TypeKindId::StructId(id) => id.0,
+        }
+    }
 }
 
 impl_froms!(TypeKindId: TypeId, TraitId, StructId);

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -18,7 +18,7 @@ macro_rules! ty {
 
     (projection (item $n:tt) $($arg:tt)*) => {
         $crate::Ty::Projection(ProjectionTy {
-            associated_ty_id: ItemId { index: $n },
+            associated_ty_id: TypeId(RawId { index: $n }),
             parameters: vec![$(arg!($arg)),*],
         })
     };
@@ -77,7 +77,7 @@ macro_rules! lifetime {
 #[macro_export]
 macro_rules! ty_name {
     ((item $n:expr)) => {
-        $crate::TypeName::ItemId(ItemId { index: $n })
+        $crate::TypeName::TypeKindId(TypeKindId::TypeId(TypeId(RawId { index: $n })))
     };
     ((placeholder $n:expr)) => {
         $crate::TypeName::Placeholder(PlaceholderIndex {

--- a/chalk-ir/src/tls.rs
+++ b/chalk-ir/src/tls.rs
@@ -1,4 +1,4 @@
-use crate::{ProjectionTy, RawId};
+use crate::{ProjectionTy, TypeKindId};
 use std::cell::RefCell;
 use std::fmt;
 use std::sync::Arc;
@@ -8,7 +8,11 @@ thread_local! {
 }
 
 pub trait DebugContext {
-    fn debug_raw_id(&self, id: RawId, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error>;
+    fn debug_type_kind_id(
+        &self,
+        id: TypeKindId,
+        fmt: &mut fmt::Formatter,
+    ) -> Result<(), fmt::Error>;
 
     fn debug_projection(
         &self,

--- a/chalk-ir/src/tls.rs
+++ b/chalk-ir/src/tls.rs
@@ -1,4 +1,4 @@
-use crate::{ItemId, ProjectionTy};
+use crate::{ProjectionTy, RawId};
 use std::cell::RefCell;
 use std::fmt;
 use std::sync::Arc;
@@ -8,7 +8,7 @@ thread_local! {
 }
 
 pub trait DebugContext {
-    fn debug_item_id(&self, item_id: ItemId, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error>;
+    fn debug_raw_id(&self, id: RawId, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error>;
 
     fn debug_projection(
         &self,

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -148,6 +148,9 @@ macro_rules! eq_zip {
 }
 
 eq_zip!(ItemId);
+eq_zip!(StructId);
+eq_zip!(TraitId);
+eq_zip!(TypeId);
 eq_zip!(TypeName);
 eq_zip!(Identifier);
 eq_zip!(QuantifierKind);

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -151,6 +151,7 @@ eq_zip!(ItemId);
 eq_zip!(StructId);
 eq_zip!(TraitId);
 eq_zip!(TypeId);
+eq_zip!(TypeKindId);
 eq_zip!(TypeName);
 eq_zip!(Identifier);
 eq_zip!(QuantifierKind);

--- a/src/coherence.rs
+++ b/src/coherence.rs
@@ -2,7 +2,7 @@ use petgraph::prelude::*;
 
 use crate::rust_ir::Program;
 use chalk_ir::ProgramEnvironment;
-use chalk_ir::{self, Identifier, ItemId};
+use chalk_ir::{self, Identifier, ImplId};
 use chalk_solve::solve::SolverChoice;
 use failure::Fallible;
 use std::sync::Arc;
@@ -43,7 +43,7 @@ impl Program {
         &self,
         env: Arc<ProgramEnvironment>,
         solver_choice: SolverChoice,
-    ) -> Fallible<Graph<ItemId, ()>> {
+    ) -> Fallible<Graph<ImplId, ()>> {
         // The forest is returned as a graph but built as a GraphMap; this is
         // so that we never add multiple nodes with the same ItemId.
         let mut forest = DiGraphMap::new();
@@ -59,7 +59,7 @@ impl Program {
     }
 
     // Recursively set priorities for those node and all of its children.
-    fn set_priorities(&mut self, idx: NodeIndex, forest: &Graph<ItemId, ()>, p: usize) {
+    fn set_priorities(&mut self, idx: NodeIndex, forest: &Graph<ImplId, ()>, p: usize) {
         // Get the impl datum recorded at this node and reset its priority
         {
             let impl_id = forest

--- a/src/coherence/orphan.rs
+++ b/src/coherence/orphan.rs
@@ -29,7 +29,7 @@ pub(crate) fn perform_orphan_check(
     for impl_datum in local_impls {
         if !solver.orphan_check(impl_datum) {
             let trait_id = impl_datum.binders.value.trait_ref.trait_ref().trait_id;
-            let trait_id = program.type_kinds.get(&trait_id).unwrap().name;
+            let trait_id = program.type_kinds.get(&trait_id.into()).unwrap().name;
             Err(CoherenceError::FailedOrphanCheck(trait_id))?;
         }
     }

--- a/src/coherence/solve.rs
+++ b/src/coherence/solve.rs
@@ -23,7 +23,7 @@ impl Program {
         mut record_specialization: F,
     ) -> Fallible<()>
     where
-        F: FnMut(ItemId, ItemId),
+        F: FnMut(ImplId, ImplId),
     {
         let mut solver = DisjointSolver { env, solver_choice };
 
@@ -53,7 +53,7 @@ impl Program {
 
         // Iterate over every pair of impls for the same trait.
         for (trait_id, impls) in &impl_groupings {
-            let impls: Vec<(&ItemId, &ImplDatum)> = impls.collect();
+            let impls: Vec<(&ImplId, &ImplDatum)> = impls.collect();
 
             for ((&l_id, lhs), (&r_id, rhs)) in impls.into_iter().tuple_combinations() {
                 // Two negative impls never overlap.
@@ -71,7 +71,7 @@ impl Program {
                         (true, false) => record_specialization(l_id, r_id),
                         (false, true) => record_specialization(r_id, l_id),
                         (_, _) => {
-                            let trait_id = self.type_kinds.get(&trait_id).unwrap().name;
+                            let trait_id = self.type_kinds.get(&trait_id.into()).unwrap().name;
                             Err(CoherenceError::OverlappingImpls(trait_id))?;
                         }
                     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -296,7 +296,7 @@ impl AssociatedTyValue {
                 }),
                 conditions: vec![
                     normalize_goal.cast(),
-                    DomainGoal::InScope(impl_trait_ref.trait_id).cast(),
+                    DomainGoal::InScope(impl_trait_ref.trait_id.into()).cast(),
                 ],
             },
         }

--- a/src/rules/wf.rs
+++ b/src/rules/wf.rs
@@ -55,7 +55,11 @@ fn solve_wf_requirements(
 
     for (id, struct_datum) in &program.struct_data {
         if !solver.verify_struct_decl(struct_datum) {
-            let name = program.type_kinds.get(id).unwrap().name;
+            let name = program
+                .type_kinds
+                .get(&TypeKindId::StructId(*id))
+                .unwrap()
+                .name;
             Err(WfError::IllFormedTypeDecl(name))?;
         }
     }
@@ -63,7 +67,11 @@ fn solve_wf_requirements(
     for impl_datum in program.impl_data.values() {
         if !solver.verify_trait_impl(impl_datum) {
             let trait_ref = impl_datum.binders.value.trait_ref.trait_ref();
-            let name = program.type_kinds.get(&trait_ref.trait_id).unwrap().name;
+            let name = program
+                .type_kinds
+                .get(&trait_ref.trait_id.into())
+                .unwrap()
+                .name;
             Err(WfError::IllFormedTraitImpl(name))?;
         }
     }

--- a/src/rust_ir.rs
+++ b/src/rust_ir.rs
@@ -20,7 +20,7 @@ pub mod lowering;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Program {
     /// From type-name to item-id. Used during lowering only.
-    pub(crate) type_ids: BTreeMap<Identifier, TypeId>,
+    pub(crate) type_ids: BTreeMap<Identifier, TypeKindId>,
 
     /// For each struct/trait:
     pub(crate) type_kinds: BTreeMap<TypeKindId, TypeKind>,

--- a/src/rust_ir/lowering.rs
+++ b/src/rust_ir/lowering.rs
@@ -594,7 +594,7 @@ impl LowerStructDefn for StructDefn {
     ) -> Fallible<rust_ir::StructDatum> {
         let binders = env.in_binders(self.all_parameters(), |env| {
             let self_ty = chalk_ir::ApplicationTy {
-                name: chalk_ir::TypeName::ItemId(struct_id.into()),
+                name: chalk_ir::TypeName::TypeKindId(struct_id.into()),
                 parameters: self
                     .all_parameters()
                     .anonymize()
@@ -888,7 +888,7 @@ impl LowerTy for Ty {
                         })?
                     } else {
                         Ok(chalk_ir::Ty::Apply(chalk_ir::ApplicationTy {
-                            name: chalk_ir::TypeName::ItemId(id.into()),
+                            name: chalk_ir::TypeName::TypeKindId(id.into()),
                             parameters: vec![],
                         }))
                     }
@@ -921,7 +921,7 @@ impl LowerTy for Ty {
                 }
 
                 Ok(chalk_ir::Ty::Apply(chalk_ir::ApplicationTy {
-                    name: chalk_ir::TypeName::ItemId(id.into()),
+                    name: chalk_ir::TypeName::TypeKindId(id.into()),
                     parameters: parameters,
                 }))
             }


### PR DESCRIPTION
As part of [Chalk-RLS integration](https://paper.dropbox.com/doc/Chalk-RLS-integration-QCJelXDeaq7GV6jVQln4j), this attempts to split the `ItemId` type into several types like `TypeId` and `TraitId`. I feel that this also improves the code, since code that handles a subset of item kinds becomes more descriptive (which is currently often reflected in variable naming, like in `trait_id: ItemId`)

Similar to how rust-analyzer handles its ids, each id is a newtype wrapper around a single `RawId` type. To keep the solver general over different value types, `ItemId` becomes an enum with variants for all item-id types, with some more specific id enums like `TypeKindId`.

Note: this is an early WIP, I just got it to compile but the tests are still failing, so some types are probably incorrectly assigned.