### PR TITLE
move doc comments into macro so they reach rustdoc

### DIFF
--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -85,11 +85,11 @@ index_struct! {
     }
 }
 
-/// The StackIndex identifies the position of a table's goal in the
-/// stack of goals that are actively being processed. Note that once a
-/// table is completely evaluated, it may be popped from the stack,
-/// and hence no longer have a stack index.
 index_struct! {
+    /// The StackIndex identifies the position of a table's goal in the
+    /// stack of goals that are actively being processed. Note that once a
+    /// table is completely evaluated, it may be popped from the stack,
+    /// and hence no longer have a stack index.
     struct StackIndex {
         value: usize,
     }

--- a/chalk-engine/src/stack.rs
+++ b/chalk-engine/src/stack.rs
@@ -8,11 +8,11 @@ pub(crate) struct Stack {
     stack: Vec<StackEntry>,
 }
 
-/// The StackIndex identifies the position of a table's goal in the
-/// stack of goals that are actively being processed. Note that once a
-/// table is completely evaluated, it may be popped from the stack,
-/// and hence no longer have a stack index.
 index_struct! {
+    /// The StackIndex identifies the position of a table's goal in the
+    /// stack of goals that are actively being processed. Note that once a
+    /// table is completely evaluated, it may be popped from the stack,
+    /// and hence no longer have a stack index.
     pub(crate) struct StackIndex {
         value: usize,
     }

--- a/chalk-macros/src/index.rs
+++ b/chalk-macros/src/index.rs
@@ -1,9 +1,10 @@
 #[macro_export]
 macro_rules! index_struct {
-    ($v:vis struct $n:ident {
+    ($(#[$m:meta])* $v:vis struct $n:ident {
         $vf:vis value: usize,
     }) => {
         #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        $(#[$m])*
         $v struct $n {
             $vf value: usize,
         }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -85,9 +85,7 @@ impl FoldInputTypes for Ty {
             // lazily, so no need to include them here.
             Ty::ForAll(..) => (),
 
-            Ty::InferenceVar(..) => {
-                panic!("unexpected inference variable in wf rules: {:?}", self,)
-            }
+            Ty::InferenceVar(..) => panic!("unexpected inference variable in wf rules: {:?}", self),
         }
     }
 }


### PR DESCRIPTION
also eliminates warnings