### PR TITLE
Introduce concept of floundering

### DIFF
--- a/chalk-engine/src/README.md
+++ b/chalk-engine/src/README.md
@@ -246,7 +246,7 @@ The first thing we do when we create a table is to initialize it with
 a set of strands. These strands represent all the ways that one can
 solve the table's associated goal. For an ordinary trait, we would
 effectively create one strand per "relevant impl". But sometimes the
-goals are vague for this to be possible; other times, it may be possible
+goals are too vague for this to be possible; other times, it may be possible
 but just really inefficient, since all of those strands must be explored.
 
 As an example of when it may not be possible, consider a goal like

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -284,7 +284,7 @@ pub trait UnificationOps<C: Context, I: Context> {
     /// unresolved type variables that would have to be resolved
     /// first; the goal will be considered floundered.
     fn program_clauses(
-        &self,
+        &mut self,
         environment: &I::Environment,
         goal: &I::DomainGoal,
     ) -> Option<Vec<I::ProgramClause>>;

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -272,11 +272,16 @@ pub trait InferenceTable<C: Context, I: Context>:
 pub trait UnificationOps<C: Context, I: Context> {
     /// Returns the set of program clauses that might apply to
     /// `goal`. (This set can be over-approximated, naturally.)
+    ///
+    /// If this callback returns `None`, that indicates that the set
+    /// of program clauses cannot be enumerated because there are
+    /// unresolved type variables that would have to be resolved
+    /// first; the goal will be considered floundered.
     fn program_clauses(
         &self,
         environment: &I::Environment,
         goal: &I::DomainGoal,
-    ) -> Vec<I::ProgramClause>;
+    ) -> Option<Vec<I::ProgramClause>>;
 
     // Used by: simplify
     fn instantiate_binders_universally(&mut self, arg: &I::BindersGoal) -> I::Goal;

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -170,6 +170,12 @@ pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
     /// True if this is a coinductive goal -- e.g., proving an auto trait.
     fn is_coinductive(&self, goal: &C::UCanonicalGoalInEnvironment) -> bool;
 
+    /// Returns a identity substitution.
+    fn identity_constrained_subst(
+        &self,
+        goal: &C::UCanonicalGoalInEnvironment,
+    ) -> C::CanonicalConstrainedSubst;
+
     /// Create an inference table for processing a new goal and instantiate that goal
     /// in that context, returning "all the pieces".
     ///

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -274,6 +274,11 @@ pub trait InferenceTable<C: Context, I: Context>:
     fn next_subgoal_index(&mut self, ex_clause: &ExClause<I>) -> usize;
 }
 
