### PR TITLE
Fix slice is not unsized in libstd.chalk

### DIFF
--- a/libstd.chalk
+++ b/libstd.chalk
@@ -32,7 +32,6 @@ impl<T> Sized for Box<T> { }
 
 // Meant to be [T]
 struct Slice<T> where T: Sized { }
-impl<T> Sized for Slice<T> { }
 impl<T> AsRef<Slice<T>> for Slice<T> where T: Sized { }
 
 struct Vec<T> where T: Sized { }


### PR DESCRIPTION
Before:
```
?- load libstd.chalk
?- Slice<i32> : Sized
Unique; substitution [], lifetime constraints []

?- WellFormed(Vec<Slice<i32>>)
Unique; substitution [], lifetime constraints []
```

Now:
```
?- load libstd.chalk
?- Slice<i32> : Sized
No possible solution.

?- WellFormed(Vec<Slice<i32>>)
No possible solution.
```