### PR TITLE
Strip commas in tests

### DIFF
--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -64,6 +64,7 @@ extern crate rustc_hash;
 use crate::context::Context;
 use rustc_hash::FxHashSet;
 use std::cmp::min;
+use std::fmt::{self, Debug};
 use std::usize;
 
 pub mod context;
@@ -164,9 +165,18 @@ enum InnerDelayedLiteralSets<C: Context> {
 /// we get back an approximated answer with `Goal::CannotProve` as a
 /// delayed literal, which in turn forces its subgoal to be delayed,
 /// and so forth. Therefore, we store canonicalized goals.)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
 struct DelayedLiteralSet<C: Context> {
     delayed_literals: FxHashSet<DelayedLiteral<C>>,
+}
+
+impl<T: Context + Debug> Debug for DelayedLiteralSet<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        // Workaround to keep ordering consistent between nightly and stable
+        let mut literals = self.delayed_literals.iter().collect::<Vec<_>>();
+        literals.sort_by_key(|l| format!("{:?}", l));
+        fmt.debug_set().entries(literals.iter()).finish()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/lowering/test.rs
+++ b/src/lowering/test.rs
@@ -191,8 +191,8 @@ fn atc_accounting() {
         let impl_text = format!("{:#?}", &program.impl_data.values().next().unwrap());
         println!("{}", impl_text);
         assert_eq!(
-            &impl_text[..],
-            r#"ImplDatum {
+            &impl_text[..].replace(",\n", "\n"),
+            &r#"ImplDatum {
     binders: for<type> ImplDatumBound {
         trait_ref: Positive(
             Vec<^0> as Iterable
@@ -210,6 +210,7 @@ fn atc_accounting() {
         impl_type: Local
     }
 }"#
+            .replace(",\n", "\n")
         );
         let goal = db
             .parse_and_lower_goal(

--- a/src/test/slg.rs
+++ b/src/test/slg.rs
@@ -41,6 +41,9 @@ fn solve_goal(program_text: &str, goals: Vec<(usize, usize, &str, &str)>) {
                 "{:#?}",
                 slg_solver.force_answers(&db, &peeled_goal, num_answers)
             );
+            // Strip trailing commas to handle both nightly and stable debug formatting
+            let result = result.replace(",\n", "\n");
+            let expected = expected.replace(",\n", "\n");
             assert_test_result_eq(&expected, &result);
         }
     });
@@ -66,6 +69,10 @@ fn solve_goal_fixed_num_answers(program_text: &str, goals: Vec<(usize, usize, &s
             let peeled_goal = goal.into_peeled_goal();
             let mut solver = SolverChoice::SLG { max_size }.into_solver().into_test();
             let result = format!("{:?}", solver.solve(&db, &peeled_goal));
+
+            // Strip trailing commas to handle both nightly and stable debug formatting
+            let result = result.replace(",\n", "\n");
+            let expected = expected.replace(",\n", "\n");
             assert_test_result_eq(&expected, &result);
 
             let num_cached_answers_for_goal = solver.num_cached_answers_for_goal(&db, &peeled_goal);

--- a/src/test/slg.rs
+++ b/src/test/slg.rs
@@ -107,9 +107,7 @@ fn basic() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -144,9 +142,7 @@ fn breadth_first() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -156,9 +152,7 @@ fn breadth_first() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -168,9 +162,7 @@ fn breadth_first() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -180,9 +172,7 @@ fn breadth_first() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -192,9 +182,7 @@ fn breadth_first() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -271,12 +259,10 @@ fn flounder() {
                             Ty(U0)
                         ]
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {
-                            CannotProve(
-                                ()
-                            )
-                        }
+                    delayed_literals: {
+                        CannotProve(
+                            ()
+                        )
                     }
                 }
             ]"
@@ -361,12 +347,10 @@ fn negative_loop() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {
-                            Negative(
-                                TableIndex(1)
-                            )
-                        }
+                    delayed_literals: {
+                        Negative(
+                            TableIndex(1)
+                        )
                     }
                 }
             ]"
