### PR TITLE
Adding the ability to parse 'default type Foo = Bar' when implementing a trait

### DIFF
--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -144,6 +144,7 @@ pub struct AssocTyValue {
     pub name: Identifier,
     pub parameter_kinds: Vec<ParameterKind>,
     pub value: Ty,
+    pub default: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -151,10 +151,11 @@ ParameterKind: ParameterKind = {
 };
 
 AssocTyValue: AssocTyValue = {
-    "type" <n:Id> <a:Angle<ParameterKind>> "=" <v:Ty> ";" => AssocTyValue {
+    <default:"default"?> "type" <n:Id> <a:Angle<ParameterKind>> "=" <v:Ty> ";" => AssocTyValue {
         name: n,
         parameter_kinds: a,
         value: v,
+        default: default.is_some(),
     },
 };
 


### PR DESCRIPTION
Should be an easy to review PR. This implements the first step laid out by @nikomatsakis here: https://github.com/rust-lang/chalk/issues/219#issuecomment-489219272

> As @sunjay pointed out on Zulip, an obvious first step is:
> 
> Extend the parser to support `default type Foo = Bar` inside of an impl; that should be a flag on the [associated type value](https://github.com/rust-lang/chalk/blob/3238c6d0bc7d09b6eebe069ebd47dfabae787082/chalk-parse/src/ast.rs#L142-L147).