+/// Error type for the `UnificationOps::program_clauses` method --
+/// indicates that the complete set of program clauses for this goal
+/// cannot be enumerated.
+pub struct Floundered;
+
 /// Methods for unifying and manipulating terms and binders.
 pub trait UnificationOps<C: Context, I: Context> {
     /// Returns the set of program clauses that might apply to
@@ -287,7 +292,7 @@ pub trait UnificationOps<C: Context, I: Context> {
         &mut self,
         environment: &I::Environment,
         goal: &I::DomainGoal,
-    ) -> Option<Vec<I::ProgramClause>>;
+    ) -> Result<Vec<I::ProgramClause>, Floundered>;
 
     // Used by: simplify
     fn instantiate_binders_universally(&mut self, arg: &I::BindersGoal) -> I::Goal;

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -183,7 +183,11 @@ where
                 }
 
                 Err(RootSearchFail::Floundered) => {
-                    panic!("gotta gin up an answer here")
+                    let table_goal = &self.forest.tables[self.table].table_goal;
+                    return Some(SimplifiedAnswer {
+                        subst: self.context.identity_constrained_subst(table_goal),
+                        ambiguous: true,
+                    });
                 }
 
                 Err(RootSearchFail::NoMoreSolutions) => {

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -139,7 +139,7 @@ pub struct ExClause<C: Context> {
 /// we encounter a positive answer in processing a particular
 /// strand. This is used as an optimization to help us figure out when
 /// we *may* have changed inference variables.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TimeStamp {
     clock: u64
 }
@@ -183,7 +183,7 @@ impl TimeStamp {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FlounderedSubgoal<C: Context> {
     /// Literal that floundered.
-    pub literal: Literal<C>,
+    pub floundered_literal: Literal<C>,
 
     /// Current value of the strand's clock at the time of
     /// floundering.
@@ -225,7 +225,7 @@ enum InnerDelayedLiteralSets<C: Context> {
 /// A set of delayed literals.
 ///
 /// (One might expect delayed literals to always be ground, since
-/// non-ground negative literals result in flounded
+/// non-ground negative literals result in floundered
 /// executions. However, due to the approximations introduced via RR
 /// to ensure termination, it *is* in fact possible for delayed goals
 /// to contain free variables. For example, what could happen is that

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -121,6 +121,29 @@ pub struct ExClause<C: Context> {
 
     /// Subgoals: literals that must be proven
     pub subgoals: Vec<Literal<C>>,
+
+    /// Time stamp that is incremented each time we find an answer to
+    /// some subgoal. This is used to figure out whether any of the
+    /// floundered subgoals may no longer be floundered: we record the
+    /// current time when we add something to the list of floundered
+    /// subgoals, and then we can compare whether its value has
+    /// changed since then.
+    pub current_time: TimeStamp,
+
+/// The "time stamp" is a simple clock that gets incremented each time
+/// we encounter a positive answer in processing a particular
+/// strand. This is used as an optimization to help us figure out when
+/// we *may* have changed inference variables.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TimeStamp {
+    clock: u64
+}
+
+impl TimeStamp {
+    fn increment(&mut self) {
+        self.clock += 1;
+    }
+}
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -141,7 +141,7 @@ pub struct ExClause<C: Context> {
 /// we *may* have changed inference variables.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TimeStamp {
-    clock: u64
+    clock: u64,
 }
 
 impl TimeStamp {

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -154,7 +154,7 @@ impl TimeStamp {
 /// variables for which it cannot produce a value. The classic example
 /// of flounding is a negative subgoal:
 ///
-/// ```
+/// ```ignore
 /// not { Implemented(?T: Foo) }
 /// ```
 ///
@@ -173,7 +173,7 @@ impl TimeStamp {
 ///
 /// Floundering can also occur indirectly. For example:
 ///
-/// ```rust
+/// ```rust,ignore
 /// trait Foo { }
 /// impl<T> Foo for T { }
 /// ```

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -566,10 +566,12 @@ impl<C: Context> Forest<C> {
                     delayed_literals,
                     subgoals,
                     current_time: _,
+                    floundered_subgoals,
                 },
             selected_subgoal: _,
         } = strand;
         assert!(subgoals.is_empty());
+        assert!(floundered_subgoals.is_empty());
 
         let answer_subst = infer.canonicalize_constrained_subst(subst, constraints);
         debug!("answer: table={:?}, answer_subst={:?}", table, answer_subst);
@@ -1181,6 +1183,7 @@ impl<C: Context> Forest<C> {
                     constraints: vec![],
                     subgoals: vec![],
                     current_time: TimeStamp::default(),
+                    floundered_subgoals: vec![],
                 }
             }
         }

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -7,6 +7,7 @@ use crate::strand::{CanonicalStrand, SelectedSubgoal, Strand};
 use crate::table::{Answer, AnswerIndex};
 use crate::{
     DelayedLiteral, DelayedLiteralSet, DepthFirstNumber, ExClause, Literal, Minimums, TableIndex,
+    TimeStamp,
 };
 use rustc_hash::FxHashSet;
 use std::mem;
@@ -564,6 +565,7 @@ impl<C: Context> Forest<C> {
                     constraints,
                     delayed_literals,
                     subgoals,
+                    current_time: _,
                 },
             selected_subgoal: _,
         } = strand;
@@ -1091,6 +1093,9 @@ impl<C: Context> Forest<C> {
                     }
                 }
 
+                // Increment time counter because we received a new answer.
+                ex_clause.current_time.increment();
+
                 // Apply answer abstraction.
                 let ex_clause = self.truncate_returned(ex_clause, &mut *infer);
 
@@ -1175,6 +1180,7 @@ impl<C: Context> Forest<C> {
                     delayed_literals: vec![DelayedLiteral::CannotProve(())],
                     constraints: vec![],
                     subgoals: vec![],
+                    current_time: TimeStamp::default(),
                 }
             }
         }

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -1,4 +1,6 @@
-use crate::context::{prelude::*, Floundered, WithInstantiatedExClause, WithInstantiatedUCanonicalGoal};
+use crate::context::{
+    prelude::*, Floundered, WithInstantiatedExClause, WithInstantiatedUCanonicalGoal,
+};
 use crate::fallible::NoSolution;
 use crate::forest::Forest;
 use crate::hh::HhGoal;
