### PR TITLE
Adding parsing and AST->IR lowering for RevealMode + Overrides + added reveal { G } syntax

### DIFF
--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -213,7 +213,10 @@ impl Debug for UnselectedNormalize {
 
 impl Debug for Overrides {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        let Overrides {assoc_ty_id, trait_ref} = self;
+        let Overrides {
+            assoc_ty_id,
+            trait_ref,
+        } = self;
         write!(
             fmt,
             "Overrides[{:?}]({:?}: {:?}{:?})",

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -211,6 +211,20 @@ impl Debug for UnselectedNormalize {
     }
 }
 
+impl Debug for Overrides {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        let Overrides {assoc_ty_id, trait_ref} = self;
+        write!(
+            fmt,
+            "Overrides[{:?}]({:?}: {:?}{:?})",
+            assoc_ty_id,
+            trait_ref.parameters[0],
+            trait_ref.trait_id,
+            Angle(&trait_ref.parameters[1..])
+        )
+    }
+}
+
 impl Debug for WhereClause {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
@@ -263,8 +277,10 @@ impl Debug for DomainGoal {
                 tr.trait_id,
                 Angle(&tr.parameters[1..])
             ),
-            DomainGoal::Compatible(_) => write!(fmt, "Compatible"),
+            DomainGoal::Compatible(()) => write!(fmt, "Compatible"),
             DomainGoal::DownstreamType(n) => write!(fmt, "DownstreamType({:?})", n),
+            DomainGoal::RevealMode(()) => write!(fmt, "RevealMode"),
+            DomainGoal::Overrides(ov) => write!(fmt, "{:?}", ov),
         }
     }
 }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -680,7 +680,10 @@ struct_fold!(TraitRef {
 struct_fold!(Normalize { projection, ty });
 struct_fold!(ProjectionEq { projection, ty });
 struct_fold!(UnselectedNormalize { projection, ty });
-struct_fold!(Overrides { assoc_ty_id, trait_ref });
+struct_fold!(Overrides {
+    assoc_ty_id,
+    trait_ref
+});
 struct_fold!(Environment { clauses });
 struct_fold!(InEnvironment[F] { environment, goal } where F: Fold<Result = F>);
 struct_fold!(EqGoal { a, b });

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -540,7 +540,8 @@ enum_fold!(WellFormed[] { Trait(a), Ty(a) });
 enum_fold!(FromEnv[] { Trait(a), Ty(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a), UnselectedNormalize(a),
                           InScope(a), IsLocal(a), IsUpstream(a), IsFullyVisible(a),
-                          LocalImplAllowed(a), Compatible(a), DownstreamType(a) });
+                          LocalImplAllowed(a), Compatible(a), DownstreamType(a), RevealMode(a),
+                          Overrides(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });
 enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),
