### PR TITLE
fix the paper name

### DIFF
--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -7,7 +7,7 @@
 //! This algorithm is very closed based on the description found in the
 //! following paper, which I will refer to in the comments as EWFS:
 //!
-//! > Efficient Top-Down Computation of Queries Under the Well-formed Semantics
+//! > Efficient Top-Down Computation of Queries Under the Well-founded Semantics
 //! > (Chen, Swift, and Warren; Journal of Logic Programming '95)
 //!
 //! However, to understand that paper, I would recommend first


### PR DESCRIPTION
I searched the paper name, and it turned out to be "well-founded" instead of "well-formed" ;) 

EDIT: Notice that the other typo is already fixed in latest master.