### PR TITLE
Simplify chalk-engine a bit

### DIFF
--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -280,11 +280,6 @@ pub trait UnificationOps<C: Context> {
         constraints: Vec<C::RegionConstraint>,
     ) -> C::CanonicalConstrainedSubst;
 
-    fn sink_answer_subset(
-        &self,
-        value: &C::CanonicalConstrainedSubst,
-    ) -> C::CanonicalConstrainedSubst;
-
     fn lift_delayed_literal(&self, value: DelayedLiteral<C>) -> DelayedLiteral<C>;
 
     // Used by: logic

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -118,10 +118,6 @@ pub trait Context: Clone + Debug {
     /// the equality relation.
     type Variance;
 
-    /// The successful result from unification: contains new subgoals
-    /// and things that can be attached to an ex-clause.
-    type UnificationResult;
-
     /// Given an environment and a goal, glue them together to create
     /// a `GoalInEnvironment`.
     fn goal_in_environment(
@@ -294,18 +290,20 @@ pub trait UnificationOps<C: Context> {
     // Used by: logic
     fn invert_goal(&mut self, value: &C::GoalInEnvironment) -> Option<C::GoalInEnvironment>;
 
+    /// First unify the parameters, then add the residual subgoals
+    /// as new subgoals of the ex-clause.
+    /// Also add region constraints.
+    /// 
+    /// If the parameters fail to unify, then `Error` is returned
     // Used by: simplify
-    fn unify_parameters(
+    fn unify_parameters_into_ex_clause(
         &mut self,
         environment: &C::Environment,
         variance: C::Variance,
         a: &C::Parameter,
         b: &C::Parameter,
-    ) -> Fallible<C::UnificationResult>;
-
-    /// Add the residual subgoals as new subgoals of the ex-clause.
-    /// Also add region constraints.
-    fn into_ex_clause(&mut self, result: C::UnificationResult, ex_clause: &mut ExClause<C>);
+        ex_clause: &mut ExClause<C>,
+    ) -> Fallible<()>;
 }
 
 /// "Truncation" (called "abstraction" in the papers referenced below)

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -272,7 +272,7 @@ pub trait UnificationOps<C: Context> {
     fn debug_ex_clause<'v>(&mut self, value: &'v ExClause<C>) -> Box<dyn Debug + 'v>;
 
     // Used by: logic
-    fn canonicalize_goal(&mut self, value: &C::GoalInEnvironment) -> C::CanonicalGoalInEnvironment;
+    fn fully_canonicalize_goal(&mut self, value: &C::GoalInEnvironment) -> (C::UCanonicalGoalInEnvironment, C::UniverseMap);
 
     // Used by: logic
     fn canonicalize_ex_clause(&mut self, value: &ExClause<C>) -> C::CanonicalExClause;
@@ -283,12 +283,6 @@ pub trait UnificationOps<C: Context> {
         subst: C::Substitution,
         constraints: Vec<C::RegionConstraint>,
     ) -> C::CanonicalConstrainedSubst;
-
-    // Used by: logic
-    fn u_canonicalize_goal(
-        &mut self,
-        value: &C::CanonicalGoalInEnvironment,
-    ) -> (C::UCanonicalGoalInEnvironment, C::UniverseMap);
 
     fn sink_answer_subset(
         &self,

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -268,7 +268,10 @@ pub trait UnificationOps<C: Context> {
     fn debug_ex_clause<'v>(&mut self, value: &'v ExClause<C>) -> Box<dyn Debug + 'v>;
 
     // Used by: logic
-    fn fully_canonicalize_goal(&mut self, value: &C::GoalInEnvironment) -> (C::UCanonicalGoalInEnvironment, C::UniverseMap);
+    fn fully_canonicalize_goal(
+        &mut self,
+        value: &C::GoalInEnvironment,
+    ) -> (C::UCanonicalGoalInEnvironment, C::UniverseMap);
 
     // Used by: logic
     fn canonicalize_ex_clause(&mut self, value: &ExClause<C>) -> C::CanonicalExClause;
@@ -288,7 +291,7 @@ pub trait UnificationOps<C: Context> {
     /// First unify the parameters, then add the residual subgoals
     /// as new subgoals of the ex-clause.
     /// Also add region constraints.
-    /// 
+    ///
     /// If the parameters fail to unify, then `Error` is returned
     // Used by: simplify
     fn unify_parameters_into_ex_clause(

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -104,7 +104,7 @@ impl<C: Context> Forest<C> {
     ///
     /// Example: Given a program like:
     ///
-    /// ```
+    /// ```notrust
     /// struct Foo { a: Option<Box<Bar>> }
     /// struct Bar { a: Option<Box<Foo>> }
     /// trait XXX { }

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -143,18 +143,14 @@ impl<C: Context> Forest<C> {
     }
 }
 
-struct ForestSolver<'me, C: Context + 'me, CO: ContextOps<C> + 'me> {
+struct ForestSolver<'me, C: Context, CO: ContextOps<C>> {
     forest: &'me mut Forest<C>,
     context: &'me CO,
     table: TableIndex,
     answer: AnswerIndex,
 }
 
-impl<'me, C, CO> AnswerStream<C> for ForestSolver<'me, C, CO>
-where
-    C: Context,
-    CO: ContextOps<C>,
-{
+impl<'me, C: Context, CO: ContextOps<C>> AnswerStream<C> for ForestSolver<'me, C, CO> {
     fn peek_answer(&mut self) -> Option<SimplifiedAnswer<C>> {
         loop {
             match self

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -288,7 +288,7 @@ pub enum Literal<C: Context> {
 ///     // 1 bar(X)
 ///     // 2 baz(X)   <-- top of stack
 /// ```
-/// 
+///
 /// In this case, `positive` would be initially 0, 1, and 2 for `foo`,
 /// `bar`, and `baz` respectively. This reflects the fact that the
 /// answers for `foo(X)` depend on the answers for `foo(X)`. =)

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -154,7 +154,7 @@ impl TimeStamp {
 /// variables for which it cannot produce a value. The classic example
 /// of floundering is a negative subgoal:
 ///
-/// ```ignore
+/// ```notrust
 /// not { Implemented(?T: Foo) }
 /// ```
 ///
@@ -173,7 +173,7 @@ impl TimeStamp {
 ///
 /// Floundering can also occur indirectly. For example:
 ///
-/// ```rust,ignore
+/// ```notrust
 /// trait Foo { }
 /// impl<T> Foo for T { }
 /// ```
@@ -283,10 +283,12 @@ pub enum Literal<C: Context> {
 /// initialized with the index of the predicate on the stack. So
 /// imagine we have a stack like this:
 ///
+/// ```notrust
 ///     // 0 foo(X)   <-- bottom of stack
 ///     // 1 bar(X)
 ///     // 2 baz(X)   <-- top of stack
-///
+/// ```
+/// 
 /// In this case, `positive` would be initially 0, 1, and 2 for `foo`,
 /// `bar`, and `baz` respectively. This reflects the fact that the
 /// answers for `foo(X)` depend on the answers for `foo(X)`. =)

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -812,7 +812,7 @@ impl<C: Context> Forest<C> {
                 // applying built-in "meta program clauses" that
                 // reduce HH goals into Domain goals.
                 if let Ok(ex_clause) =
-                    Self::simplify_hh_goal(&mut *infer, subst, &environment, hh_goal)
+                    Self::simplify_hh_goal(infer, subst, environment, hh_goal)
                 {
                     info!(
                         "pushing initial strand with ex-clause: {:#?}",

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -301,9 +301,7 @@ impl<C: Context> Forest<C> {
         }
     }
 
-    fn canonicalize_strand(
-        strand: Strand<C>,
-    ) -> CanonicalStrand<C> {
+    fn canonicalize_strand(strand: Strand<C>) -> CanonicalStrand<C> {
         let Strand {
             mut infer,
             ex_clause,
@@ -422,10 +420,7 @@ impl<C: Context> Forest<C> {
                     };
                     let (delayed_strand, subgoal_table) =
                         Self::delay_strand_after_cycle(table, strand);
-                    (
-                        Self::canonicalize_strand(delayed_strand),
-                        subgoal_table,
-                    )
+                    (Self::canonicalize_strand(delayed_strand), subgoal_table)
                 },
             );
             *canonical_strand = new_canonical;
@@ -553,11 +548,7 @@ impl<C: Context> Forest<C> {
     ///   strand led nowhere of interest.
     /// - the strand may represent a new answer, in which case it is
     ///   added to the table and `Ok` is returned.
-    fn pursue_answer(
-        &mut self,
-        depth: StackIndex,
-        strand: Strand<C>,
-    ) -> StrandResult<C, ()> {
+    fn pursue_answer(&mut self, depth: StackIndex, strand: Strand<C>) -> StrandResult<C, ()> {
         let table = self.stack[depth].table;
         let Strand {
             mut infer,
@@ -764,13 +755,20 @@ impl<C: Context> Forest<C> {
         // Instantiate the table goal with fresh inference variables.
         let table_goal = self.tables[table].table_goal.clone();
         context.instantiate_ucanonical_goal(&table_goal, |mut infer, subst, environment, goal| {
-            self.push_initial_strands_instantiated(context, table, &mut infer, subst, environment, goal);
+            self.push_initial_strands_instantiated(
+                context,
+                table,
+                &mut infer,
+                subst,
+                environment,
+                goal,
+            );
         });
     }
 
     fn push_initial_strands_instantiated(
         &mut self,
-        context: &impl ContextOps<C>, 
+        context: &impl ContextOps<C>,
         table: TableIndex,
         infer: &mut C::InferenceTable,
         subst: C::Substitution,
@@ -811,9 +809,7 @@ impl<C: Context> Forest<C> {
                 // simplified subgoals. You can think of this as
                 // applying built-in "meta program clauses" that
                 // reduce HH goals into Domain goals.
-                if let Ok(ex_clause) =
-                    Self::simplify_hh_goal(infer, subst, environment, hh_goal)
-                {
+                if let Ok(ex_clause) = Self::simplify_hh_goal(infer, subst, environment, hh_goal) {
                     info!(
                         "pushing initial strand with ex-clause: {:#?}",
                         infer.debug_ex_clause(&ex_clause),

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -1101,7 +1101,7 @@ impl<C: Context> Forest<C> {
                     if !answer.delayed_literals.is_empty() {
                         ex_clause.delayed_literals.push(DelayedLiteral::Positive(
                             subgoal_table,
-                            infer.sink_answer_subset(&answer.subst),
+                            answer.subst.clone(),
                         ));
                     }
                 }

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -11,7 +11,7 @@ impl<C: Context> Forest<C> {
     pub(super) fn simplify_hh_goal(
         infer: &mut dyn InferenceTable<C>,
         subst: C::Substitution,
-        initial_environment: &C::Environment,
+        initial_environment: C::Environment,
         initial_hh_goal: HhGoal<C>,
     ) -> Fallible<ExClause<C>> {
         let mut ex_clause = ExClause {
@@ -24,7 +24,7 @@ impl<C: Context> Forest<C> {
         };
 
         // A stack of higher-level goals to process.
-        let mut pending_goals = vec![(initial_environment.clone(), initial_hh_goal)];
+        let mut pending_goals = vec![(initial_environment, initial_hh_goal)];
 
         while let Some((environment, hh_goal)) = pending_goals.pop() {
             match hh_goal {

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -52,9 +52,13 @@ impl<C: Context> Forest<C> {
                             subgoal,
                         )));
                 }
-                HhGoal::Unify(variance, a, b) => {
-                    infer.unify_parameters_into_ex_clause(&environment, variance, &a, &b, &mut ex_clause)?
-                }
+                HhGoal::Unify(variance, a, b) => infer.unify_parameters_into_ex_clause(
+                    &environment,
+                    variance,
+                    &a,
+                    &b,
+                    &mut ex_clause,
+                )?,
                 HhGoal::DomainGoal(domain_goal) => {
                     ex_clause
                         .subgoals

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -8,12 +8,12 @@ impl<C: Context> Forest<C> {
     /// Simplifies an HH goal into a series of positive domain goals
     /// and negative HH goals. This operation may fail if the HH goal
     /// includes unifications that cannot be completed.
-    pub(super) fn simplify_hh_goal<I: Context>(
-        infer: &mut dyn InferenceTable<C, I>,
-        subst: I::Substitution,
-        initial_environment: &I::Environment,
-        initial_hh_goal: HhGoal<I>,
-    ) -> Fallible<ExClause<I>> {
+    pub(super) fn simplify_hh_goal(
+        infer: &mut dyn InferenceTable<C>,
+        subst: C::Substitution,
+        initial_environment: &C::Environment,
+        initial_hh_goal: HhGoal<C>,
+    ) -> Fallible<ExClause<C>> {
         let mut ex_clause = ExClause {
             subst,
             delayed_literals: vec![],
@@ -47,7 +47,7 @@ impl<C: Context> Forest<C> {
                 HhGoal::Not(subgoal) => {
                     ex_clause
                         .subgoals
-                        .push(Literal::Negative(I::goal_in_environment(
+                        .push(Literal::Negative(C::goal_in_environment(
                             &environment,
                             subgoal,
                         )));
@@ -59,7 +59,7 @@ impl<C: Context> Forest<C> {
                 HhGoal::DomainGoal(domain_goal) => {
                     ex_clause
                         .subgoals
-                        .push(Literal::Positive(I::goal_in_environment(
+                        .push(Literal::Positive(C::goal_in_environment(
                             &environment,
                             infer.into_goal(domain_goal),
                         )));
@@ -74,7 +74,7 @@ impl<C: Context> Forest<C> {
                     let goal = infer.cannot_prove();
                     ex_clause
                         .subgoals
-                        .push(Literal::Negative(I::goal_in_environment(
+                        .push(Literal::Negative(C::goal_in_environment(
                             &environment,
                             goal,
                         )));

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -53,8 +53,7 @@ impl<C: Context> Forest<C> {
                         )));
                 }
                 HhGoal::Unify(variance, a, b) => {
-                    let result = infer.unify_parameters(&environment, variance, &a, &b)?;
-                    infer.into_ex_clause(result, &mut ex_clause)
+                    infer.unify_parameters_into_ex_clause(&environment, variance, &a, &b, &mut ex_clause)?
                 }
                 HhGoal::DomainGoal(domain_goal) => {
                     ex_clause

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -1,4 +1,4 @@
-use crate::context::{Context, InferenceTable};
+use crate::context::Context;
 use crate::table::AnswerIndex;
 use crate::{ExClause, TableIndex};
 use std::fmt::{Debug, Error, Formatter};
@@ -11,10 +11,8 @@ pub(crate) struct CanonicalStrand<C: Context> {
     pub(crate) selected_subgoal: Option<SelectedSubgoal<C>>,
 }
 
-pub(crate) struct Strand<'table, C: Context + 'table, I: Context + 'table> {
-    pub(crate) infer: &'table mut dyn InferenceTable<C, I>,
-
-    pub(super) ex_clause: ExClause<I>,
+pub(crate) struct Strand<C: Context> {
+    pub(super) ex_clause: ExClause<C>,
 
     /// Index into `ex_clause.subgoals`.
     pub(crate) selected_subgoal: Option<SelectedSubgoal<C>>,
@@ -36,7 +34,7 @@ pub(crate) struct SelectedSubgoal<C: Context> {
     pub(crate) universe_map: C::UniverseMap,
 }
 
-impl<'table, C: Context, I: Context> Debug for Strand<'table, C, I> {
+impl<'table, C: Context> Debug for Strand<C> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         fmt.debug_struct("Strand")
             .field("ex_clause", &self.ex_clause)

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -12,6 +12,8 @@ pub(crate) struct CanonicalStrand<C: Context> {
 }
 
 pub(crate) struct Strand<C: Context> {
+    pub(super) infer: C::InferenceTable,
+
     pub(super) ex_clause: ExClause<C>,
 
     /// Index into `ex_clause.subgoals`.

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -57,7 +57,8 @@ pub use self::subst::Subst;
 /// ```
 pub trait Folder<TF: TypeFamily>:
     FreeVarFolder<TF> + InferenceFolder<TF> + PlaceholderFolder<TF> + TypeFolder<TF>
-{}
+{
+}
 
 pub trait TypeFolder<TF: TypeFamily> {
     fn fold_ty(&mut self, ty: &TF::Type, binders: usize) -> Fallible<TF::Type>;
@@ -68,7 +69,8 @@ impl<T, TF> Folder<TF> for T
 where
     T: FreeVarFolder<TF> + InferenceFolder<TF> + PlaceholderFolder<TF> + TypeFolder<TF>,
     TF: TypeFamily,
-{}
+{
+}
 
 /// A convenience trait that indicates that this folder doesn't take
 /// any action on types in particular, but just recursively folds

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -57,12 +57,7 @@ pub use self::subst::Subst;
 /// ```
 pub trait Folder<TF: TypeFamily>:
     FreeVarFolder<TF> + InferenceFolder<TF> + PlaceholderFolder<TF> + TypeFolder<TF>
-{
-    /// Returns a "dynamic" version of this trait. There is no
-    /// **particular** reason to require this, except that I didn't
-    /// feel like making `super_fold_ty` generic for no reason.
-    fn to_dyn(&mut self) -> &mut dyn Folder<TF>;
-}
+{}
 
 pub trait TypeFolder<TF: TypeFamily> {
     fn fold_ty(&mut self, ty: &TF::Type, binders: usize) -> Fallible<TF::Type>;
@@ -73,11 +68,7 @@ impl<T, TF> Folder<TF> for T
 where
     T: FreeVarFolder<TF> + InferenceFolder<TF> + PlaceholderFolder<TF> + TypeFolder<TF>,
     TF: TypeFamily,
-{
-    fn to_dyn(&mut self) -> &mut dyn Folder<TF> {
-        self
-    }
-}
+{}
 
 /// A convenience trait that indicates that this folder doesn't take
 /// any action on types in particular, but just recursively folds
@@ -92,11 +83,11 @@ where
     TF: TypeFamily,
 {
     fn fold_ty(&mut self, ty: &TF::Type, binders: usize) -> Fallible<TF::Type> {
-        super_fold_ty(self.to_dyn(), ty, binders)
+        super_fold_ty(self, ty, binders)
     }
 
     fn fold_lifetime(&mut self, lifetime: &TF::Lifetime, binders: usize) -> Fallible<TF::Lifetime> {
-        super_fold_lifetime(self.to_dyn(), lifetime, binders)
+        super_fold_lifetime(self, lifetime, binders)
     }
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -11,7 +11,6 @@ use lalrpop_intern::InternedString;
 use std::collections::BTreeSet;
 use std::iter;
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Void {}
@@ -75,29 +74,29 @@ impl<TF: TypeFamily> HasTypeFamily for Environment<TF> {
 }
 
 impl<TF: TypeFamily> Environment<TF> {
-    pub fn new() -> Arc<Self> {
-        Arc::new(Environment { clauses: vec![] })
+    pub fn new() -> Self {
+        Environment { clauses: vec![] }
     }
 
-    pub fn add_clauses<I>(&self, clauses: I) -> Arc<Self>
+    pub fn add_clauses<I>(&self, clauses: I) -> Self
     where
         I: IntoIterator<Item = ProgramClause<TF>>,
     {
         let mut env = self.clone();
         let env_clauses: BTreeSet<_> = env.clauses.into_iter().chain(clauses).collect();
         env.clauses = env_clauses.into_iter().collect();
-        Arc::new(env)
+        env
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
 pub struct InEnvironment<G: HasTypeFamily> {
-    pub environment: Arc<Environment<G::TypeFamily>>,
+    pub environment: Environment<G::TypeFamily>,
     pub goal: G,
 }
 
 impl<G: HasTypeFamily> InEnvironment<G> {
-    pub fn new(environment: &Arc<Environment<G::TypeFamily>>, goal: G) -> Self {
+    pub fn new(environment: &Environment<G::TypeFamily>, goal: G) -> Self {
         InEnvironment {
             environment: environment.clone(),
             goal,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -6,7 +6,6 @@ use chalk_ir::could_match::CouldMatch;
 use chalk_ir::family::ChalkIr;
 use chalk_ir::*;
 use rustc_hash::FxHashSet;
-use std::sync::Arc;
 
 mod env_elaborator;
 pub mod program_clauses;
@@ -109,7 +108,7 @@ pub fn push_auto_trait_impls(
 /// derived from the trait `Clone` and its impls.
 pub(crate) fn program_clauses_for_goal<'db>(
     db: &'db dyn RustIrDatabase,
-    environment: &Arc<Environment<ChalkIr>>,
+    environment: &Environment<ChalkIr>,
     goal: &DomainGoal<ChalkIr>,
 ) -> Vec<ProgramClause<ChalkIr>> {
     debug_heading!(
@@ -135,7 +134,7 @@ pub(crate) fn program_clauses_for_goal<'db>(
 /// be.
 fn program_clauses_that_could_match(
     db: &dyn RustIrDatabase,
-    environment: &Arc<Environment<ChalkIr>>,
+    environment: &Environment<ChalkIr>,
     goal: &DomainGoal<ChalkIr>,
     clauses: &mut Vec<ProgramClause<ChalkIr>>,
 ) {
@@ -281,7 +280,7 @@ fn push_program_clauses_for_associated_type_values_in_impls_of(
 /// earlier parts of the logic should "flounder" in that case.
 fn match_ty(
     db: &dyn RustIrDatabase,
-    environment: &Arc<Environment<ChalkIr>>,
+    environment: &Environment<ChalkIr>,
     ty: &Ty<ChalkIr>,
     clauses: &mut Vec<ProgramClause<ChalkIr>>,
 ) {
@@ -321,7 +320,7 @@ fn match_type_kind(
 
 fn program_clauses_for_env<'db>(
     db: &'db dyn RustIrDatabase,
-    environment: &Arc<Environment<ChalkIr>>,
+    environment: &Environment<ChalkIr>,
     clauses: &mut Vec<ProgramClause<ChalkIr>>,
 ) {
     let mut last_round = FxHashSet::default();

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -5,7 +5,6 @@ use chalk_ir::fold::{
     DefaultFreeVarFolder, DefaultTypeFolder, Fold, InferenceFolder, PlaceholderFolder,
 };
 use chalk_ir::zip::{Zip, Zipper};
-use std::sync::Arc;
 
 use super::var::*;
 use super::*;
@@ -13,7 +12,7 @@ use super::*;
 impl InferenceTable {
     pub(crate) fn unify<T>(
         &mut self,
-        environment: &Arc<Environment<ChalkIr>>,
+        environment: &Environment<ChalkIr>,
         a: &T,
         b: &T,
     ) -> Fallible<UnificationResult>
@@ -42,7 +41,7 @@ impl InferenceTable {
 
 struct Unifier<'t> {
     table: &'t mut InferenceTable,
-    environment: &'t Arc<Environment<ChalkIr>>,
+    environment: &'t Environment<ChalkIr>,
     goals: Vec<InEnvironment<DomainGoal<ChalkIr>>>,
     constraints: Vec<InEnvironment<Constraint<ChalkIr>>>,
 }
@@ -54,7 +53,7 @@ pub(crate) struct UnificationResult {
 }
 
 impl<'t> Unifier<'t> {
-    fn new(table: &'t mut InferenceTable, environment: &'t Arc<Environment<ChalkIr>>) -> Self {
+    fn new(table: &'t mut InferenceTable, environment: &'t Environment<ChalkIr>) -> Self {
         Unifier {
             environment: environment,
             table: table,

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -19,7 +19,6 @@ use chalk_engine::hh::HhGoal;
 use chalk_engine::{DelayedLiteral, ExClause, Literal};
 
 use std::fmt::Debug;
-use std::sync::Arc;
 
 mod aggregate;
 mod resolvent;
@@ -61,7 +60,7 @@ impl context::Context for SlgContext {
     type InferenceNormalizedSubst = Substitution<ChalkIr>;
     type Solution = Solution;
     type InferenceTable = TruncatingInferenceTable;
-    type Environment = Arc<Environment<ChalkIr>>;
+    type Environment = Environment<ChalkIr>;
     type DomainGoal = DomainGoal<ChalkIr>;
     type Goal = Goal<ChalkIr>;
     type BindersGoal = Binders<Box<Goal<ChalkIr>>>;
@@ -76,7 +75,7 @@ impl context::Context for SlgContext {
     type Variance = ();
 
     fn goal_in_environment(
-        environment: &Arc<Environment<ChalkIr>>,
+        environment: &Environment<ChalkIr>,
         goal: Goal<ChalkIr>,
     ) -> InEnvironment<Goal<ChalkIr>> {
         InEnvironment::new(environment, goal)
@@ -150,7 +149,7 @@ impl<'me> context::ContextOps<SlgContext> for SlgContextOps<'me> {
 
     fn program_clauses(
         &self,
-        environment: &Arc<Environment<ChalkIr>>,
+        environment: &Environment<ChalkIr>,
         goal: &DomainGoal<ChalkIr>,
         infer: &mut TruncatingInferenceTable,
     ) -> Result<Vec<ProgramClause<ChalkIr>>, Floundered> {
@@ -200,7 +199,7 @@ impl<'me> context::ContextOps<SlgContext> for SlgContextOps<'me> {
         op: impl FnOnce(
             TruncatingInferenceTable,
             Substitution<ChalkIr>,
-            Arc<Environment<ChalkIr>>,
+            Environment<ChalkIr>,
             Goal<ChalkIr>,
         ) -> R,
     ) -> R {
@@ -274,9 +273,9 @@ impl context::InferenceTable<SlgContext> for TruncatingInferenceTable {
     // Used by: simplify
     fn add_clauses(
         &mut self,
-        env: &Arc<Environment<ChalkIr>>,
+        env: &Environment<ChalkIr>,
         clauses: Vec<ProgramClause<ChalkIr>>,
-    ) -> Arc<Environment<ChalkIr>> {
+    ) -> Environment<ChalkIr> {
         Environment::add_clauses(env, clauses)
     }
 
@@ -367,7 +366,7 @@ impl context::UnificationOps<SlgContext> for TruncatingInferenceTable {
 
     fn unify_parameters(
         &mut self,
-        environment: &Arc<Environment<ChalkIr>>,
+        environment: &Environment<ChalkIr>,
         _: (),
         a: &Parameter<ChalkIr>,
         b: &Parameter<ChalkIr>,

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -319,11 +319,16 @@ impl context::UnificationOps<SlgContext> for TruncatingInferenceTable {
         Box::new(self.infer.normalize_deep(value))
     }
 
-    fn canonicalize_goal(
+    fn fully_canonicalize_goal(
         &mut self,
-        value: &InEnvironment<Goal<ChalkIr>>,
-    ) -> Canonical<InEnvironment<Goal<ChalkIr>>> {
-        self.infer.canonicalize(value).quantified
+        value: &InEnvironment<Goal<ChalkIr>>
+    ) -> (UCanonical<InEnvironment<Goal<ChalkIr>>>, UniverseMap) {
+        let canonicalized_goal = self.infer.canonicalize(value).quantified;
+        let UCanonicalized {
+            quantified,
+            universes,
+        } = self.infer.u_canonicalize(&canonicalized_goal);
+        (quantified, universes)
     }
 
     fn canonicalize_ex_clause(
@@ -341,20 +346,6 @@ impl context::UnificationOps<SlgContext> for TruncatingInferenceTable {
         self.infer
             .canonicalize(&ConstrainedSubst { subst, constraints })
             .quantified
-    }
-
-    fn u_canonicalize_goal(
-        &mut self,
-        value: &Canonical<InEnvironment<Goal<ChalkIr>>>,
-    ) -> (
-        UCanonical<InEnvironment<Goal<ChalkIr>>>,
-        crate::infer::ucanonicalize::UniverseMap,
-    ) {
-        let UCanonicalized {
-            quantified,
-            universes,
-        } = self.infer.u_canonicalize(value);
-        (quantified, universes)
     }
 
     fn invert_goal(

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -223,17 +223,14 @@ impl<'me> context::ContextOps<SlgContext> for SlgContextOps<'me> {
 
 impl TruncatingInferenceTable {
     fn new(max_size: usize, infer: InferenceTable) -> Self {
-        Self {
-            max_size,
-            infer,
-        }
+        Self { max_size, infer }
     }
 }
 
 impl context::TruncateOps<SlgContext> for TruncatingInferenceTable {
     fn truncate_goal(
         &mut self,
-        subgoal: &InEnvironment<Goal<ChalkIr>>
+        subgoal: &InEnvironment<Goal<ChalkIr>>,
     ) -> Option<InEnvironment<Goal<ChalkIr>>> {
         let Truncated { overflow, value } =
             truncate::truncate(&mut self.infer, self.max_size, subgoal);
@@ -320,7 +317,7 @@ impl context::UnificationOps<SlgContext> for TruncatingInferenceTable {
 
     fn fully_canonicalize_goal(
         &mut self,
-        value: &InEnvironment<Goal<ChalkIr>>
+        value: &InEnvironment<Goal<ChalkIr>>,
     ) -> (UCanonical<InEnvironment<Goal<ChalkIr>>>, UniverseMap) {
         let canonicalized_goal = self.infer.canonicalize(value).quantified;
         let UCanonicalized {
@@ -360,7 +357,7 @@ impl context::UnificationOps<SlgContext> for TruncatingInferenceTable {
         _: (),
         a: &Parameter<ChalkIr>,
         b: &Parameter<ChalkIr>,
-        ex_clause: &mut ExClause<SlgContext>
+        ex_clause: &mut ExClause<SlgContext>,
     ) -> Fallible<()> {
         let result = self.infer.unify(environment, a, b)?;
         Ok(into_ex_clause(result, ex_clause))

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -368,15 +368,6 @@ impl context::UnificationOps<SlgContext> for TruncatingInferenceTable {
 
     /// Since we do not have distinct types for the inference context and the slg-context,
     /// these conversion operations are just no-ops.q
-    fn sink_answer_subset(
-        &self,
-        c: &Canonical<ConstrainedSubst<ChalkIr>>,
-    ) -> Canonical<ConstrainedSubst<ChalkIr>> {
-        c.clone()
-    }
-
-    /// Since we do not have distinct types for the inference context and the slg-context,
-    /// these conversion operations are just no-ops.q
     fn lift_delayed_literal(&self, c: DelayedLiteral<SlgContext>) -> DelayedLiteral<SlgContext> {
         c
     }

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -67,7 +67,6 @@ impl context::Context for SlgContext {
     type Parameter = Parameter<ChalkIr>;
     type ProgramClause = ProgramClause<ChalkIr>;
     type ProgramClauses = Vec<ProgramClause<ChalkIr>>;
-    type UnificationResult = UnificationResult;
     type CanonicalConstrainedSubst = Canonical<ConstrainedSubst<ChalkIr>>;
     type GoalInEnvironment = InEnvironment<Goal<ChalkIr>>;
     type Substitution = Substitution<ChalkIr>;
@@ -355,14 +354,16 @@ impl context::UnificationOps<SlgContext> for TruncatingInferenceTable {
         self.infer.invert(value)
     }
 
-    fn unify_parameters(
+    fn unify_parameters_into_ex_clause(
         &mut self,
         environment: &Environment<ChalkIr>,
         _: (),
         a: &Parameter<ChalkIr>,
         b: &Parameter<ChalkIr>,
-    ) -> Fallible<UnificationResult> {
-        self.infer.unify(environment, a, b)
+        ex_clause: &mut ExClause<SlgContext>
+    ) -> Fallible<()> {
+        let result = self.infer.unify(environment, a, b)?;
+        Ok(into_ex_clause(result, ex_clause))
     }
 
     /// Since we do not have distinct types for the inference context and the slg-context,
@@ -378,10 +379,6 @@ impl context::UnificationOps<SlgContext> for TruncatingInferenceTable {
     /// these conversion operations are just no-ops.q
     fn lift_delayed_literal(&self, c: DelayedLiteral<SlgContext>) -> DelayedLiteral<SlgContext> {
         c
-    }
-
-    fn into_ex_clause(&mut self, result: UnificationResult, ex_clause: &mut ExClause<SlgContext>) {
-        into_ex_clause(result, ex_clause)
     }
 }
 

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -9,7 +9,6 @@ use chalk_ir::*;
 
 use chalk_engine::context;
 use chalk_engine::{ExClause, Literal, TimeStamp};
-use std::sync::Arc;
 
 ///////////////////////////////////////////////////////////////////////////
 // SLG RESOLVENTS
@@ -58,7 +57,7 @@ impl context::ResolventOps<SlgContext> for TruncatingInferenceTable {
     /// - `clause` is the program clause that may be useful to that end
     fn resolvent_clause(
         &mut self,
-        environment: &Arc<Environment<ChalkIr>>,
+        environment: &Environment<ChalkIr>,
         goal: &DomainGoal<ChalkIr>,
         subst: &Substitution<ChalkIr>,
         clause: &ProgramClause<ChalkIr>,
@@ -246,7 +245,7 @@ impl context::ResolventOps<SlgContext> for TruncatingInferenceTable {
 
 struct AnswerSubstitutor<'t> {
     table: &'t mut InferenceTable,
-    environment: &'t Arc<Environment<ChalkIr>>,
+    environment: &'t Environment<ChalkIr>,
     answer_subst: &'t Substitution<ChalkIr>,
     answer_binders: usize,
     pending_binders: usize,
@@ -256,7 +255,7 @@ struct AnswerSubstitutor<'t> {
 impl<'t> AnswerSubstitutor<'t> {
     fn substitute<T: Zip<ChalkIr>>(
         table: &mut InferenceTable,
-        environment: &Arc<Environment<ChalkIr>>,
+        environment: &Environment<ChalkIr>,
         answer_subst: &Substitution<ChalkIr>,
         ex_clause: ExClause<SlgContext>,
         answer: &T,

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 //
 // is the SLG resolvent of G with C.
 
-impl<'me> context::ResolventOps<SlgContext> for TruncatingInferenceTable<'me> {
+impl context::ResolventOps<SlgContext> for TruncatingInferenceTable {
     /// Applies the SLG resolvent algorithm to incorporate a program
     /// clause into the main X-clause, producing a new X-clause that
     /// must be solved.

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 //
 // is the SLG resolvent of G with C.
 
-impl<'me> context::ResolventOps<SlgContext, SlgContext> for TruncatingInferenceTable<'me> {
+impl<'me> context::ResolventOps<SlgContext> for TruncatingInferenceTable<'me> {
     /// Applies the SLG resolvent algorithm to incorporate a program
     /// clause into the main X-clause, producing a new X-clause that
     /// must be solved.


### PR DESCRIPTION
cc https://github.com/rust-lang/chalk/issues/255

This removes the two different `Context`s from `Strand` and the `&'table mut dyn InferenceTable<C, I>` field (and consequently the lifetime parameter `'table`) has been removed, in lieu of passing `infer` directly to function arguments as needed. `WithInstantiatedUCanonicalGoal` and `WithInstantiatedExClause` were also removed in favor of just `FnOnce`s. And then the `with_instantiated_strand` indirection has also been removed.

`CanonicalStrand`s are still stored in `Table`, since I haven't yet figured out the best way to simplify that. But this gets us one step closer.

I'll probably still be playing around to try to remove `CanonicalStrand`, but I figured it would be better to at least make this PR since it seems fairly straightforward.