@@ -6,8 +8,8 @@ use crate::stack::StackIndex;
 use crate::strand::{CanonicalStrand, SelectedSubgoal, Strand};
 use crate::table::{Answer, AnswerIndex};
 use crate::{
-    DelayedLiteral, DelayedLiteralSet, DepthFirstNumber, ExClause, FlounderedSubgoal, Literal, Minimums, TableIndex,
-    TimeStamp,
+    DelayedLiteral, DelayedLiteralSet, DepthFirstNumber, ExClause, FlounderedSubgoal, Literal,
+    Minimums, TableIndex, TimeStamp,
 };
 use rustc_hash::FxHashSet;
 use std::mem;
@@ -692,15 +694,14 @@ impl<C: Context> Forest<C> {
         }
     }
 
-    fn reconsider_floundered_subgoals(
-        &mut self,
-        ex_clause: &mut ExClause<impl Context>,
-    ) {
-        info!(
-            "reconsider_floundered_subgoals(ex_clause={:#?})",
-            ex_clause,
-        );
-        let ExClause { current_time, subgoals, floundered_subgoals, .. } = ex_clause;
+    fn reconsider_floundered_subgoals(&mut self, ex_clause: &mut ExClause<impl Context>) {
+        info!("reconsider_floundered_subgoals(ex_clause={:#?})", ex_clause,);
+        let ExClause {
+            current_time,
+            subgoals,
+            floundered_subgoals,
+            ..
+        } = ex_clause;
         for i in (0..floundered_subgoals.len()).rev() {
             if floundered_subgoals[i].floundered_time < *current_time {
                 let floundered_subgoal = floundered_subgoals.swap_remove(i);

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -20,6 +20,7 @@ impl<C: Context> Forest<C> {
             constraints: vec![],
             subgoals: vec![],
             current_time: TimeStamp::default(),
+            floundered_subgoals: vec![],
         };
 
         // A stack of higher-level goals to process.

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -2,7 +2,7 @@ use crate::context::prelude::*;
 use crate::fallible::Fallible;
 use crate::forest::Forest;
 use crate::hh::HhGoal;
-use crate::{ExClause, Literal};
+use crate::{ExClause, Literal, TimeStamp};
 
 impl<C: Context> Forest<C> {
     /// Simplifies an HH goal into a series of positive domain goals
@@ -19,6 +19,7 @@ impl<C: Context> Forest<C> {
             delayed_literals: vec![],
             constraints: vec![],
             subgoals: vec![],
+            current_time: TimeStamp::default(),
         };
 
         // A stack of higher-level goals to process.

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -490,6 +490,7 @@ copy_fold!(TypeKindId);
 copy_fold!(usize);
 copy_fold!(QuantifierKind);
 copy_fold!(chalk_engine::TableIndex);
+copy_fold!(chalk_engine::TimeStamp);
 // copy_fold!(TypeName); -- intentionally omitted! This is folded via `fold_ap`
 copy_fold!(());
 
@@ -709,12 +710,14 @@ where
             delayed_literals,
             constraints,
             subgoals,
+            current_time,
         } = self;
         Ok(ExClause {
             subst: subst.fold_with(folder, binders)?,
             delayed_literals: delayed_literals.fold_with(folder, binders)?,
             constraints: constraints.fold_with(folder, binders)?,
             subgoals: subgoals.fold_with(folder, binders)?,
+            current_time: current_time.fold_with(folder, binders)?,
         })
     }
 }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -736,11 +736,11 @@ where
 
     fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
         let FlounderedSubgoal {
-            literal,
+            floundered_literal,
             floundered_time,
         } = self;
         Ok(FlounderedSubgoal {
-            literal: literal.fold_with(folder, binders)?,
+            floundered_literal: floundered_literal.fold_with(folder, binders)?,
             floundered_time: floundered_time.fold_with(folder, binders)?,
         })
     }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -3,7 +3,7 @@
 use crate::cast::Cast;
 use crate::*;
 use chalk_engine::context::Context;
-use chalk_engine::{DelayedLiteral, ExClause, Literal, FlounderedSubgoal};
+use chalk_engine::{DelayedLiteral, ExClause, FlounderedSubgoal, Literal};
 use std::fmt::Debug;
 use std::sync::Arc;
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -552,6 +552,10 @@ impl TraitRef {
     pub fn type_parameters<'a>(&'a self) -> impl Iterator<Item = Ty> + 'a {
         self.parameters.iter().cloned().filter_map(|p| p.ty())
     }
