### PR TITLE
Allow limiting search time using fuel

### DIFF
--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -113,6 +113,35 @@ impl Solver {
     ///     each time you invoke `solve`, as otherwise the cached data may be
     ///     invalid.
     /// - `goal` the goal to solve
+    /// - `fuel` if `Some`, this limits how much time the solver spends before giving up.
+    ///
+    /// # Returns
+    ///
+    /// - `None` is the goal cannot be proven.
+    /// - `Some(solution)` if we succeeded in finding *some* answers,
+    ///   although `solution` may reflect ambiguity and unknowns.
+    pub fn solve_with_fuel(
+        &mut self,
+        program: &dyn RustIrDatabase,
+        goal: &UCanonical<InEnvironment<Goal>>,
+        fuel: Option<usize>,
+    ) -> Option<Solution> {
+        let ops = self.forest.context().ops(program);
+        self.forest.solve(&ops, goal, fuel)
+    }
+
+    /// Attempts to solve the given goal, which must be in canonical
+    /// form. Returns a unique solution (if one exists).  This will do
+    /// only as much work towards `goal` as it has to (and that work
+    /// is cached for future attempts).
+    ///
+    /// # Parameters
+    ///
+    /// - `program` -- defines the program clauses in scope.
+    ///   - **Important:** You must supply the same set of program clauses
+    ///     each time you invoke `solve`, as otherwise the cached data may be
+    ///     invalid.
+    /// - `goal` the goal to solve
     ///
     /// # Returns
     ///
@@ -124,8 +153,7 @@ impl Solver {
         program: &dyn RustIrDatabase,
         goal: &UCanonical<InEnvironment<Goal>>,
     ) -> Option<Solution> {
-        let ops = self.forest.context().ops(program);
-        self.forest.solve(&ops, goal)
+        self.solve_with_fuel(program, goal, None)
     }
 
     pub fn into_test(self) -> TestSolver {


### PR DESCRIPTION
To use Chalk in an IDE environment (i.e. rust-analyzer), we need to be able to prevent it from taking
too much time, even if that means getting a wrong or incomplete answer.
This is an attempt to do so by specifying an amount of 'fuel'; each iteration of the top-level
search loop takes one unit of fuel, and when it runs out, we return.

I'm not sure what answer to return if fuel runs out, or if there's some other big problem with this approach; I've tested it with rust-analyzer though, and it fixes (or rather limits) the slow cases I've run into. Also, maybe you have a better suggestion for the name ;)