### PR TITLE
Output multiple solutions

### DIFF
--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -202,7 +202,10 @@ pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
     ) -> R;
 
     /// returns unique solution from answer
-    fn make_unique_solution(&self, answer: SimplifiedAnswer<C>) -> C::CanonicalConstrainedSubst;
+    fn constrained_subst_from_answer(
+        &self,
+        answer: SimplifiedAnswer<C>,
+    ) -> C::CanonicalConstrainedSubst;
 }
 
 /// Callback trait for `instantiate_ucanonical_goal`. Unlike the other

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -200,6 +200,9 @@ pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
         canonical_ex_clause: &C::CanonicalExClause,
         op: impl WithInstantiatedExClause<C, Output = R>,
     ) -> R;
+
+    /// returns unique solution from answer
+    fn make_unique_solution(&self, answer: SimplifiedAnswer<C>) -> C::CanonicalConstrainedSubst;
 }
 
 /// Callback trait for `instantiate_ucanonical_goal`. Unlike the other

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -107,16 +107,18 @@ impl<C: Context> Forest<C> {
         &mut self,
         context: &impl ContextOps<C>,
         goal: &C::UCanonicalGoalInEnvironment,
-        mut f: impl FnMut(C::CanonicalConstrainedSubst) -> bool,
-    ) {
+        mut f: impl FnMut(C::CanonicalConstrainedSubst, bool) -> bool,
+    ) -> bool {
         let mut answers = self.iter_answers(context, goal);
-        while let Some(answer) = answers.peek_answer() {
-            if f(context.make_unique_solution(answer)) {
-                answers.next_answer();
-            } else {
-                break;
+        while let Some(answer) = answers.next_answer() {
+            if !f(
+                context.make_unique_solution(answer),
+                answers.peek_answer().is_some(),
+            ) {
+                return false;
             }
         }
+        return true;
     }
 
     /// True if all the tables on the stack starting from `depth` and

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -99,6 +99,26 @@ impl<C: Context> Forest<C> {
         context.make_solution(C::canonical(&goal), self.iter_answers(context, goal))
     }
 
+    /// Solves a given goal, producing the solution. This will do only
+    /// as much work towards `goal` as it has to (and that works is
+    /// cached for future attempts). Calls provided function `f` to
+    /// iterate over multiple solutions until the function return `false`.
+    pub fn solve_multiple(
+        &mut self,
+        context: &impl ContextOps<C>,
+        goal: &C::UCanonicalGoalInEnvironment,
+        mut f: impl FnMut(C::CanonicalConstrainedSubst) -> bool,
+    ) {
+        let mut answers = self.iter_answers(context, goal);
+        while let Some(answer) = answers.peek_answer() {
+            if f(context.make_unique_solution(answer)) {
+                answers.next_answer();
+            } else {
+                break;
+            }
+        }
+    }
+
     /// True if all the tables on the stack starting from `depth` and
     /// continuing until the top of the stack are coinductive.
     ///

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -112,7 +112,7 @@ impl<C: Context> Forest<C> {
         let mut answers = self.iter_answers(context, goal);
         while let Some(answer) = answers.next_answer() {
             if !f(
-                context.make_unique_solution(answer),
+                context.constrained_subst_from_answer(answer),
                 answers.peek_answer().is_some(),
             ) {
                 return false;

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -143,6 +143,9 @@ impl Solver {
     /// - `goal` the goal to solve
     /// - `f` -- function to proceed solution. New solutions will be generated
     /// while function returns `true`.
+    ///   - first argument is solution found
+    ///   - second argument is ther next solution present
+    ///   - returns true if next solution should be handled
     ///
     /// # Returns
     ///

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -129,6 +129,30 @@ impl Solver {
         self.forest.solve(&ops, goal)
     }
 
+    /// Attempts to solve the given goal, which must be in canonical
+    /// form. Provides multiple solutions to function `f`.  This will do
+    /// only as much work towards `goal` as it has to (and that work
+    /// is cached for future attempts).
+    ///
+    /// # Parameters
+    ///
+    /// - `program` -- defines the program clauses in scope.
+    ///   - **Important:** You must supply the same set of program clauses
+    ///     each time you invoke `solve`, as otherwise the cached data may be
+    ///     invalid.
+    /// - `goal` the goal to solve
+    /// - `f` -- function to proceed solution. New solutions will be generated
+    /// while function returns `true`.
+    pub fn solve_multiple(
+        &mut self,
+        program: &dyn RustIrDatabase,
+        goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>,
+        f: impl FnMut(Canonical<ConstrainedSubst<ChalkIr>>) -> bool,
+    ) {
+        let ops = self.forest.context().ops(program);
+        self.forest.solve_multiple(&ops, goal, f)
+    }
+
     pub fn into_test(self) -> TestSolver {
         TestSolver { state: self }
     }

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -143,12 +143,17 @@ impl Solver {
     /// - `goal` the goal to solve
     /// - `f` -- function to proceed solution. New solutions will be generated
     /// while function returns `true`.
+    ///
+    /// # Returns
+    ///
+    /// - `true` all solutions were processed with the function.
+    /// - `false` the function returned `false` and solutions were interrupted.
     pub fn solve_multiple(
         &mut self,
         program: &dyn RustIrDatabase,
         goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>,
-        f: impl FnMut(Canonical<ConstrainedSubst<ChalkIr>>) -> bool,
-    ) {
+        f: impl FnMut(Canonical<ConstrainedSubst<ChalkIr>>, bool) -> bool,
+    ) -> bool {
         let ops = self.forest.context().ops(program);
         self.forest.solve_multiple(&ops, goal, f)
     }

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -171,7 +171,7 @@ impl<'me> context::ContextOps<SlgContext> for SlgContextOps<'me> {
         op.with(dyn_infer, ex_cluse)
     }
 
-    fn make_unique_solution(
+    fn constrained_subst_from_answer(
         &self,
         answer: SimplifiedAnswer<SlgContext>,
     ) -> Canonical<ConstrainedSubst<ChalkIr>> {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -16,7 +16,7 @@ use chalk_ir::*;
 
 use chalk_engine::context;
 use chalk_engine::hh::HhGoal;
-use chalk_engine::{DelayedLiteral, ExClause, Literal};
+use chalk_engine::{DelayedLiteral, ExClause, Literal, SimplifiedAnswer};
 
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -169,6 +169,14 @@ impl<'me> context::ContextOps<SlgContext> for SlgContextOps<'me> {
             InferenceTable::from_canonical(num_universes, canonical_ex_clause);
         let dyn_infer = &mut TruncatingInferenceTable::new(self.program, self.max_size, infer);
         op.with(dyn_infer, ex_cluse)
+    }
+
+    fn make_unique_solution(
+        &self,
+        answer: SimplifiedAnswer<SlgContext>,
+    ) -> Canonical<ConstrainedSubst<ChalkIr>> {
+        let SimplifiedAnswer { subst, .. } = answer;
+        subst
     }
 }
 

--- a/src/bin/chalki.rs
+++ b/src/bin/chalki.rs
@@ -68,27 +68,32 @@ impl LoadedProgram {
         let goal = chalk_parse::parse_goal(text)?.lower(&*program)?;
         let peeled_goal = goal.into_peeled_goal();
         if multiple_answers {
-            self.db.solve_multiple(&peeled_goal, |v| {
+            if self.db.solve_multiple(&peeled_goal, |v, has_next| {
                 println!("{}\n", v);
-                if let Some(ref mut rl) = rl {
-                    loop {
-                        if let Ok(next) = rl.readline("Show next answer (y/n): ") {
-                            if "y" == next {
-                                return true;
-                            } else if "n" == next {
-                                return false;
+                if has_next {
+                    if let Some(ref mut rl) = rl {
+                        loop {
+                            if let Ok(next) = rl.readline("Show next answer (y/n): ") {
+                                if "y" == next {
+                                    return true;
+                                } else if "n" == next {
+                                    return false;
+                                } else {
+                                    println!("Unknown response. Try again.");
+                                }
                             } else {
-                                println!("Unknown response. Try again.");
+                                return false;
                             }
-                        } else {
-                            return false;
                         }
+                    } else {
+                        true
                     }
                 } else {
                     true
                 }
-            });
-            println!("No more solutions");
+            }) {
+                println!("No more solutions");
+            }
         } else {
             match self.db.solve(&peeled_goal) {
                 Some(v) => println!("{}\n", v),

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,6 +5,8 @@ use crate::query::{Lowering, LoweringDatabase};
 use chalk_ir::could_match::CouldMatch;
 use chalk_ir::family::ChalkIr;
 use chalk_ir::tls;
+use chalk_ir::Canonical;
+use chalk_ir::ConstrainedSubst;
 use chalk_ir::Goal;
 use chalk_ir::Identifier;
 use chalk_ir::ImplId;
@@ -66,11 +68,13 @@ impl ChalkDatabase {
         solution
     }
 
-    pub fn solve_multiple(&self, goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>) -> Vec<i32> {
+    pub fn solve_multiple(
+        &self,
+        goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>,
+        f: impl FnMut(Canonical<ConstrainedSubst<ChalkIr>>) -> bool,
+    ) {
         let solver = self.solver();
-        let solution = solver.lock().unwrap().solve(self, goal);
-        // ToDo: do something real
-        vec![1, 2, 3, 4, 5]
+        solver.lock().unwrap().solve_multiple(self, goal, f);
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -71,10 +71,11 @@ impl ChalkDatabase {
     pub fn solve_multiple(
         &self,
         goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>,
-        f: impl FnMut(Canonical<ConstrainedSubst<ChalkIr>>) -> bool,
-    ) {
+        f: impl FnMut(Canonical<ConstrainedSubst<ChalkIr>>, bool) -> bool,
+    ) -> bool {
         let solver = self.solver();
-        solver.lock().unwrap().solve_multiple(self, goal, f);
+        let solution = solver.lock().unwrap().solve_multiple(self, goal, f);
+        solution
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -65,6 +65,13 @@ impl ChalkDatabase {
         let solution = solver.lock().unwrap().solve(self, goal);
         solution
     }
+
+    pub fn solve_multiple(&self, goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>) -> Vec<i32> {
+        let solver = self.solver();
+        let solution = solver.lock().unwrap().solve(self, goal);
+        // ToDo: do something real
+        vec![1, 2, 3, 4, 5]
+    }
 }
 
 impl RustIrDatabase for ChalkDatabase {

--- a/src/test/projection.rs
+++ b/src/test/projection.rs
@@ -500,7 +500,6 @@ fn normalize_under_binder() {
 }
 
 #[test]
-#[should_panic]
 fn normalize_under_binder_multi() {
     test! {
         program {
@@ -531,8 +530,8 @@ fn normalize_under_binder_multi() {
                 }
             }
         } yields_all {
-            "s",
-            "s2"
+            "for<?U0,?U0> { substitution [?0 := (Deref::Item)<Ref<'^0, I32>, '^1>], lifetime constraints [InEnvironment { environment: Env([]), goal: '^0 == '!1_0 }, InEnvironment { environment: Env([]), goal: '^1 == '!1_0 }] }",
+            "substitution [?0 := I32], lifetime constraints []"
         }
 
         goal {
@@ -542,8 +541,7 @@ fn normalize_under_binder_multi() {
                 }
             }
         } yields_first {
-            "s",
-            "s2"
+            "for<?U0,?U0> { substitution [?0 := (Deref::Item)<Ref<'^0, I32>, '^1>], lifetime constraints [InEnvironment { environment: Env([]), goal: '^0 == '!1_0 }, InEnvironment { environment: Env([]), goal: '^1 == '!1_0 }] }"
         }
     }
 }

--- a/src/test/projection.rs
+++ b/src/test/projection.rs
@@ -500,6 +500,55 @@ fn normalize_under_binder() {
 }
 
 #[test]
+#[should_panic]
+fn normalize_under_binder_multi() {
+    test! {
+        program {
+            struct Ref<'a, T> { }
+            struct I32 { }
+
+            trait Deref<'a> {
+                type Item;
+            }
+
+            trait Id<'a> {
+                type Item;
+            }
+
+            impl<'a, T> Deref<'a> for Ref<'a, T> {
+                type Item = T;
+            }
+
+            impl<'a, T> Id<'a> for Ref<'a, T> {
+                type Item = Ref<'a, T>;
+            }
+        }
+
+        goal {
+            exists<U> {
+                forall<'a> {
+                    Ref<'a, I32>: Deref<'a, Item = U>
+                }
+            }
+        } yields_all {
+            "s",
+            "s2"
+        }
+
+        goal {
+            exists<U> {
+                forall<'a> {
+                    Ref<'a, I32>: Deref<'a, Item = U>
+                }
+            }
+        } yields_first {
+            "s",
+            "s2"
+        }
+    }
+}
+
+#[test]
 fn projection_from_env_a() {
     test! {
         program {


### PR DESCRIPTION
I've tried to use chalk as generic logic solver and found I can not get output if there more than one solution. 

This PR adds `--multiple` flag to chalki. If it enabled chalki iterates over multiple solutions with confirmation from user instead of generating "ambiguous" solution. If goal was provided with arguments it iterates over all solutions.

It uses callback function to manage iteration over solution because I couldn't export `ForestSolver` iterator structure.