@@ -406,9 +390,7 @@ fn subgoal_cycle_uninhabited() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -426,9 +408,7 @@ fn subgoal_cycle_uninhabited() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -447,12 +427,10 @@ fn subgoal_cycle_uninhabited() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {
-                            CannotProve(
-                                ()
-                            )
-                        }
+                    delayed_literals: {
+                        CannotProve(
+                            ()
+                        )
                     }
                 }
             ]"
@@ -471,9 +449,7 @@ fn subgoal_cycle_uninhabited() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -491,9 +467,7 @@ fn subgoal_cycle_uninhabited() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -524,9 +498,7 @@ fn subgoal_cycle_inhabited() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -560,9 +532,7 @@ fn basic_region_constraint_from_positive_impl() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -599,9 +569,7 @@ fn example_2_1_EWFS() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -611,9 +579,7 @@ fn example_2_1_EWFS() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -623,9 +589,7 @@ fn example_2_1_EWFS() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -664,9 +628,7 @@ fn example_2_2_EWFS() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -705,9 +667,7 @@ fn example_2_3_EWFS() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -744,15 +704,13 @@ fn example_3_3_EWFS() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {
-                            Negative(
-                                TableIndex(1)
-                            ),
-                            Negative(
-                                TableIndex(6)
-                            )
-                        }
+                    delayed_literals: {
+                        Negative(
+                            TableIndex(1)
+                        ),
+                        Negative(
+                            TableIndex(6)
+                        )
                     }
                 }
             ]"
@@ -784,12 +742,10 @@ fn contradiction() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {
-                            Negative(
-                                TableIndex(0)
-                            )
-                        }
+                    delayed_literals: {
+                        Negative(
+                            TableIndex(0)
+                        )
                     }
                 }
             ]"
@@ -835,9 +791,7 @@ fn cached_answers_1() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -847,9 +801,7 @@ fn cached_answers_1() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -859,9 +811,7 @@ fn cached_answers_1() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -871,9 +821,7 @@ fn cached_answers_1() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -885,12 +833,10 @@ fn cached_answers_1() {
                             Ty(U0)
                         ]
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {
-                            CannotProve(
-                                ()
-                            )
-                        }
+                    delayed_literals: {
+                        CannotProve(
+                            ()
+                        )
                     }
                 }
             ]"
@@ -925,9 +871,7 @@ fn cached_answers_2() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -937,9 +881,7 @@ fn cached_answers_2() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -949,9 +891,7 @@ fn cached_answers_2() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -961,9 +901,7 @@ fn cached_answers_2() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -975,12 +913,10 @@ fn cached_answers_2() {
                             Ty(U0)
                         ]
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {
-                            CannotProve(
-                                ()
-                            )
-                        }
+                    delayed_literals: {
+                        CannotProve(
+                            ()
+                        )
                     }
                 }
             ]"
@@ -1015,9 +951,7 @@ fn cached_answers_3() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -1027,9 +961,7 @@ fn cached_answers_3() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -1039,9 +971,7 @@ fn cached_answers_3() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 },
                 Answer {
                     subst: Canonical {
@@ -1053,12 +983,10 @@ fn cached_answers_3() {
                             Ty(U0)
                         ]
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {
-                            CannotProve(
-                                ()
-                            )
-                        }
+                    delayed_literals: {
+                        CannotProve(
+                            ()
+                        )
                     }
                 },
                 Answer {
@@ -1069,9 +997,7 @@ fn cached_answers_3() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {}
-                    }
+                    delayed_literals: {}
                 }
             ]"
         }
@@ -1105,12 +1031,10 @@ fn negative_answer_delayed_literal() {
                         },
                         binders: []
                     },
-                    delayed_literals: DelayedLiteralSet {
-                        delayed_literals: {
-                            Negative(
-                                TableIndex(1)
-                            )
-                        }
+                    delayed_literals: {
+                        Negative(
+                            TableIndex(1)
+                        )
                     }
                 }
             ]"


### PR DESCRIPTION
Mostly fixes #220, with the exception of `test::slg::example_3_3_EWFS`, where the ordering of the `1` and `6` get reversed on nightly:
```
                        delayed_literals: {
                            Negative(
                                TableIndex(1)
                            )
                            Negative(
                                TableIndex(6)
                            )
                        }
```