@@ -679,6 +680,7 @@ struct_fold!(TraitRef {
 struct_fold!(Normalize { projection, ty });
 struct_fold!(ProjectionEq { projection, ty });
 struct_fold!(UnselectedNormalize { projection, ty });
+struct_fold!(Overrides { assoc_ty_id, trait_ref });
 struct_fold!(Environment { clauses });
 struct_fold!(InEnvironment[F] { environment, goal } where F: Fold<Result = F>);
 struct_fold!(EqGoal { a, b });

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -189,7 +189,10 @@ struct_zip!(UnselectedProjectionTy {
 struct_zip!(Normalize { projection, ty });
 struct_zip!(ProjectionEq { projection, ty });
 struct_zip!(UnselectedNormalize { projection, ty });
-struct_zip!(Overrides { assoc_ty_id, trait_ref });
+struct_zip!(Overrides {
+    assoc_ty_id,
+    trait_ref
+});
 struct_zip!(EqGoal { a, b });
 struct_zip!(ProgramClauseImplication {
     consequence,

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -189,6 +189,7 @@ struct_zip!(UnselectedProjectionTy {
 struct_zip!(Normalize { projection, ty });
 struct_zip!(ProjectionEq { projection, ty });
 struct_zip!(UnselectedNormalize { projection, ty });
+struct_zip!(Overrides { assoc_ty_id, trait_ref });
 struct_zip!(EqGoal { a, b });
 struct_zip!(ProgramClauseImplication {
     consequence,
@@ -244,7 +245,9 @@ enum_zip!(DomainGoal {
     IsFullyVisible,
     LocalImplAllowed,
     Compatible,
-    DownstreamType
+    DownstreamType,
+    RevealMode,
+    Overrides
 });
 enum_zip!(LeafGoal { DomainGoal, EqGoal });
 enum_zip!(ProgramClause { Implies, ForAll });

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -242,6 +242,8 @@ pub enum DomainGoal {
     LocalImplAllowed { trait_ref: TraitRef },
     Compatible,
     DownstreamType { ty: Ty },
+    RevealMode,
+    Overrides { assoc_ty: Identifier, trait_ref: TraitRef },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -282,6 +284,9 @@ pub enum Goal {
 
     /// The `compatible { G }` syntax
     Compatible(Box<Goal>),
+
+    /// The `reveal { G }` syntax
+    Reveal(Box<Goal>),
 
     // Additional kinds of goals:
     Leaf(LeafGoal),

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -229,21 +229,49 @@ pub enum WhereClause {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum DomainGoal {
-    Holds { where_clause: WhereClause },
-    Normalize { projection: ProjectionTy, ty: Ty },
-    TraitRefWellFormed { trait_ref: TraitRef },
-    TyWellFormed { ty: Ty },
-    TyFromEnv { ty: Ty },
-    TraitRefFromEnv { trait_ref: TraitRef },
-    TraitInScope { trait_name: Identifier },
-    IsLocal { ty: Ty },
-    IsUpstream { ty: Ty },
-    IsFullyVisible { ty: Ty },
-    LocalImplAllowed { trait_ref: TraitRef },
+    Holds {
+        where_clause: WhereClause,
+    },
+    Normalize {
+        projection: ProjectionTy,
+        ty: Ty,
+    },
+    TraitRefWellFormed {
+        trait_ref: TraitRef,
+    },
+    TyWellFormed {
+        ty: Ty,
+    },
+    TyFromEnv {
+        ty: Ty,
+    },
+    TraitRefFromEnv {
+        trait_ref: TraitRef,
+    },
+    TraitInScope {
+        trait_name: Identifier,
+    },
+    IsLocal {
+        ty: Ty,
+    },
+    IsUpstream {
+        ty: Ty,
+    },
+    IsFullyVisible {
+        ty: Ty,
+    },
+    LocalImplAllowed {
+        trait_ref: TraitRef,
+    },
     Compatible,
-    DownstreamType { ty: Ty },
+    DownstreamType {
+        ty: Ty,
+    },
     RevealMode,
-    Overrides { assoc_ty: Identifier, trait_ref: TraitRef },
+    Overrides {
+        assoc_ty: Identifier,
+        trait_ref: TraitRef,
+    },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -32,6 +32,7 @@ Goal1: Box<Goal> = {
     "if" "(" <h:SemiColon<InlineClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(h, g)),
     "not" "{" <g:Goal> "}" => Box::new(Goal::Not(g)),
     "compatible" "{" <g:Goal> "}" => Box::new(Goal::Compatible(g)),
+    "reveal" "{" <g:Goal> "}" => Box::new(Goal::Reveal(g)),
     <leaf:LeafGoal> => Box::new(Goal::Leaf(leaf)),
     "(" <Goal> ")",
 };
@@ -308,6 +309,9 @@ DomainGoal: DomainGoal = {
 
     "Compatible" => DomainGoal::Compatible,
     "DownstreamType" "(" <ty:Ty> ")" => DomainGoal::DownstreamType { ty },
+
+    "RevealMode" => DomainGoal::RevealMode,
+    "Overrides" "[" <assoc_ty:Id> "]" "(" <trait_ref:TraitRef<":">> ")" => DomainGoal::Overrides { assoc_ty, trait_ref },
 };
 
 LeafGoal: LeafGoal = {

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -212,7 +212,11 @@ fn program_clauses_that_could_match(
         DomainGoal::LocalImplAllowed(trait_ref) => db
             .trait_datum(trait_ref.trait_id)
             .to_program_clauses(db, clauses),
-        DomainGoal::Compatible(()) => (),
+        DomainGoal::Compatible(()) | DomainGoal::RevealMode(()) => (),
+        DomainGoal::Overrides(ov) => {
+            //TODO(sunjay)
+            unimplemented!()
+        }
     };
 }
 

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -168,7 +168,7 @@ impl TestSolver {
         program: &dyn RustIrDatabase,
         goal: &UCanonical<InEnvironment<Goal>>,
         num_answers: usize,
-    ) -> Box<dyn std::fmt::Debug> {
+    ) -> Box<dyn fmt::Debug> {
         let ops = self.forest.context().ops(program);
         match self.forest.force_answers(&ops, goal.clone(), num_answers) {
             Some(v) => Box::new(v),

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -527,15 +527,23 @@ impl LowerDomainGoal for DomainGoal {
                 vec![chalk_ir::DomainGoal::DownstreamType(ty.lower(env)?)]
             }
             DomainGoal::RevealMode => vec![chalk_ir::DomainGoal::RevealMode(())],
-            DomainGoal::Overrides { assoc_ty, trait_ref } => {
+            DomainGoal::Overrides {
+                assoc_ty,
+                trait_ref,
+            } => {
                 let trait_ref = trait_ref.lower(env)?;
 
-                let assoc_ty_id = match env.associated_ty_infos.get(&(trait_ref.trait_id, assoc_ty.str)) {
+                let assoc_ty_id = match env
+                    .associated_ty_infos
+                    .get(&(trait_ref.trait_id, assoc_ty.str))
+                {
                     Some(info) => info.id,
-                    None => return Err(format_err!(
-                        "no associated type `{}` defined in trait",
-                        assoc_ty,
-                    )),
+                    None => {
+                        return Err(format_err!(
+                            "no associated type `{}` defined in trait",
+                            assoc_ty,
+                        ))
+                    }
                 };
 
                 vec![chalk_ir::DomainGoal::Overrides(chalk_ir::Overrides {


### PR DESCRIPTION
This begins to implement the first bullet in https://github.com/rust-lang/chalk/issues/219#issuecomment-498370956.

I added a number of things:

1. A new `reveal { G }` syntax similar to the `compatible { G }` syntax we already have for introducing the `RevealMode` (this is useful for testing and whatnot)
2. Parsing for `RevealMode` and `Overrides[V0](P0: Trait<P1..Pn>)` syntax
3. Lowering from the AST to the chalk IR for all of this
4. All the standard `Debug`, `Fold`, `Zip` stuff for the new variants and types

Unresolved questions for @nikomatsakis before this is merged:

- [ ] Do I need to add/change anything in the rust_ir? I didn't encounter any compiler errors, so I wasn't sure
- [ ] Did I look up the associated type's TypeId correctly during lowering?
- [ ] What should we do when lowering `Overrides` in clauses.rs? Right now I've just left it as `unimplemented!()`
    * I could just do the same thing as when we added `LocalImplAllowed` and create program clauses for the trait ref, but do we also have to take the associated type ID into account?

I'm going to do the second part of this ("Modify the lowering for default type to include the `Overrides` clause") after this PR.