### PR TITLE
Remove all structs callback

### DIFF
--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -38,7 +38,7 @@ pub struct ImplDatumBound {
     pub impl_type: ImplType,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ImplType {
     Local,
     External,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -106,7 +106,7 @@ pub fn push_auto_trait_impls(
 /// to this goal from the Rust program. So for example if the goal
 /// is `Implemented(T: Clone)`, then this function might return clauses
 /// derived from the trait `Clone` and its impls.
-pub fn program_clauses_for_goal<'db>(
+pub(crate) fn program_clauses_for_goal<'db>(
     db: &'db dyn RustIrDatabase,
     environment: &Arc<Environment>,
     goal: &DomainGoal,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -260,13 +260,7 @@ fn match_ty(
             .to_program_clauses(db, clauses),
         Ty::ForAll(quantified_ty) => match_ty(db, environment, &quantified_ty.ty, clauses),
         Ty::BoundVar(_) => {}
-        Ty::InferenceVar(_) => {
-            // If the type is an (unbound) inference variable, it
-            // could be any of these things:
-            for struct_id in db.all_structs() {
-                db.struct_datum(struct_id).to_program_clauses(db, clauses);
-            }
-        }
+        Ty::InferenceVar(_) => panic!("should have floundered"),
     }
 }
 

--- a/chalk-solve/src/coherence/solve.rs
+++ b/chalk-solve/src/coherence/solve.rs
@@ -23,11 +23,7 @@ where
         }
 
         // Iterate over every pair of impls for the same trait.
-        //
-        // FIXME -- Ideally, we would only need to do this iteration
-        // for the impls **added by the current crate**. I'm not sure
-        // how to structure this though in terms of queries.
-        let impls = self.db.impls_for_trait(self.trait_id);
+        let impls = self.db.local_impls_to_coherence_check(self.trait_id);
         for (l_id, r_id) in impls.into_iter().tuple_combinations() {
             let lhs = &self.db.impl_datum(l_id);
             let rhs = &self.db.impl_datum(r_id);

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -38,6 +38,14 @@ pub trait RustIrDatabase: Debug {
     /// returning a ton of entries here.
     fn impls_for_trait(&self, trait_id: TraitId) -> Vec<ImplId>;
 
+    /// Returns the impls that require coherence checking. This is not the
+    /// full set of impls that exist:
+    ///
+    /// - It can exclude impls not defined in the current crate.
+    /// - It can exclude "built-in" impls, like those for closures; only the
+    ///   impls actually written by users need to be checked.
+    fn local_impls_to_coherence_check(&self, trait_id: TraitId) -> Vec<ImplId>;
+
     /// Returns the id of every struct in the program.
     ///
     /// FIXME(rust-lang/chalk#217): We currently use this to derive

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -46,14 +46,6 @@ pub trait RustIrDatabase: Debug {
     ///   impls actually written by users need to be checked.
     fn local_impls_to_coherence_check(&self, trait_id: TraitId) -> Vec<ImplId>;
 
-    /// Returns the id of every struct in the program.
-    ///
-    /// FIXME(rust-lang/chalk#217): We currently use this to derive
-    /// the program clauses for a case like `?T: Send` (which could be
-    /// any struct). But really we should be using a "non-enumerable
-    /// goal" strategy here.
-    fn all_structs(&self) -> Vec<StructId>;
-
     /// Returns true if there is an explicit impl of the auto trait
     /// `auto_trait_id` for the struct `struct_id`. This is part of
     /// the auto trait handling -- if there is no explicit impl given

--- a/src/db.rs
+++ b/src/db.rs
@@ -19,6 +19,7 @@ use chalk_ir::TypeName;
 use chalk_ir::UCanonical;
 use chalk_rust_ir::AssociatedTyDatum;
 use chalk_rust_ir::ImplDatum;
+use chalk_rust_ir::ImplType;
 use chalk_rust_ir::StructDatum;
 use chalk_rust_ir::TraitDatum;
 use chalk_solve::RustIrDatabase;
@@ -93,6 +94,20 @@ impl RustIrDatabase for ChalkDatabase {
             .filter(|(_, impl_datum)| {
                 let impl_trait_id = impl_datum.binders.value.trait_ref.trait_ref().trait_id;
                 impl_trait_id == trait_id
+            })
+            .map(|(&impl_id, _)| impl_id)
+            .collect()
+    }
+
+    fn local_impls_to_coherence_check(&self, trait_id: TraitId) -> Vec<ImplId> {
+        self.program_ir()
+            .unwrap()
+            .impl_data
+            .iter()
+            .filter(|(_, impl_datum)| {
+                let impl_trait_id = impl_datum.binders.value.trait_ref.trait_ref().trait_id;
+                let impl_type = impl_datum.binders.value.impl_type;
+                impl_trait_id == trait_id && impl_type == ImplType::Local
             })
             .map(|(&impl_id, _)| impl_id)
             .collect()

--- a/src/db.rs
+++ b/src/db.rs
@@ -113,15 +113,6 @@ impl RustIrDatabase for ChalkDatabase {
             .collect()
     }
 
-    fn all_structs(&self) -> Vec<StructId> {
-        self.program_ir()
-            .unwrap()
-            .struct_data
-            .keys()
-            .cloned()
-            .collect()
-    }
-
     fn impl_provided_for(&self, auto_trait_id: TraitId, struct_id: StructId) -> bool {
         // Look for an impl like `impl Send for Foo` where `Foo` is
         // the struct.  See `push_auto_trait_impls` for more.

--- a/src/test.rs
+++ b/src/test.rs
@@ -2522,7 +2522,7 @@ fn fundamental_types() {
 
         // With fundamental, Box can be local for certain types, so there is no unique solution
         // anymore for any of these
-        goal { forall<T> { not { IsLocal(Box<T>) } } } yields { "No possible solution" }
+        goal { forall<T> { not { IsLocal(Box<T>) } } } yields { "Ambiguous" }
         goal { forall<T> { IsLocal(Box<T>) } } yields { "No possible solution" }
         goal { forall<T> { IsUpstream(Box<T>) } } yields { "No possible solution" }
 


### PR DESCRIPTION
This PR is work towards #241 -- in particular, it eliminates the `all_structs` callback and adds a separate callback for coherence. Next step (which can be in a separate PR) is to modify the `impls_for_trait` callback to take a self-type -- in the case of rust-analyzer, where we intentionally mark all traits as "non-exhaustive", that self-type should always be at least shallowly known (except that it could be a projection).

cc @flodiebold 
r? @scalexm 