+
+    pub fn self_type_parameter(&self) -> Option<Ty> {
+        self.type_parameters().next()
+    }
 }
 
 /// Where clauses that can be written by a Rust programmer.

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -56,6 +56,7 @@ pub struct TraitFlags {
     pub marker: bool,
     pub upstream: bool,
     pub fundamental: bool,
+    pub non_enumerable: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -40,6 +40,7 @@ UpstreamKeyword: () = "#" "[" "upstream" "]";
 AutoKeyword: () = "#" "[" "auto" "]";
 MarkerKeyword: () = "#" "[" "marker" "]";
 FundamentalKeyword: () = "#" "[" "fundamental" "]";
+NonEnumerableKeyword: () = "#" "[" "non_enumerable" "]";
 
 StructDefn: StructDefn = {
     <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
@@ -57,7 +58,7 @@ StructDefn: StructDefn = {
 };
 
 TraitDefn: TraitDefn = {
-    <auto:AutoKeyword?> <marker:MarkerKeyword?> <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> "trait" <n:Id><p:Angle<ParameterKind>>
+    <auto:AutoKeyword?> <marker:MarkerKeyword?> <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> <non_enumerable:NonEnumerableKeyword?> "trait" <n:Id><p:Angle<ParameterKind>>
         <w:QuantifiedWhereClauses> "{" <a:AssocTyDefn*> "}" => TraitDefn
     {
         name: n,
@@ -69,6 +70,7 @@ TraitDefn: TraitDefn = {
             marker: marker.is_some(),
             upstream: upstream.is_some(),
             fundamental: fundamental.is_some(),
+            non_enumerable: non_enumerable.is_some(),
         },
     }
 };

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -83,6 +83,10 @@ impl TraitDatum {
     pub fn is_auto_trait(&self) -> bool {
         self.binders.value.flags.auto
     }
+
+    pub fn is_non_enumerable_trait(&self) -> bool {
+        self.binders.value.flags.non_enumerable
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -121,6 +125,7 @@ pub struct TraitFlags {
     pub marker: bool,
     pub upstream: bool,
     pub fundamental: bool,
+    pub non_enumerable: bool,
 }
 
 /// An inline bound, e.g. `: Foo<K>` in `impl<K, T: Foo<K>> SomeType<T>`.

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -161,9 +161,7 @@ fn program_clauses_that_could_match(
                         }
                     }
                     Ty::InferenceVar(_) => {
-                        for struct_id in db.all_structs() {
-                            push_auto_trait_impls(trait_id, struct_id, db, clauses);
-                        }
+                        panic!("auto-traits should flounder if nothing is known")
                     }
                     _ => {}
                 }

--- a/chalk-solve/src/infer.rs
+++ b/chalk-solve/src/infer.rs
@@ -146,6 +146,14 @@ impl InferenceTable {
         Some(v1)
     }
 
+    /// Returns true if `var` has been bound.
+    pub(crate) fn var_is_bound(&mut self, var: InferenceVar) -> bool {
+        match self.unify.probe_value(EnaVariable::from(var)) {
+            InferenceValue::Unbound(_) => false,
+            InferenceValue::Bound(_) => true,
+        }
+    }
+
     /// Finds the type to which `var` is bound, returning `None` if it is not yet
     /// bound.
     ///

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -168,9 +168,16 @@ impl TestSolver {
         program: &dyn RustIrDatabase,
         goal: &UCanonical<InEnvironment<Goal>>,
         num_answers: usize,
-    ) -> Box<std::fmt::Debug> {
+    ) -> Box<dyn std::fmt::Debug> {
         let ops = self.forest.context().ops(program);
-        Box::new(self.forest.force_answers(&ops, goal.clone(), num_answers))
+        match self.forest.force_answers(&ops, goal.clone(), num_answers) {
+            Some(v) => Box::new(v),
+            None => {
+                #[derive(Debug)]
+                struct Floundered;
+                Box::new(Floundered)
+            }
+        }
     }
 
     /// Returns then number of cached answers for `goal`. Used only in

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -126,6 +126,17 @@ impl<'me> context::ContextOps<SlgContext> for SlgContextOps<'me> {
         goal.is_coinductive(self.program)
     }
 
+    fn identity_constrained_subst(
+        &self,
+        goal: &UCanonical<InEnvironment<Goal>>,
+    ) -> Canonical<ConstrainedSubst> {
+        let (mut infer, subst, _) =
+            InferenceTable::from_canonical(goal.universes, &goal.canonical);
+        infer
+            .canonicalize(&ConstrainedSubst { subst, constraints: vec![] })
+            .quantified
+    }
+
     fn instantiate_ucanonical_goal<R>(
         &self,
         arg: &UCanonical<InEnvironment<Goal>>,

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -231,7 +231,7 @@ impl<'me> context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenc
         &self,
         environment: &Arc<Environment>,
         goal: &DomainGoal,
-    ) -> Vec<ProgramClause> {
+    ) -> Option<Vec<ProgramClause>> {
         let mut clauses: Vec<_> = environment
             .clauses
             .iter()
@@ -240,7 +240,7 @@ impl<'me> context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenc
             .collect();
 
         clauses.extend(program_clauses_for_goal(self.program, environment, goal));
-        clauses
+        Some(clauses)
     }
 
     fn instantiate_binders_universally(&mut self, arg: &Binders<Box<Goal>>) -> Goal {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -6,6 +6,7 @@ use crate::infer::InferenceTable;
 use crate::solve::truncate::{self, Truncated};
 use crate::solve::Solution;
 use crate::RustIrDatabase;
+use chalk_engine::context::Floundered;
 use chalk_engine::fallible::Fallible;
 use chalk_ir::cast::Cast;
 use chalk_ir::cast::Caster;
@@ -242,7 +243,7 @@ impl<'me> context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenc
         &mut self,
         environment: &Arc<Environment>,
         goal: &DomainGoal,
-    ) -> Option<Vec<ProgramClause>> {
+    ) -> Result<Vec<ProgramClause>, Floundered> {
         // Check for a goal like `?T: Foo` where `Foo` is not enumerable.
         if let DomainGoal::Holds(WhereClause::Implemented(trait_ref))= goal {
             let trait_datum = self.program.trait_datum(trait_ref.trait_id);
@@ -250,21 +251,23 @@ impl<'me> context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenc
                 let self_ty = trait_ref.self_type_parameter().unwrap();
                 if let Some(v) = self_ty.inference_var() {
                     if !self.infer.var_is_bound(v) {
-                        return None;
+                        return Err(Floundered);
                     }
                 }
             }
         }
 
-        let mut clauses: Vec<_> = environment
-            .clauses
-            .iter()
-            .filter(|&env_clause| env_clause.could_match(goal))
-            .cloned()
-            .collect();
+        let mut clauses: Vec<_> = program_clauses_for_goal(self.program, environment, goal);
 
-        clauses.extend(program_clauses_for_goal(self.program, environment, goal));
-        Some(clauses)
+        clauses.extend(
+            environment
+                .clauses
+                .iter()
+                .filter(|&env_clause| env_clause.could_match(goal))
+                .cloned(),
+        );
+
+        Ok(clauses)
     }
 
     fn instantiate_binders_universally(&mut self, arg: &Binders<Box<Goal>>) -> Goal {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -245,7 +245,8 @@ impl<'me> context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenc
     ) -> Option<Vec<ProgramClause>> {
         // Check for a goal like `?T: Foo` where `Foo` is not enumerable.
         if let DomainGoal::Holds(WhereClause::Implemented(trait_ref))= goal {
-            if self.program.trait_datum(trait_ref.trait_id).is_non_enumerable_trait() {
+            let trait_datum = self.program.trait_datum(trait_ref.trait_id);
+            if trait_datum.is_non_enumerable_trait() || trait_datum.is_auto_trait() {
                 let self_ty = trait_ref.self_type_parameter().unwrap();
                 if let Some(v) = self_ty.inference_var() {
                     if !self.infer.var_is_bound(v) {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -131,10 +131,12 @@ impl<'me> context::ContextOps<SlgContext> for SlgContextOps<'me> {
         &self,
         goal: &UCanonical<InEnvironment<Goal>>,
     ) -> Canonical<ConstrainedSubst> {
-        let (mut infer, subst, _) =
-            InferenceTable::from_canonical(goal.universes, &goal.canonical);
+        let (mut infer, subst, _) = InferenceTable::from_canonical(goal.universes, &goal.canonical);
         infer
-            .canonicalize(&ConstrainedSubst { subst, constraints: vec![] })
+            .canonicalize(&ConstrainedSubst {
+                subst,
+                constraints: vec![],
+            })
             .quantified
     }
 
@@ -245,7 +247,7 @@ impl<'me> context::UnificationOps<SlgContext, SlgContext> for TruncatingInferenc
         goal: &DomainGoal,
     ) -> Result<Vec<ProgramClause>, Floundered> {
         // Check for a goal like `?T: Foo` where `Foo` is not enumerable.
-        if let DomainGoal::Holds(WhereClause::Implemented(trait_ref))= goal {
+        if let DomainGoal::Holds(WhereClause::Implemented(trait_ref)) = goal {
             let trait_datum = self.program.trait_datum(trait_ref.trait_id);
             if trait_datum.is_non_enumerable_trait() || trait_datum.is_auto_trait() {
                 let self_ty = trait_ref.self_type_parameter().unwrap();

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -7,7 +7,7 @@ use chalk_ir::zip::{Zip, Zipper};
 use chalk_ir::*;
 
 use chalk_engine::context;
-use chalk_engine::{ExClause, Literal};
+use chalk_engine::{ExClause, Literal, TimeStamp};
 use std::sync::Arc;
 
 ///////////////////////////////////////////////////////////////////////////
@@ -102,6 +102,7 @@ impl<'me> context::ResolventOps<SlgContext, SlgContext> for TruncatingInferenceT
             delayed_literals: vec![],
             constraints: vec![],
             subgoals: vec![],
+            current_time: TimeStamp::default(),
         };
 
         // Add the subgoals/region-constraints that unification gave us.

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -103,6 +103,7 @@ impl<'me> context::ResolventOps<SlgContext, SlgContext> for TruncatingInferenceT
             constraints: vec![],
             subgoals: vec![],
             current_time: TimeStamp::default(),
+            floundered_subgoals: vec![],
         };
 
         // Add the subgoals/region-constraints that unification gave us.

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -1108,6 +1108,7 @@ impl LowerTrait for TraitDefn {
                     marker: self.flags.marker,
                     upstream: self.flags.upstream,
                     fundamental: self.flags.fundamental,
+                    non_enumerable: self.flags.non_enumerable,
                 },
                 associated_ty_ids,
             })

--- a/src/test.rs
+++ b/src/test.rs
@@ -1915,24 +1915,22 @@ fn mixed_semantics() {
             #[auto] trait Send { }
             trait Foo { }
 
-            impl<T> Send for T where T: Foo { }
-            impl<T> Foo for T where T: Send { }
+            struct Bar { }
+
+            impl Send for Bar where Bar: Foo { }
+            impl Foo for Bar where Bar: Send { }
         }
 
         // We have a cycle `(T: Send) :- (T: Foo) :- (T: Send)` with a non-coinductive
         // inner component `T: Foo` so we reject it.
         goal {
-            exists<T> {
-                T: Send
-            }
+            Bar: Send
         } yields {
             "No possible solution"
         }
 
         goal {
-            exists<T> {
-                T: Foo
-            }
+            Bar: Foo
         } yields {
             "No possible solution"
         }

--- a/src/test/slg.rs
+++ b/src/test/slg.rs
@@ -243,29 +243,9 @@ fn flounder() {
         }
 
         goal {
-            // This goal "flounders" because it has a free existential
-            // variable. We choose to replace it with a `CannotProve`
-            // result.
             exists<T> { not { T: A } }
         } first 5 with max 10 {
-            r"[
-                Answer {
-                    subst: Canonical {
-                        value: ConstrainedSubst {
-                            subst: [?0 := ^0],
-                            constraints: []
-                        },
-                        binders: [
-                            Ty(U0)
-                        ]
-                    },
-                    delayed_literals: {
-                        CannotProve(
-                            ()
-                        )
-                    }
-                }
-            ]"
+            "Floundered"
         }
     }
 }
@@ -418,22 +398,7 @@ fn subgoal_cycle_uninhabited() {
         goal {
             exists<T> { T = Vec<u32>, not { Vec<Vec<T>>: Foo } }
         } first 10 with max 3 {
-            r"[
-                Answer {
-                    subst: Canonical {
-                        value: ConstrainedSubst {
-                            subst: [?0 := Vec<u32>],
-                            constraints: []
-                        },
-                        binders: []
-                    },
-                    delayed_literals: {
-                        CannotProve(
-                            ()
-                        )
-                    }
-                }
-            ]"
+            "Floundered"
         }
 
         // Same query with larger threshold works fine, though.

--- a/src/test/slg.rs
+++ b/src/test/slg.rs
@@ -1006,3 +1006,256 @@ fn negative_answer_delayed_literal() {
         }
     }
 }
+
+#[test]
+fn non_enumerable_traits_direct() {
+    test! {
+        program {
+            struct Foo { }
+            struct Bar { }
+
+            #[non_enumerable]
+            trait NonEnumerable { }
+            impl NonEnumerable for Foo { }
+            impl NonEnumerable for Bar { }
+
+            trait Enumerable { }
+            impl Enumerable for Foo { }
+            impl Enumerable for Bar { }
+        }
+
+        goal {
+            exists<A> { A: NonEnumerable }
+        } first 10 with max 3 {
+            r"Floundered"
+        }
+
+        goal {
+            exists<A> { A: Enumerable }
+        } first 10 with max 3 {
+            r"[
+                Answer {
+                    subst: Canonical {
+                        value: ConstrainedSubst {
+                            subst: [?0 := Foo]
+                            constraints: []
+                        }
+                        binders: []
+                    }
+                    delayed_literals: {}
+                },
+                Answer {
+                    subst: Canonical {
+                        value: ConstrainedSubst {
+                            subst: [?0 := Bar]
+                            constraints: []
+                        }
+                        binders: []
+                    }
+                    delayed_literals: {}
+                }
+            ]"
+        }
+
+        goal {
+            Foo: NonEnumerable
+        } first 10 with max 3 {
+            r"[
+                Answer {
+                    subst: Canonical {
+                        value: ConstrainedSubst {
+                            subst: []
+                            constraints: []
+                        }
+                        binders: []
+                    }
+                    delayed_literals: {}
+                }
+            ]"
+        }
+    }
+}
+
+#[test]
+fn non_enumerable_traits_indirect() {
+    test! {
+        program {
+            struct Foo { }
+            struct Bar { }
+
+            #[non_enumerable]
+            trait NonEnumerable { }
+            impl NonEnumerable for Foo { }
+            impl NonEnumerable for Bar { }
+
+            trait Debug { }
+            impl<T> Debug for T where T: NonEnumerable { }
+        }
+
+        goal {
+            exists<A> { A: Debug }
+        } first 10 with max 3 {
+            r"Floundered"
+        }
+    }
+}
+
+#[test]
+fn non_enumerable_traits_double() {
+    test! {
+        program {
+            struct Foo { }
+            struct Bar { }
+
+            #[non_enumerable]
+            trait NonEnumerable1 { }
+            impl NonEnumerable1 for Foo { }
+            impl NonEnumerable1 for Bar { }
+
+            #[non_enumerable]
+            trait NonEnumerable2 { }
+            impl NonEnumerable2 for Foo { }
+            impl NonEnumerable2 for Bar { }
+
+            trait Debug { }
+            impl<T> Debug for T where T: NonEnumerable1, T: NonEnumerable2  { }
+        }
+
+        goal {
+            exists<A> { A: Debug }
+        } first 10 with max 3 {
+            r"Floundered"
+        }
+    }
+}
+
+#[test]
+fn non_enumerable_traits_reorder() {
+    test! {
+        program {
+            struct Foo { }
+            struct Bar { }
+
+            #[non_enumerable]
+            trait NonEnumerable { }
+            impl NonEnumerable for Foo { }
+            impl NonEnumerable for Bar { }
+
+            trait Enumerable { }
+            impl Enumerable for Foo { }
+
+            // In this test, we first try to solve to solve `T:
+            // NonEnumerable` but then we discover it's
+            // non-enumerable, and so we push it off for later. Then
+            // we try to solve the `T: Enumerable` trait.
+
+            trait Debug1 { }
+            impl<T> Debug1 for T where T: Enumerable, T: NonEnumerable { }
+
+            trait Debug2 { }
+            impl<T> Debug2 for T where T: NonEnumerable, T: Enumerable { }
+        }
+
+        goal {
+            exists<A> { A: Debug1 }
+        } first 10 with max 3 {
+            r"[
+                Answer {
+                    subst: Canonical {
+                        value: ConstrainedSubst {
+                            subst: [?0 := Foo]
+                            constraints: []
+                        }
+                        binders: []
+                    }
+                    delayed_literals: {}
+                }
+            ]"
+        }
+
+
+        goal {
+            exists<A> { A: Debug2 }
+        } first 10 with max 3 {
+            r"[
+                Answer {
+                    subst: Canonical {
+                        value: ConstrainedSubst {
+                            subst: [?0 := Foo]
+                            constraints: []
+                        }
+                        binders: []
+                    }
+                    delayed_literals: {}
+                }
+            ]"
+        }
+    }
+}
+
+#[test]
+fn negative_reorder() {
+    test! {
+        program {
+            struct Foo { }
+            struct Bar { }
+
+            trait IsFoo { }
+            impl IsFoo for Foo { }
+
+            trait Enumerable { }
+            impl Enumerable for Foo { }
+            impl Enumerable for Bar { }
+
+            // In this test, we first try to solve to solve `not { T:
+            //  IsFoo }` but then we discover it's
+            // non-enumerable, and so we push it off for later. Then
+            // we try to solve the `T: Enumerable` trait.
+
+            trait Debug1 { }
+            forall<T> {
+                T: Debug1 if T: Enumerable, not { T: IsFoo }
+            }
+
+            trait Debug2 { }
+            forall<T> {
+                T: Debug2 if not { T: IsFoo }, T: Enumerable
+            }
+        }
+
+        goal {
+            exists<A> { A: Debug1 }
+        } first 10 with max 3 {
+            r"[
+                Answer {
+                    subst: Canonical {
+                        value: ConstrainedSubst {
+                            subst: [?0 := Bar]
+                            constraints: []
+                        }
+                        binders: []
+                    }
+                    delayed_literals: {}
+                }
+            ]"
+        }
+
+
+        goal {
+            exists<A> { A: Debug2 }
+        } first 10 with max 3 {
+            r"[
+                Answer {
+                    subst: Canonical {
+                        value: ConstrainedSubst {
+                            subst: [?0 := Bar]
+                            constraints: []
+                        }
+                        binders: []
+                    }
+                    delayed_literals: {}
+                }
+            ]"
+        }
+    }
+}

--- a/src/test/slg.rs
+++ b/src/test/slg.rs
@@ -1194,6 +1194,25 @@ fn non_enumerable_traits_reorder() {
 }
 
 #[test]
+fn auto_traits_flounder() {
+    test! {
+        program {
+            struct Foo { }
+            struct Bar { }
+
+            #[auto]
+            trait Send { }
+        }
+
+        goal {
+            exists<A> { A: Send }
+        } first 10 with max 3 {
+            r"Floundered"
+        }
+    }
+}
+
+#[test]
 fn negative_reorder() {
     test! {
         program {


### PR DESCRIPTION
This introduces the idea of "floundering" into chalk-engine and uses it to mark auto-traits as non-enumerable, along with a new `#[non_enumerable]` traits (used for testing purposes). See the edits to the README.md in one of the final commits for a high-level summary.

Fixes https://github.com/rust-lang/chalk/issues/217