### PR TITLE
introduce `TypeFamily` and make chalk-ir generic over it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
-cache: cargo
+
+# This seems to be causing timeouts and problems like
+# https://travis-ci.com/rust-lang/chalk/jobs/249066404
+# cache: cargo
 
 rust:
   - stable

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -141,12 +141,6 @@ impl<TF: TypeFamily> Cast<Ty<TF>> for ProjectionTy<TF> {
     }
 }
 
-impl<TF: TypeFamily> Cast<Parameter<TF>> for Ty<TF> {
-    fn cast(self) -> Parameter<TF> {
-        Parameter(ParameterKind::Ty(self))
-    }
-}
-
 impl<TF: TypeFamily> Cast<Parameter<TF>> for Lifetime<TF> {
     fn cast(self) -> Parameter<TF> {
         Parameter(ParameterKind::Lifetime(self))

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -141,12 +141,6 @@ impl<TF: TypeFamily> Cast<Ty<TF>> for ProjectionTy<TF> {
     }
 }
 
-impl<TF: TypeFamily> Cast<Parameter<TF>> for Lifetime<TF> {
-    fn cast(self) -> Parameter<TF> {
-        Parameter(ParameterKind::Lifetime(self))
-    }
-}
-
 impl<T, TF> Cast<ProgramClause<TF>> for T
 where
     T: Cast<DomainGoal<TF>>,

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -259,7 +259,6 @@ impl Debug for DomainGoal {
             DomainGoal::WellFormed(n) => write!(fmt, "{:?}", n),
             DomainGoal::FromEnv(n) => write!(fmt, "{:?}", n),
             DomainGoal::Normalize(n) => write!(fmt, "{:?}", n),
-            DomainGoal::InScope(n) => write!(fmt, "InScope({:?})", n),
             DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),
             DomainGoal::IsUpstream(n) => write!(fmt, "IsUpstream({:?})", n),
             DomainGoal::IsFullyVisible(n) => write!(fmt, "IsFullyVisible({:?})", n),

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -132,14 +132,44 @@ impl Debug for ApplicationTy {
     }
 }
 
+impl TraitRef {
+    /// Returns a "Debuggable" type that prints like `P0 as Trait<P1..>`
+    pub fn with_as(&self) -> impl std::fmt::Debug + '_ {
+        SeparatorTraitRef {
+            trait_ref: self,
+            separator: " as ",
+        }
+    }
+
+    /// Returns a "Debuggable" type that prints like `P0: Trait<P1..>`
+    pub fn with_colon(&self) -> impl std::fmt::Debug + '_ {
+        SeparatorTraitRef {
+            trait_ref: self,
+            separator: ": ",
+        }
+    }
+}
+
 impl Debug for TraitRef {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        Debug::fmt(&self.with_as(), fmt)
+    }
+}
+
+struct SeparatorTraitRef<'me> {
+    trait_ref: &'me TraitRef,
+    separator: &'me str,
+}
+
+impl Debug for SeparatorTraitRef<'_> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(
             fmt,
-            "{:?} as {:?}{:?}",
-            self.parameters[0],
-            self.trait_id,
-            Angle(&self.parameters[1..])
+            "{:?}{}{:?}{:?}",
+            self.trait_ref.parameters[0],
+            self.separator,
+            self.trait_ref.trait_id,
+            Angle(&self.trait_ref.parameters[1..])
         )
     }
 }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -81,7 +81,7 @@ impl Debug for ItemId {
     }
 }
 
-impl Debug for Ty {
+impl<TF: TypeFamily> Debug for Ty<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             Ty::BoundVar(depth) => write!(fmt, "^{}", depth),
@@ -101,7 +101,7 @@ impl Debug for InferenceVar {
     }
 }
 
-impl Debug for QuantifiedTy {
+impl<TF: TypeFamily> Debug for QuantifiedTy<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         // FIXME -- we should introduce some names or something here
         let QuantifiedTy { num_binders, ty } = self;
@@ -109,12 +109,13 @@ impl Debug for QuantifiedTy {
     }
 }
 
-impl Debug for Lifetime {
+impl<TF: TypeFamily> Debug for Lifetime<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             Lifetime::BoundVar(depth) => write!(fmt, "'^{}", depth),
             Lifetime::InferenceVar(var) => write!(fmt, "'{:?}", var),
             Lifetime::Placeholder(index) => write!(fmt, "'{:?}", index),
+            Lifetime::Phantom(..) => unreachable!(),
         }
     }
 }
@@ -126,13 +127,13 @@ impl Debug for PlaceholderIndex {
     }
 }
 
-impl Debug for ApplicationTy {
+impl<TF: TypeFamily> Debug for ApplicationTy<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(fmt, "{:?}{:?}", self.name, Angle(&self.parameters))
     }
 }
 
-impl TraitRef {
+impl<TF: TypeFamily> TraitRef<TF> {
     /// Returns a "Debuggable" type that prints like `P0 as Trait<P1..>`
     pub fn with_as(&self) -> impl std::fmt::Debug + '_ {
         SeparatorTraitRef {
@@ -150,18 +151,18 @@ impl TraitRef {
     }
 }
 
-impl Debug for TraitRef {
+impl<TF: TypeFamily> Debug for TraitRef<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         Debug::fmt(&self.with_as(), fmt)
     }
 }
 
-struct SeparatorTraitRef<'me> {
-    trait_ref: &'me TraitRef,
+struct SeparatorTraitRef<'me, TF: TypeFamily> {
+    trait_ref: &'me TraitRef<TF>,
     separator: &'me str,
 }
 
-impl Debug for SeparatorTraitRef<'_> {
+impl<TF: TypeFamily> Debug for SeparatorTraitRef<'_, TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(
             fmt,
@@ -174,17 +175,9 @@ impl Debug for SeparatorTraitRef<'_> {
     }
 }
 
-impl Debug for ProjectionTy {
+impl<TF: TypeFamily> Debug for ProjectionTy<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        tls::with_current_program(|p| match p {
-            Some(program) => program.debug_projection(self, fmt),
-            None => write!(
-                fmt,
-                "({:?}){:?}",
-                self.associated_ty_id,
-                Angle(&self.parameters)
-            ),
-        })
+        TF::debug_projection(self, fmt)
     }
 }
 
@@ -207,34 +200,28 @@ impl<'a, T: Debug> Debug for Angle<'a, T> {
     }
 }
 
-impl Debug for Normalize {
+impl<TF: TypeFamily> Debug for Normalize<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(fmt, "Normalize({:?} -> {:?})", self.projection, self.ty)
     }
 }
 
-impl Debug for ProjectionEq {
+impl<TF: TypeFamily> Debug for ProjectionEq<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(fmt, "ProjectionEq({:?} = {:?})", self.projection, self.ty)
     }
 }
 
-impl Debug for WhereClause {
+impl<TF: TypeFamily> Debug for WhereClause<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
-            WhereClause::Implemented(tr) => write!(
-                fmt,
-                "Implemented({:?}: {:?}{:?})",
-                tr.parameters[0],
-                tr.trait_id,
-                Angle(&tr.parameters[1..])
-            ),
+            WhereClause::Implemented(tr) => write!(fmt, "Implemented({:?})", tr.with_colon()),
             WhereClause::ProjectionEq(p) => write!(fmt, "{:?}", p),
         }
     }
 }
 
-impl Debug for FromEnv {
+impl<TF: TypeFamily> Debug for FromEnv<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             FromEnv::Trait(t) => write!(fmt, "FromEnv({:?})", t),
@@ -243,7 +230,7 @@ impl Debug for FromEnv {
     }
 }
 
-impl Debug for WellFormed {
+impl<TF: TypeFamily> Debug for WellFormed<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             WellFormed::Trait(t) => write!(fmt, "WellFormed({:?})", t),
@@ -252,7 +239,7 @@ impl Debug for WellFormed {
     }
 }
 
-impl Debug for DomainGoal {
+impl<TF: TypeFamily> Debug for DomainGoal<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             DomainGoal::Holds(n) => write!(fmt, "{:?}", n),
@@ -275,7 +262,7 @@ impl Debug for DomainGoal {
     }
 }
 
-impl Debug for LeafGoal {
+impl<TF: TypeFamily> Debug for LeafGoal<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match *self {
             LeafGoal::EqGoal(ref eq) => write!(fmt, "{:?}", eq),
@@ -284,13 +271,13 @@ impl Debug for LeafGoal {
     }
 }
 
-impl Debug for EqGoal {
+impl<TF: TypeFamily> Debug for EqGoal<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(fmt, "({:?} = {:?})", self.a, self.b)
     }
 }
 
-impl Debug for Goal {
+impl<TF: TypeFamily> Debug for Goal<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match *self {
             Goal::Quantified(qkind, ref subgoal) => {
@@ -338,7 +325,7 @@ impl<T: Debug> Debug for Binders<T> {
     }
 }
 
-impl Debug for ProgramClause {
+impl<TF: TypeFamily> Debug for ProgramClause<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             ProgramClause::Implies(pc) => write!(fmt, "{:?}", pc),
@@ -347,7 +334,7 @@ impl Debug for ProgramClause {
     }
 }
 
-impl Debug for ProgramClauseImplication {
+impl<TF: TypeFamily> Debug for ProgramClauseImplication<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(fmt, "{:?}", self.consequence)?;
 
@@ -364,7 +351,7 @@ impl Debug for ProgramClauseImplication {
     }
 }
 
-impl Debug for Environment {
+impl<TF: TypeFamily> Debug for Environment<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(fmt, "Env({:?})", self.clauses)
     }
@@ -402,7 +389,7 @@ impl<T: Debug, L: Debug> Debug for ParameterKind<T, L> {
     }
 }
 
-impl Debug for Parameter {
+impl<TF: TypeFamily> Debug for Parameter<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match &self.0 {
             ParameterKind::Ty(n) => write!(fmt, "{:?}", n),
@@ -411,7 +398,7 @@ impl Debug for Parameter {
     }
 }
 
-impl Debug for Constraint {
+impl<TF: TypeFamily> Debug for Constraint<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             Constraint::LifetimeEq(a, b) => write!(fmt, "{:?} == {:?}", a, b),
@@ -419,7 +406,7 @@ impl Debug for Constraint {
     }
 }
 
-impl Display for ConstrainedSubst {
+impl<TF: TypeFamily> Display for ConstrainedSubst<TF> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         let ConstrainedSubst { subst, constraints } = self;
 
@@ -431,13 +418,13 @@ impl Display for ConstrainedSubst {
     }
 }
 
-impl Debug for Substitution {
+impl<TF: TypeFamily> Debug for Substitution<TF> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         Display::fmt(self, f)
     }
 }
 
-impl Display for Substitution {
+impl<TF: TypeFamily> Display for Substitution<TF> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         let mut first = true;
 

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -1,0 +1,44 @@
+use crate::debug::Angle;
+use crate::tls;
+use crate::ProjectionTy;
+use std::fmt::{self, Debug};
+use std::hash::Hash;
+
+pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
+    fn debug_projection(
+        projection: &ProjectionTy<Self>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result;
+}
+
+pub trait HasTypeFamily {
+    type TypeFamily: TypeFamily;
+}
+
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct ChalkIr {}
+
+impl TypeFamily for ChalkIr {
+    fn debug_projection(
+        projection: &ProjectionTy<ChalkIr>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        tls::with_current_program(|p| match p {
+            Some(program) => program.debug_projection(projection, fmt),
+            None => write!(
+                fmt,
+                "({:?}){:?}",
+                projection.associated_ty_id,
+                Angle(&projection.parameters)
+            ),
+        })
+    }
+}
+
+impl<T: HasTypeFamily> HasTypeFamily for [T] {
+    type TypeFamily = T::TypeFamily;
+}
+
+impl<T: HasTypeFamily> HasTypeFamily for Vec<T> {
+    type TypeFamily = T::TypeFamily;
+}

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -12,7 +12,24 @@ use chalk_engine::fallible::Fallible;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
+/// A "type family" encapsulates the concrete representation of
+/// certain "core types" from chalk-ir. All the types in chalk-ir are
+/// parameterized by a `TF: TypeFamily`, and so (e.g.) if they want to
+/// store a type, they don't store a `Ty<TF>` instance directly, but
+/// rather prefer a `TF::Type`. You can think of `TF::Type` as the
+/// interned representation (and, indeed, it may well be an interned
+/// pointer, e.g. in rustc).
+///
+/// Type families allow chalk to be embedded in different contexts
+/// where the concrete representation of core types varies. They also
+/// allow us to write generic code that reasons about multiple
+/// distinct sets of types by using distinct generic type parameters
+/// (e.g., `SourceTF` and `TargetTF`) -- even if those type parameters
+/// wind up being mapped to the same underlying type families in the
+/// end.
 pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
+    /// "Interned" representation of types. You can use the `Lookup`
+    /// trait to convert this to a `Ty<Self>`.
     type Type: Debug
         + Clone
         + Eq
@@ -23,6 +40,8 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
         + Lookup<Ty<Self>>
         + Cast<Parameter<Self>>;
 
+    /// "Interned" representation of lifetimes. You can use the
+    /// `Lookup` trait to convert this to a `Lifetime<Self>`.
     type Lifetime: Debug
         + Clone
         + Eq
@@ -33,20 +52,37 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
         + Lookup<Lifetime<Self>>
         + Cast<Parameter<Self>>;
 
+    /// Prints the debug representation of a projection. To get good
+    /// results, this requires inspecting TLS, and is difficult to
+    /// code without reference to a specific type-family (and hence
+    /// fully known types).
     fn debug_projection(
         projection: &ProjectionTy<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> fmt::Result;
 
+    /// Create an "interned" type from `ty`. You can also use the
+    /// `Ty::intern` method, which is preferred.
     fn intern_ty(ty: Ty<Self>) -> Self::Type;
 
+    /// Create an "interned" type from `lifetime`. You can also use
+    /// the `Lifetime::intern` method, which is preferred.
     fn intern_lifetime(lifetime: Lifetime<Self>) -> Self::Lifetime;
 }
 
+/// Implemented by types that have an associated type family (which
+/// are virtually all of the types in chalk-ir, for example).
+/// This lets us map from a type like `Ty<TF>` to the parameter `TF`.
+///
+/// It's particularly useful for writing `Fold` impls for generic
+/// types like `Binder<T>`, since it allows us to figure out the type
+/// family of `T`.
 pub trait HasTypeFamily {
     type TypeFamily: TypeFamily;
 }
 
+/// Given an interned representation, convert to the uninterned enum
+/// `DataType`. Used to (e.g.) convert from `TF::Type` to `Ty<TF>`.
 pub trait Lookup<DataType> {
     fn lookup_ref(&self) -> &DataType;
 
@@ -73,6 +109,8 @@ impl Lookup<Lifetime<ChalkIr>> for Lifetime<ChalkIr> {
     }
 }
 
+/// The default "type family" and the only type family used by chalk
+/// itself. In this family, no interning actually occurs.
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct ChalkIr {}
 

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -538,7 +538,7 @@ enum_fold!(WhereClause[] { Implemented(a), ProjectionEq(a) });
 enum_fold!(WellFormed[] { Trait(a), Ty(a) });
 enum_fold!(FromEnv[] { Trait(a), Ty(a) });
 enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a),
-                          InScope(a), IsLocal(a), IsUpstream(a), IsFullyVisible(a),
+                          IsLocal(a), IsUpstream(a), IsFullyVisible(a),
                           LocalImplAllowed(a), Compatible(a), DownstreamType(a) });
 enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
 enum_fold!(Constraint[] { LifetimeEq(a, b) });

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -5,6 +5,7 @@ use crate::*;
 use chalk_engine::context::Context;
 use chalk_engine::{DelayedLiteral, ExClause, FlounderedSubgoal, Literal};
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 pub mod shift;
@@ -54,23 +55,26 @@ pub use self::subst::Subst;
 /// ```rust,ignore
 /// let x = x.fold_with(&mut folder, 0);
 /// ```
-pub trait Folder: FreeVarFolder + InferenceFolder + PlaceholderFolder + TypeFolder {
+pub trait Folder<TF: TypeFamily>:
+    FreeVarFolder<TF> + InferenceFolder<TF> + PlaceholderFolder<TF> + TypeFolder<TF>
+{
     /// Returns a "dynamic" version of this trait. There is no
     /// **particular** reason to require this, except that I didn't
     /// feel like making `super_fold_ty` generic for no reason.
-    fn to_dyn(&mut self) -> &mut dyn Folder;
+    fn to_dyn(&mut self) -> &mut dyn Folder<TF>;
 }
 
-pub trait TypeFolder {
-    fn fold_ty(&mut self, ty: &Ty, binders: usize) -> Fallible<Ty>;
-    fn fold_lifetime(&mut self, lifetime: &Lifetime, binders: usize) -> Fallible<Lifetime>;
+pub trait TypeFolder<TF: TypeFamily> {
+    fn fold_ty(&mut self, ty: &Ty<TF>, binders: usize) -> Fallible<Ty<TF>>;
+    fn fold_lifetime(&mut self, lifetime: &Lifetime<TF>, binders: usize) -> Fallible<Lifetime<TF>>;
 }
 
-impl<T> Folder for T
+impl<T, TF> Folder<TF> for T
 where
-    T: FreeVarFolder + InferenceFolder + PlaceholderFolder + TypeFolder,
+    T: FreeVarFolder<TF> + InferenceFolder<TF> + PlaceholderFolder<TF> + TypeFolder<TF>,
+    TF: TypeFamily,
 {
-    fn to_dyn(&mut self) -> &mut dyn Folder {
+    fn to_dyn(&mut self) -> &mut dyn Folder<TF> {
         self
     }
 }
@@ -82,15 +86,16 @@ where
 /// folders implement this trait.
 pub trait DefaultTypeFolder {}
 
-impl<T> TypeFolder for T
+impl<T, TF> TypeFolder<TF> for T
 where
-    T: FreeVarFolder + InferenceFolder + PlaceholderFolder + DefaultTypeFolder,
+    T: FreeVarFolder<TF> + InferenceFolder<TF> + PlaceholderFolder<TF> + DefaultTypeFolder,
+    TF: TypeFamily,
 {
-    fn fold_ty(&mut self, ty: &Ty, binders: usize) -> Fallible<Ty> {
+    fn fold_ty(&mut self, ty: &Ty<TF>, binders: usize) -> Fallible<Ty<TF>> {
         super_fold_ty(self.to_dyn(), ty, binders)
     }
 
-    fn fold_lifetime(&mut self, lifetime: &Lifetime, binders: usize) -> Fallible<Lifetime> {
+    fn fold_lifetime(&mut self, lifetime: &Lifetime<TF>, binders: usize) -> Fallible<Lifetime<TF>> {
         super_fold_lifetime(self.to_dyn(), lifetime, binders)
     }
 }
@@ -99,7 +104,7 @@ where
 /// instances where the binder is not something we folded over.  This
 /// is used when you are instantiating previously bound things with some
 /// replacement.
-pub trait FreeVarFolder {
+pub trait FreeVarFolder<TF: TypeFamily> {
     /// Invoked for `Ty::BoundVar` instances that are not bound within the type being folded
     /// over:
     ///
@@ -108,10 +113,10 @@ pub trait FreeVarFolder {
     /// - `binders` is the number of binders in scope.
     ///
     /// This should return a type suitable for a context with `binders` in scope.
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty>;
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty<TF>>;
 
     /// As `fold_free_var_ty`, but for lifetimes.
-    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime>;
+    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>>;
 }
 
 /// A convenience trait. If you implement this, you get an
@@ -126,8 +131,8 @@ pub trait DefaultFreeVarFolder {
     }
 }
 
-impl<T: DefaultFreeVarFolder> FreeVarFolder for T {
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<T: DefaultFreeVarFolder, TF: TypeFamily> FreeVarFolder<TF> for T {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty<TF>> {
         if T::forbid() {
             panic!("unexpected free variable with depth `{:?}`", depth)
         } else {
@@ -135,7 +140,7 @@ impl<T: DefaultFreeVarFolder> FreeVarFolder for T {
         }
     }
 
-    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime> {
+    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>> {
         if T::forbid() {
             panic!("unexpected free variable with depth `{:?}`", depth)
         } else {
@@ -144,7 +149,7 @@ impl<T: DefaultFreeVarFolder> FreeVarFolder for T {
     }
 }
 
-pub trait PlaceholderFolder {
+pub trait PlaceholderFolder<TF: TypeFamily> {
     /// Invoked for each occurrence of a placeholder type; these are
     /// used when we instantiate binders universally. Returns a type
     /// to use instead, which should be suitably shifted to account
@@ -156,14 +161,14 @@ pub trait PlaceholderFolder {
         &mut self,
         universe: PlaceholderIndex,
         binders: usize,
-    ) -> Fallible<Ty>;
+    ) -> Fallible<Ty<TF>>;
 
     /// As with `fold_free_placeholder_ty`, but for lifetimes.
     fn fold_free_placeholder_lifetime(
         &mut self,
         universe: PlaceholderIndex,
         binders: usize,
-    ) -> Fallible<Lifetime>;
+    ) -> Fallible<Lifetime<TF>>;
 }
 
 /// A convenience trait. If you implement this, you get an
@@ -178,12 +183,12 @@ pub trait DefaultPlaceholderFolder {
     }
 }
 
-impl<T: DefaultPlaceholderFolder> PlaceholderFolder for T {
+impl<T: DefaultPlaceholderFolder, TF: TypeFamily> PlaceholderFolder<TF> for T {
     fn fold_free_placeholder_ty(
         &mut self,
         universe: PlaceholderIndex,
         _binders: usize,
-    ) -> Fallible<Ty> {
+    ) -> Fallible<Ty<TF>> {
         if T::forbid() {
             panic!("unexpected placeholder type `{:?}`", universe)
         } else {
@@ -195,7 +200,7 @@ impl<T: DefaultPlaceholderFolder> PlaceholderFolder for T {
         &mut self,
         universe: PlaceholderIndex,
         _binders: usize,
-    ) -> Fallible<Lifetime> {
+    ) -> Fallible<Lifetime<TF>> {
         if T::forbid() {
             panic!("unexpected placeholder lifetime `{:?}`", universe)
         } else {
@@ -204,7 +209,7 @@ impl<T: DefaultPlaceholderFolder> PlaceholderFolder for T {
     }
 }
 
-pub trait InferenceFolder {
+pub trait InferenceFolder<TF: TypeFamily> {
     /// Invoked for each occurrence of a inference type; these are
     /// used when we instantiate binders universally. Returns a type
     /// to use instead, which should be suitably shifted to account
@@ -212,10 +217,14 @@ pub trait InferenceFolder {
     ///
     /// - `universe` is the universe of the `TypeName::ForAll` that was found
     /// - `binders` is the number of binders in scope
-    fn fold_inference_ty(&mut self, var: InferenceVar, binders: usize) -> Fallible<Ty>;
+    fn fold_inference_ty(&mut self, var: InferenceVar, binders: usize) -> Fallible<Ty<TF>>;
 
     /// As with `fold_free_inference_ty`, but for lifetimes.
-    fn fold_inference_lifetime(&mut self, var: InferenceVar, binders: usize) -> Fallible<Lifetime>;
+    fn fold_inference_lifetime(
+        &mut self,
+        var: InferenceVar,
+        binders: usize,
+    ) -> Fallible<Lifetime<TF>>;
 }
 
 /// A convenience trait. If you implement this, you get an
@@ -230,8 +239,8 @@ pub trait DefaultInferenceFolder {
     }
 }
 
-impl<T: DefaultInferenceFolder> InferenceFolder for T {
-    fn fold_inference_ty(&mut self, var: InferenceVar, _binders: usize) -> Fallible<Ty> {
+impl<T: DefaultInferenceFolder, TF: TypeFamily> InferenceFolder<TF> for T {
+    fn fold_inference_ty(&mut self, var: InferenceVar, _binders: usize) -> Fallible<Ty<TF>> {
         if T::forbid() {
             panic!("unexpected inference type `{:?}`", var)
         } else {
@@ -243,7 +252,7 @@ impl<T: DefaultInferenceFolder> InferenceFolder for T {
         &mut self,
         var: InferenceVar,
         _binders: usize,
-    ) -> Fallible<Lifetime> {
+    ) -> Fallible<Lifetime<TF>> {
         if T::forbid() {
             panic!("unexpected inference lifetime `'{:?}`", var)
         } else {
@@ -253,55 +262,55 @@ impl<T: DefaultInferenceFolder> InferenceFolder for T {
 }
 
 /// Applies the given folder to a value.
-pub trait Fold: Debug {
+pub trait Fold<TF: TypeFamily>: Debug {
     /// The type of value that will be produced once folding is done.
     /// Typically this is `Self`, unless `Self` contains borrowed
     /// values, in which case owned values are produced (for example,
     /// one can fold over a `&T` value where `T: Fold`, in which case
     /// you get back a `T`, not a `&T`).
-    type Result: Fold;
+    type Result: Fold<TF>;
 
     /// Apply the given folder `folder` to `self`; `binders` is the
     /// number of binders that are in scope when beginning the
     /// folder. Typically `binders` starts as 0, but is adjusted when
     /// we encounter `Binders<T>` in the IR or other similar
     /// constructs.
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result>;
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result>;
 }
 
-impl<'a, T: Fold> Fold for &'a T {
+impl<'a, T: Fold<TF>, TF: TypeFamily> Fold<TF> for &'a T {
     type Result = T::Result;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         (**self).fold_with(folder, binders)
     }
 }
 
-impl<T: Fold> Fold for Vec<T> {
+impl<T: Fold<TF>, TF: TypeFamily> Fold<TF> for Vec<T> {
     type Result = Vec<T::Result>;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         self.iter().map(|e| e.fold_with(folder, binders)).collect()
     }
 }
 
-impl<T: Fold> Fold for Box<T> {
+impl<T: Fold<TF>, TF: TypeFamily> Fold<TF> for Box<T> {
     type Result = Box<T::Result>;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         Ok(Box::new((**self).fold_with(folder, binders)?))
     }
 }
 
-impl<T: Fold> Fold for Arc<T> {
+impl<T: Fold<TF>, TF: TypeFamily> Fold<TF> for Arc<T> {
     type Result = Arc<T::Result>;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         Ok(Arc::new((**self).fold_with(folder, binders)?))
     }
 }
 
 macro_rules! tuple_fold {
     ($($n:ident),*) => {
-        impl<$($n: Fold,)*> Fold for ($($n,)*) {
+        impl<$($n: Fold<TF>,)* TF: TypeFamily> Fold<TF> for ($($n,)*) {
             type Result = ($($n::Result,)*);
-            fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+            fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
                 #[allow(non_snake_case)]
                 let &($(ref $n),*) = self;
                 Ok(($($n.fold_with(folder, binders)?,)*))
@@ -315,9 +324,9 @@ tuple_fold!(A, B, C);
 tuple_fold!(A, B, C, D);
 tuple_fold!(A, B, C, D, E);
 
-impl<T: Fold> Fold for Option<T> {
+impl<T: Fold<TF>, TF: TypeFamily> Fold<TF> for Option<T> {
     type Result = Option<T::Result>;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         match self {
             None => Ok(None),
             Some(e) => Ok(Some(e.fold_with(folder, binders)?)),
@@ -325,14 +334,21 @@ impl<T: Fold> Fold for Option<T> {
     }
 }
 
-impl Fold for Ty {
+impl<TF: TypeFamily> Fold<TF> for Ty<TF> {
     type Result = Self;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         folder.fold_ty(self, binders)
     }
 }
 
-pub fn super_fold_ty(folder: &mut dyn Folder, ty: &Ty, binders: usize) -> Fallible<Ty> {
+pub fn super_fold_ty<TF>(
+    folder: &mut dyn Folder<TF>,
+    ty: &Ty<TF>,
+    binders: usize,
+) -> Fallible<Ty<TF>>
+where
+    TF: TypeFamily,
+{
     match *ty {
         Ty::BoundVar(depth) => {
             if depth >= binders {
@@ -371,9 +387,9 @@ pub fn super_fold_ty(folder: &mut dyn Folder, ty: &Ty, binders: usize) -> Fallib
     }
 }
 
-impl Fold for QuantifiedTy {
+impl<TF: TypeFamily> Fold<TF> for QuantifiedTy<TF> {
     type Result = Self;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         let QuantifiedTy {
             num_binders,
             ref ty,
@@ -385,12 +401,13 @@ impl Fold for QuantifiedTy {
     }
 }
 
-impl<T> Fold for Binders<T>
+impl<T, TF: TypeFamily> Fold<TF> for Binders<T>
 where
-    T: Fold,
+    T: Fold<TF>,
+    TF: TypeFamily,
 {
     type Result = Binders<T::Result>;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         let Binders {
             binders: ref self_binders,
             value: ref self_value,
@@ -403,12 +420,13 @@ where
     }
 }
 
-impl<T> Fold for Canonical<T>
+impl<T, TF> Fold<TF> for Canonical<T>
 where
-    T: Fold,
+    T: Fold<TF>,
+    TF: TypeFamily,
 {
     type Result = Canonical<T::Result>;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         let Canonical {
             binders: ref self_binders,
             value: ref self_value,
@@ -421,18 +439,18 @@ where
     }
 }
 
-impl Fold for Lifetime {
+impl<TF: TypeFamily> Fold<TF> for Lifetime<TF> {
     type Result = Self;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         folder.fold_lifetime(self, binders)
     }
 }
 
-pub fn super_fold_lifetime(
-    folder: &mut dyn Folder,
-    lifetime: &Lifetime,
+pub fn super_fold_lifetime<TF: TypeFamily>(
+    folder: &mut dyn Folder<TF>,
+    lifetime: &Lifetime<TF>,
     binders: usize,
-) -> Fallible<Lifetime> {
+) -> Fallible<Lifetime<TF>> {
     match *lifetime {
         Lifetime::BoundVar(depth) => {
             if depth >= binders {
@@ -443,20 +461,21 @@ pub fn super_fold_lifetime(
         }
         Lifetime::InferenceVar(var) => folder.fold_inference_lifetime(var, binders),
         Lifetime::Placeholder(universe) => folder.fold_free_placeholder_lifetime(universe, binders),
+        Lifetime::Phantom(..) => unreachable!(),
     }
 }
 
-impl Fold for Substitution {
-    type Result = Substitution;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+impl<TF: TypeFamily> Fold<TF> for Substitution<TF> {
+    type Result = Substitution<TF>;
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         let parameters = self.parameters.fold_with(folder, binders)?;
         Ok(Substitution { parameters })
     }
 }
 
-impl Fold for Parameter {
-    type Result = Parameter;
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+impl<TF: TypeFamily> Fold<TF> for Parameter<TF> {
+    type Result = Parameter<TF>;
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         let inner = self.0.fold_with(folder, binders)?;
         Ok(Parameter(inner))
     }
@@ -464,12 +483,12 @@ impl Fold for Parameter {
 
 #[macro_export]
 macro_rules! copy_fold {
-    ($t:ty) => {
-        impl $crate::fold::Fold for $t {
+    ($TF:ident => $t:ty) => {
+        impl<$TF: TypeFamily> $crate::fold::Fold<$TF> for $t {
             type Result = Self;
             fn fold_with(
                 &self,
-                _folder: &mut dyn ($crate::fold::Folder),
+                _folder: &mut dyn ($crate::fold::Folder<$TF>),
                 _binders: usize,
             ) -> ::chalk_engine::fallible::Fallible<Self::Result> {
                 Ok(*self)
@@ -478,34 +497,41 @@ macro_rules! copy_fold {
     };
 }
 
-copy_fold!(Identifier);
-copy_fold!(UniverseIndex);
-copy_fold!(ItemId);
-copy_fold!(ImplId);
-copy_fold!(StructId);
-copy_fold!(TraitId);
-copy_fold!(TypeId);
-copy_fold!(TypeKindId);
-copy_fold!(usize);
-copy_fold!(QuantifierKind);
-copy_fold!(chalk_engine::TableIndex);
-copy_fold!(chalk_engine::TimeStamp);
+copy_fold!(TF => Identifier);
+copy_fold!(TF => UniverseIndex);
+copy_fold!(TF => ItemId);
+copy_fold!(TF => ImplId);
+copy_fold!(TF => StructId);
+copy_fold!(TF => TraitId);
+copy_fold!(TF => TypeId);
+copy_fold!(TF => TypeKindId);
+copy_fold!(TF => usize);
+copy_fold!(TF => QuantifierKind);
+copy_fold!(TF => chalk_engine::TableIndex);
+copy_fold!(TF => chalk_engine::TimeStamp);
 // copy_fold!(TypeName); -- intentionally omitted! This is folded via `fold_ap`
-copy_fold!(());
+copy_fold!(TF => ());
+copy_fold!(TF => PhantomData<TF>);
 
 #[macro_export]
 macro_rules! enum_fold {
-    ($s:ident [$($n:ident),*] { $($variant:ident($($name:ident),*)),* } $($w:tt)*) => {
-        impl<$($n),*> $crate::fold::Fold for $s<$($n),*> $($w)* {
-            type Result = $s<$($n :: Result),*>;
-            fn fold_with(&self,
-                         folder: &mut dyn ($crate::fold::Folder),
-                         binders: usize)
-                         -> ::chalk_engine::fallible::Fallible<Self::Result> {
-                match self {
+    (impl[$($param:tt)*] Fold<$TF:ty> for $self:ty { $($variant:ident($($name:ident),*)),* $(,)* } $($w:tt)*) => {
+        impl<$($param)*>
+            $crate::fold::Fold<$TF>
+            for $self $($w)*
+        {
+            type Result = Self;
+
+            #[allow(unused_variables)]
+            fn fold_with(
+                &self,
+                folder: &mut dyn ($crate::fold::Folder<$TF>),
+                binders: usize,
+            ) -> ::chalk_engine::fallible::Fallible<Self::Result> {
+                match *self {
                     $(
-                        $s::$variant( $($name),* ) => {
-                            Ok($s::$variant( $($name.fold_with(folder, binders)?),* ))
+                        Self::$variant( $(ref $name),* ) => {
+                            Ok(Self::$variant( $($name.fold_with(folder, binders)?),* ))
                         }
                     )*
                 }
@@ -515,7 +541,7 @@ macro_rules! enum_fold {
 
     // Hacky variant for use in slg::context::implementation
     ($s:ty { $p:ident :: { $($variant:ident($($name:ident),*)),* } }) => {
-        impl $crate::fold::Fold for $s {
+        impl $crate::fold::Fold<TF> for $s {
             type Result = $s;
             fn fold_with(&self,
                          folder: &mut dyn ($crate::fold::Folder),
@@ -533,172 +559,95 @@ macro_rules! enum_fold {
     }
 }
 
-enum_fold!(ParameterKind[T,L] { Ty(a), Lifetime(a) } where T: Fold, L: Fold);
-enum_fold!(WhereClause[] { Implemented(a), ProjectionEq(a) });
-enum_fold!(WellFormed[] { Trait(a), Ty(a) });
-enum_fold!(FromEnv[] { Trait(a), Ty(a) });
-enum_fold!(DomainGoal[] { Holds(a), WellFormed(a), FromEnv(a), Normalize(a),
-                          IsLocal(a), IsUpstream(a), IsFullyVisible(a),
-                          LocalImplAllowed(a), Compatible(a), DownstreamType(a) });
-enum_fold!(LeafGoal[] { EqGoal(a), DomainGoal(a) });
-enum_fold!(Constraint[] { LifetimeEq(a, b) });
-enum_fold!(Goal[] { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),
+impl<TF: TypeFamily, T, L> Fold<TF> for ParameterKind<T, L>
+where
+    T: Fold<TF>,
+    L: Fold<TF>,
+{
+    type Result = ParameterKind<T::Result, L::Result>;
+
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
+        match self {
+            ParameterKind::Ty(a) => Ok(ParameterKind::Ty(a.fold_with(folder, binders)?)),
+            ParameterKind::Lifetime(a) => {
+                Ok(ParameterKind::Lifetime(a.fold_with(folder, binders)?))
+            }
+        }
+    }
+}
+
+enum_fold!(impl[TF: TypeFamily] Fold<TF> for WellFormed<TF> { Trait(a), Ty(a) });
+enum_fold!(impl[TF: TypeFamily] Fold<TF> for FromEnv<TF> { Trait(a), Ty(a) });
+enum_fold!(impl[TF: TypeFamily] Fold<TF> for WhereClause<TF> { Implemented(a), ProjectionEq(a) });
+enum_fold!(impl[TF: TypeFamily] Fold<TF> for DomainGoal<TF> {
+    Holds(a), WellFormed(a), FromEnv(a), Normalize(a),
+    IsLocal(a), IsUpstream(a), IsFullyVisible(a),
+    LocalImplAllowed(a), Compatible(a), DownstreamType(a),
+});
+enum_fold!(impl[TF: TypeFamily] Fold<TF> for LeafGoal<TF> { EqGoal(a), DomainGoal(a) });
+enum_fold!(impl[TF: TypeFamily] Fold<TF> for Constraint<TF> { LifetimeEq(a, b), });
+enum_fold!(impl[TF: TypeFamily] Fold<TF> for Goal<TF> { Quantified(qkind, subgoal), Implies(wc, subgoal), And(g1, g2), Not(g),
                     Leaf(wc), CannotProve(a) });
-enum_fold!(ProgramClause[] { Implies(a), ForAll(a) });
+enum_fold!(impl[TF: TypeFamily] Fold<TF> for ProgramClause<TF> { Implies(a), ForAll(a) });
+enum_fold!(impl[TF: TypeFamily] Fold<TF> for Void { });
 
 #[macro_export]
 macro_rules! struct_fold {
-    ($s:ident $([$($tt_args:tt)*])* { $($name:ident),* $(,)* } $($w:tt)*) => {
-        struct_fold! {
-            @parse_tt_args($($($tt_args)*)*)
-                struct_name($s)
-                parameters()
-                self_args()
-                result_args()
-                field_names($($name),*)
-                where_clauses($($w)*)
-        }
-    };
-
-    (
-        @parse_tt_args()
-            struct_name($s:ident)
-            parameters($($parameters:tt)*)
-            self_args($($self_args:tt)*)
-            result_args($($result_args:tt)*)
-            field_names($($field_names:tt)*)
-        where_clauses($($where_clauses:tt)*)
-    ) => {
-        struct_fold! {
-            @parsed_tt_args
-                struct_name($s)
-                parameters($($parameters)*)
-                self_ty($s < $($self_args)* >)
-                result_ty($s < $($result_args)* >)
-                field_names($($field_names)*)
-                where_clauses($($where_clauses)*)
-        }
-    };
-
-    (
-        @parse_tt_args(, $($input:tt)*)
-            struct_name($s:ident)
-            parameters($($parameters:tt)*)
-            self_args($($self_args:tt)*)
-            result_args($($result_args:tt)*)
-            field_names($($field_names:tt)*)
-        where_clauses($($where_clauses:tt)*)
-    ) => {
-        struct_fold! {
-            @parse_tt_args($($input)*)
-                struct_name($s)
-                parameters($($parameters)*,)
-                self_args($($self_args)*,)
-                result_args($($result_args)*,)
-                field_names($($field_names)*)
-            where_clauses($($where_clauses)*)
-        }
-    };
-
-    (
-        @parse_tt_args(- $n:ident $($input:tt)*)
-            struct_name($s:ident)
-            parameters($($parameters:tt)*)
-            self_args($($self_args:tt)*)
-            result_args($($result_args:tt)*)
-            field_names($($field_names:tt)*)
-        where_clauses($($where_clauses:tt)*)
-    ) => {
-        struct_fold! {
-            @parse_tt_args($($input)*)
-                struct_name($s)
-                parameters($($parameters)* $n)
-                self_args($($self_args)* $n)
-                result_args($($result_args)* $n)
-                field_names($($field_names)*)
-            where_clauses($($where_clauses)*)
-        }
-    };
-
-    (
-        @parse_tt_args($n:ident $($input:tt)*)
-            struct_name($s:ident)
-            parameters($($parameters:tt)*)
-            self_args($($self_args:tt)*)
-            result_args($($result_args:tt)*)
-            field_names($($field_names:tt)*)
-        where_clauses($($where_clauses:tt)*)
-    ) => {
-        struct_fold! {
-            @parse_tt_args($($input)*)
-                struct_name($s)
-                parameters($($parameters)* $n)
-                self_args($($self_args)* $n)
-                result_args($($result_args)* $n :: Result)
-                field_names($($field_names)*)
-            where_clauses($($where_clauses)*)
-        }
-    };
-
-    (
-        @parsed_tt_args
-            struct_name($s:ident)
-            parameters($($parameters:tt)*)
-            self_ty($self_ty:ty)
-            result_ty($result_ty:ty)
-            field_names($($field_name:ident),*)
-        where_clauses($($where_clauses:tt)*)
-    ) => {
-        impl<$($parameters)*> $crate::fold::Fold for $self_ty $($where_clauses)* {
-            type Result = $result_ty;
-            fn fold_with(&self,
-                         folder: &mut dyn ($crate::fold::Folder),
-                         binders: usize)
-                         -> ::chalk_engine::fallible::Fallible<Self::Result> {
-                Ok($s {
-                    $($field_name: self.$field_name.fold_with(folder, binders)?),*
+    (impl[$($param:tt)*] Fold<$TF:ty> for $self:ty { $($name:ident),* $(,)* } $($w:tt)*) => {
+        impl<$($param)*> $crate::fold::Fold<$TF> for $self $($w)* {
+            type Result = Self;
+            fn fold_with(
+                &self,
+                folder: &mut dyn ($crate::fold::Folder<$TF>),
+                binders: usize,
+            ) -> ::chalk_engine::fallible::Fallible<Self::Result> {
+                Ok(Self {
+                    $($name: self.$name.fold_with(folder, binders)?),*
                 })
             }
         }
     };
 }
 
-struct_fold!(ProjectionTy {
+struct_fold!(impl[TF: TypeFamily] Fold<TF> for ProjectionTy<TF> {
     associated_ty_id,
     parameters,
 });
-struct_fold!(TraitRef {
+struct_fold!(impl[TF: TypeFamily] Fold<TF> for TraitRef<TF> {
     trait_id,
     parameters,
 });
-struct_fold!(Normalize { projection, ty });
-struct_fold!(ProjectionEq { projection, ty });
-struct_fold!(Environment { clauses });
-struct_fold!(InEnvironment[F] { environment, goal } where F: Fold<Result = F>);
-struct_fold!(EqGoal { a, b });
-struct_fold!(ProgramClauseImplication {
+struct_fold!(impl[TF: TypeFamily] Fold<TF> for Normalize<TF> { projection, ty });
+struct_fold!(impl[TF: TypeFamily] Fold<TF> for ProjectionEq<TF> { projection, ty });
+struct_fold!(impl[TF: TypeFamily] Fold<TF> for Environment<TF> { clauses });
+struct_fold!(impl[TF: TypeFamily, F] Fold<TF> for InEnvironment<F> {
+    environment,
+    goal,
+} where F: HasTypeFamily<TypeFamily = TF> + Fold<TF, Result = F>);
+struct_fold!(impl[TF: TypeFamily] Fold<TF> for EqGoal<TF> { a, b });
+struct_fold!(impl[TF: TypeFamily] Fold<TF> for ProgramClauseImplication<TF> {
     consequence,
     conditions,
 });
 
-struct_fold!(ConstrainedSubst {
+struct_fold!(impl[TF: TypeFamily] Fold<TF> for ConstrainedSubst<TF> {
     subst, /* NB: The `is_trivial` routine relies on the fact that `subst` is folded first. */
     constraints,
 });
 
-// struct_fold!(ApplicationTy { name, parameters }); -- intentionally omitted, folded through Ty
+// struct_fold!(impl[TF: TypeFamily] Fold<TF> for ApplicationTy { name, parameters }); -- intentionally omitted, folded through Ty
 
-impl<C: Context> Fold for ExClause<C>
+impl<C: Context, TF: TypeFamily> Fold<TF> for ExClause<C>
 where
     C: Context,
-    C::Substitution: Fold<Result = C::Substitution>,
-    C::RegionConstraint: Fold<Result = C::RegionConstraint>,
-    C::CanonicalConstrainedSubst: Fold<Result = C::CanonicalConstrainedSubst>,
-    C::GoalInEnvironment: Fold<Result = C::GoalInEnvironment>,
+    C::Substitution: Fold<TF, Result = C::Substitution>,
+    C::RegionConstraint: Fold<TF, Result = C::RegionConstraint>,
+    C::CanonicalConstrainedSubst: Fold<TF, Result = C::CanonicalConstrainedSubst>,
+    C::GoalInEnvironment: Fold<TF, Result = C::GoalInEnvironment>,
 {
     type Result = ExClause<C>;
 
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         let ExClause {
             subst,
             delayed_literals,
@@ -718,17 +667,17 @@ where
     }
 }
 
-impl<C: Context> Fold for FlounderedSubgoal<C>
+impl<C: Context, TF: TypeFamily> Fold<TF> for FlounderedSubgoal<C>
 where
     C: Context,
-    C::Substitution: Fold<Result = C::Substitution>,
-    C::RegionConstraint: Fold<Result = C::RegionConstraint>,
-    C::CanonicalConstrainedSubst: Fold<Result = C::CanonicalConstrainedSubst>,
-    C::GoalInEnvironment: Fold<Result = C::GoalInEnvironment>,
+    C::Substitution: Fold<TF, Result = C::Substitution>,
+    C::RegionConstraint: Fold<TF, Result = C::RegionConstraint>,
+    C::CanonicalConstrainedSubst: Fold<TF, Result = C::CanonicalConstrainedSubst>,
+    C::GoalInEnvironment: Fold<TF, Result = C::GoalInEnvironment>,
 {
     type Result = FlounderedSubgoal<C>;
 
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         let FlounderedSubgoal {
             floundered_literal,
             floundered_time,
@@ -740,14 +689,14 @@ where
     }
 }
 
-impl<C: Context> Fold for DelayedLiteral<C>
+impl<C: Context, TF: TypeFamily> Fold<TF> for DelayedLiteral<C>
 where
     C: Context,
-    C::CanonicalConstrainedSubst: Fold<Result = C::CanonicalConstrainedSubst>,
+    C::CanonicalConstrainedSubst: Fold<TF, Result = C::CanonicalConstrainedSubst>,
 {
     type Result = DelayedLiteral<C>;
 
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         match self {
             DelayedLiteral::CannotProve(()) => Ok(DelayedLiteral::CannotProve(())),
             DelayedLiteral::Negative(table_index) => Ok(DelayedLiteral::Negative(
@@ -761,14 +710,14 @@ where
     }
 }
 
-impl<C: Context> Fold for Literal<C>
+impl<C: Context, TF: TypeFamily> Fold<TF> for Literal<C>
 where
     C: Context,
-    C::GoalInEnvironment: Fold<Result = C::GoalInEnvironment>,
+    C::GoalInEnvironment: Fold<TF, Result = C::GoalInEnvironment>,
 {
     type Result = Literal<C>;
 
-    fn fold_with(&self, folder: &mut dyn Folder, binders: usize) -> Fallible<Self::Result> {
+    fn fold_with(&self, folder: &mut dyn Folder<TF>, binders: usize) -> Fallible<Self::Result> {
         match self {
             Literal::Positive(goal) => Ok(Literal::Positive(goal.fold_with(folder, binders)?)),
             Literal::Negative(goal) => Ok(Literal::Negative(goal.fold_with(folder, binders)?)),

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -192,7 +192,7 @@ impl<T: DefaultPlaceholderFolder, TF: TypeFamily> PlaceholderFolder<TF> for T {
         if T::forbid() {
             panic!("unexpected placeholder type `{:?}`", universe)
         } else {
-            Ok(TF::intern_ty(universe.to_ty()))
+            Ok(universe.to_ty::<TF>())
         }
     }
 

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -136,7 +136,7 @@ impl<T: DefaultFreeVarFolder, TF: TypeFamily> FreeVarFolder<TF> for T {
         if T::forbid() {
             panic!("unexpected free variable with depth `{:?}`", depth)
         } else {
-            Ok(TF::intern_ty(Ty::BoundVar(depth + binders)))
+            Ok(Ty::<TF>::BoundVar(depth + binders).intern())
         }
     }
 
@@ -144,7 +144,7 @@ impl<T: DefaultFreeVarFolder, TF: TypeFamily> FreeVarFolder<TF> for T {
         if T::forbid() {
             panic!("unexpected free variable with depth `{:?}`", depth)
         } else {
-            Ok(TF::intern_lifetime(Lifetime::BoundVar(depth + binders)))
+            Ok(Lifetime::<TF>::BoundVar(depth + binders).intern())
         }
     }
 }
@@ -356,7 +356,7 @@ where
             if *depth >= binders {
                 folder.fold_free_var_ty(*depth - binders, binders)
             } else {
-                Ok(TF::intern_ty(Ty::BoundVar(*depth)))
+                Ok(Ty::<TF>::BoundVar(*depth).intern())
             }
         }
         Ty::Dyn(clauses) => Ok(TF::intern_ty(Ty::Dyn(clauses.fold_with(folder, binders)?))),
@@ -382,16 +382,14 @@ where
 
                 TypeName::TypeKindId(_) | TypeName::AssociatedType(_) => {
                     let parameters = parameters.fold_with(folder, binders)?;
-                    Ok(TF::intern_ty(ApplicationTy { name, parameters }.cast()))
+                    Ok(ApplicationTy { name, parameters }.cast().intern())
                 }
             }
         }
-        Ty::Projection(proj) => Ok(TF::intern_ty(Ty::Projection(
-            proj.fold_with(folder, binders)?,
-        ))),
-        Ty::ForAll(quantified_ty) => Ok(TF::intern_ty(Ty::ForAll(
-            quantified_ty.fold_with(folder, binders)?,
-        ))),
+        Ty::Projection(proj) => Ok(Ty::Projection(proj.fold_with(folder, binders)?).intern()),
+        Ty::ForAll(quantified_ty) => {
+            Ok(Ty::ForAll(quantified_ty.fold_with(folder, binders)?).intern())
+        }
     }
 }
 
@@ -457,7 +455,7 @@ pub fn super_fold_lifetime<TF: TypeFamily>(
             if *depth >= binders {
                 folder.fold_free_var_lifetime(depth - binders, binders)
             } else {
-                Ok(TF::intern_lifetime(Lifetime::BoundVar(*depth)))
+                Ok(Lifetime::<TF>::BoundVar(*depth).intern())
             }
         }
         Lifetime::InferenceVar(var) => folder.fold_inference_lifetime(*var, binders),

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -277,7 +277,7 @@ pub trait Fold<TF: TypeFamily>: Debug {
     /// values, in which case owned values are produced (for example,
     /// one can fold over a `&T` value where `T: Fold`, in which case
     /// you get back a `T`, not a `&T`).
-    type Result: Fold<TF>;
+    type Result;
 
     /// Apply the given folder `folder` to `self`; `binders` is the
     /// number of binders that are in scope when beginning the

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -89,8 +89,8 @@ impl Shifter {
 impl DefaultTypeFolder for Shifter {}
 
 impl<TF: TypeFamily> FreeVarFolder<TF> for Shifter {
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty<TF>> {
-        Ok(Ty::BoundVar(self.adjust(depth, binders)))
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<TF::Type> {
+        Ok(TF::intern_ty(Ty::BoundVar(self.adjust(depth, binders))))
     }
 
     fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>> {
@@ -131,8 +131,8 @@ impl DownShifter {
 impl DefaultTypeFolder for DownShifter {}
 
 impl<TF: TypeFamily> FreeVarFolder<TF> for DownShifter {
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty<TF>> {
-        Ok(Ty::BoundVar(self.adjust(depth, binders)?))
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<TF::Type> {
+        Ok(TF::intern_ty(Ty::BoundVar(self.adjust(depth, binders)?)))
     }
 
     fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>> {

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -5,7 +5,7 @@ use crate::*;
 
 /// Methods for converting debruijn indices to move values into or out
 /// of binders.
-pub trait Shift: Fold {
+pub trait Shift<TF: TypeFamily>: Fold<TF> {
     /// Shifts debruijn indices in `self` **up**, which is used when a
     /// value is being placed under additional levels of binders.
     ///
@@ -61,7 +61,7 @@ pub trait Shift: Fold {
     fn shifted_out(&self, adjustment: usize) -> Fallible<Self::Result>;
 }
 
-impl<T: Fold + Eq> Shift for T {
+impl<T: Fold<TF> + Eq, TF: TypeFamily> Shift<TF> for T {
     fn shifted_in(&self, adjustment: usize) -> T::Result {
         self.fold_with(&mut Shifter { adjustment }, 0).unwrap()
     }
@@ -88,12 +88,12 @@ impl Shifter {
 
 impl DefaultTypeFolder for Shifter {}
 
-impl FreeVarFolder for Shifter {
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<TF: TypeFamily> FreeVarFolder<TF> for Shifter {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty<TF>> {
         Ok(Ty::BoundVar(self.adjust(depth, binders)))
     }
 
-    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime> {
+    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>> {
         Ok(Lifetime::BoundVar(self.adjust(depth, binders)))
     }
 }
@@ -130,12 +130,12 @@ impl DownShifter {
 
 impl DefaultTypeFolder for DownShifter {}
 
-impl FreeVarFolder for DownShifter {
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<TF: TypeFamily> FreeVarFolder<TF> for DownShifter {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty<TF>> {
         Ok(Ty::BoundVar(self.adjust(depth, binders)?))
     }
 
-    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime> {
+    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>> {
         Ok(Lifetime::BoundVar(self.adjust(depth, binders)?))
     }
 }

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -93,8 +93,10 @@ impl<TF: TypeFamily> FreeVarFolder<TF> for Shifter {
         Ok(TF::intern_ty(Ty::BoundVar(self.adjust(depth, binders))))
     }
 
-    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>> {
-        Ok(Lifetime::BoundVar(self.adjust(depth, binders)))
+    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<TF::Lifetime> {
+        Ok(TF::intern_lifetime(Lifetime::BoundVar(
+            self.adjust(depth, binders),
+        )))
     }
 }
 
@@ -135,8 +137,10 @@ impl<TF: TypeFamily> FreeVarFolder<TF> for DownShifter {
         Ok(TF::intern_ty(Ty::BoundVar(self.adjust(depth, binders)?)))
     }
 
-    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>> {
-        Ok(Lifetime::BoundVar(self.adjust(depth, binders)?))
+    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<TF::Lifetime> {
+        Ok(TF::intern_lifetime(Lifetime::BoundVar(
+            self.adjust(depth, binders)?,
+        )))
     }
 }
 

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -90,13 +90,11 @@ impl DefaultTypeFolder for Shifter {}
 
 impl<TF: TypeFamily> FreeVarFolder<TF> for Shifter {
     fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<TF::Type> {
-        Ok(TF::intern_ty(Ty::BoundVar(self.adjust(depth, binders))))
+        Ok(Ty::<TF>::BoundVar(self.adjust(depth, binders)).intern())
     }
 
     fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<TF::Lifetime> {
-        Ok(TF::intern_lifetime(Lifetime::BoundVar(
-            self.adjust(depth, binders),
-        )))
+        Ok(Lifetime::<TF>::BoundVar(self.adjust(depth, binders)).intern())
     }
 }
 
@@ -134,13 +132,11 @@ impl DefaultTypeFolder for DownShifter {}
 
 impl<TF: TypeFamily> FreeVarFolder<TF> for DownShifter {
     fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<TF::Type> {
-        Ok(TF::intern_ty(Ty::BoundVar(self.adjust(depth, binders)?)))
+        Ok(Ty::<TF>::BoundVar(self.adjust(depth, binders)?).intern())
     }
 
     fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<TF::Lifetime> {
-        Ok(TF::intern_lifetime(Lifetime::BoundVar(
-            self.adjust(depth, binders)?,
-        )))
+        Ok(Lifetime::<TF>::BoundVar(self.adjust(depth, binders)?).intern())
     }
 }
 

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -37,9 +37,11 @@ impl<'b, TF: TypeFamily> FreeVarFolder<TF> for Subst<'b, TF> {
         }
     }
 
-    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>> {
+    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<TF::Lifetime> {
         if depth >= self.parameters.len() {
-            Ok(Lifetime::BoundVar(depth - self.parameters.len() + binders))
+            Ok(TF::intern_lifetime(Lifetime::BoundVar(
+                depth - self.parameters.len() + binders,
+            )))
         } else {
             match self.parameters[depth].0 {
                 ParameterKind::Lifetime(ref l) => Ok(l.shifted_in(binders)),

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -26,9 +26,7 @@ impl<'b, TF: TypeFamily> DefaultTypeFolder for Subst<'b, TF> {}
 impl<'b, TF: TypeFamily> FreeVarFolder<TF> for Subst<'b, TF> {
     fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<TF::Type> {
         if depth >= self.parameters.len() {
-            Ok(TF::intern_ty(Ty::BoundVar(
-                depth - self.parameters.len() + binders,
-            )))
+            Ok(Ty::<TF>::BoundVar(depth - self.parameters.len() + binders).intern())
         } else {
             match self.parameters[depth].0 {
                 ParameterKind::Ty(ref t) => Ok(t.shifted_in(binders)),
@@ -39,9 +37,7 @@ impl<'b, TF: TypeFamily> FreeVarFolder<TF> for Subst<'b, TF> {
 
     fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<TF::Lifetime> {
         if depth >= self.parameters.len() {
-            Ok(TF::intern_lifetime(Lifetime::BoundVar(
-                depth - self.parameters.len() + binders,
-            )))
+            Ok(Lifetime::<TF>::BoundVar(depth - self.parameters.len() + binders).intern())
         } else {
             match self.parameters[depth].0 {
                 ParameterKind::Lifetime(ref l) => Ok(l.shifted_in(binders)),

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -15,7 +15,7 @@ impl<'s, TF: TypeFamily> Subst<'s, TF> {
 }
 
 impl<TF: TypeFamily> QuantifiedTy<TF> {
-    pub fn substitute(&self, parameters: &[Parameter<TF>]) -> Ty<TF> {
+    pub fn substitute(&self, parameters: &[Parameter<TF>]) -> TF::Type {
         assert_eq!(self.num_binders, parameters.len());
         Subst::apply(parameters, &self.ty)
     }
@@ -24,9 +24,11 @@ impl<TF: TypeFamily> QuantifiedTy<TF> {
 impl<'b, TF: TypeFamily> DefaultTypeFolder for Subst<'b, TF> {}
 
 impl<'b, TF: TypeFamily> FreeVarFolder<TF> for Subst<'b, TF> {
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty<TF>> {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<TF::Type> {
         if depth >= self.parameters.len() {
-            Ok(Ty::BoundVar(depth - self.parameters.len() + binders))
+            Ok(TF::intern_ty(Ty::BoundVar(
+                depth - self.parameters.len() + binders,
+            )))
         } else {
             match self.parameters[depth].0 {
                 ParameterKind::Ty(ref t) => Ok(t.shifted_in(binders)),

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -1,30 +1,30 @@
 use super::*;
 use crate::fold::shift::Shift;
 
-pub struct Subst<'s> {
+pub struct Subst<'s, TF: TypeFamily> {
     /// Values to substitute. A reference to a free variable with
     /// index `i` will be mapped to `parameters[i]` -- if `i >
     /// parameters.len()`, then we will leave the variable untouched.
-    parameters: &'s [Parameter],
+    parameters: &'s [Parameter<TF>],
 }
 
-impl<'s> Subst<'s> {
-    pub fn apply<T: Fold>(parameters: &[Parameter], value: &T) -> T::Result {
+impl<'s, TF: TypeFamily> Subst<'s, TF> {
+    pub fn apply<T: Fold<TF>>(parameters: &[Parameter<TF>], value: &T) -> T::Result {
         value.fold_with(&mut Subst { parameters }, 0).unwrap()
     }
 }
 
-impl QuantifiedTy {
-    pub fn substitute(&self, parameters: &[Parameter]) -> Ty {
+impl<TF: TypeFamily> QuantifiedTy<TF> {
+    pub fn substitute(&self, parameters: &[Parameter<TF>]) -> Ty<TF> {
         assert_eq!(self.num_binders, parameters.len());
         Subst::apply(parameters, &self.ty)
     }
 }
 
-impl<'b> DefaultTypeFolder for Subst<'b> {}
+impl<'b, TF: TypeFamily> DefaultTypeFolder for Subst<'b, TF> {}
 
-impl<'b> FreeVarFolder for Subst<'b> {
-    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty> {
+impl<'b, TF: TypeFamily> FreeVarFolder<TF> for Subst<'b, TF> {
+    fn fold_free_var_ty(&mut self, depth: usize, binders: usize) -> Fallible<Ty<TF>> {
         if depth >= self.parameters.len() {
             Ok(Ty::BoundVar(depth - self.parameters.len() + binders))
         } else {
@@ -35,7 +35,7 @@ impl<'b> FreeVarFolder for Subst<'b> {
         }
     }
 
-    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime> {
+    fn fold_free_var_lifetime(&mut self, depth: usize, binders: usize) -> Fallible<Lifetime<TF>> {
         if depth >= self.parameters.len() {
             Ok(Lifetime::BoundVar(depth - self.parameters.len() + binders))
         } else {
@@ -47,6 +47,6 @@ impl<'b> FreeVarFolder for Subst<'b> {
     }
 }
 
-impl<'b> DefaultPlaceholderFolder for Subst<'b> {}
+impl<'b, TF: TypeFamily> DefaultPlaceholderFolder for Subst<'b, TF> {}
 
-impl<'b> DefaultInferenceFolder for Subst<'b> {}
+impl<'b, TF: TypeFamily> DefaultInferenceFolder for Subst<'b, TF> {}

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -74,19 +74,6 @@ impl Environment {
         env.clauses = env_clauses.into_iter().collect();
         Arc::new(env)
     }
-
-    /// Return the set of all in-scope trait ids from the environment.
-    /// This is used in "unselected normalization" of projections like
-    /// `T::Item`, where the trait is not fully known.
-    ///
-    /// FIXME -- This is a bit of a hack, because we assume that the
-    /// set of in-scope traits is always found in the environment and
-    /// has a simple form. This happens to be true, of course.
-    pub fn in_scope_trait_ids(&self) -> impl Iterator<Item = TraitId> + '_ {
-        self.clauses
-            .iter()
-            .flat_map(|clause| clause.in_scope_trait_id())
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -641,8 +628,6 @@ pub enum DomainGoal {
 
     Normalize(Normalize),
 
-    InScope(TypeKindId),
-
     /// True if a type is considered to have been "defined" by the current crate. This is true for
     /// a `struct Foo { }` but false for a `#[upstream] struct Foo { }`. However, for fundamental types
     /// like `Box<T>`, it is true if `T` is local.
@@ -875,30 +860,10 @@ pub struct ProgramClauseImplication {
     pub conditions: Vec<Goal>,
 }
 
-impl ProgramClauseImplication {
-    /// See `Environment::in_scope_trait_ids`
-    pub fn in_scope_trait_id(&self) -> Option<TraitId> {
-        match self.consequence {
-            DomainGoal::InScope(TypeKindId::TraitId(trait_id)) => Some(trait_id),
-            _ => None,
-        }
-    }
-}
-
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ProgramClause {
     Implies(ProgramClauseImplication),
     ForAll(Binders<ProgramClauseImplication>),
-}
-
-impl ProgramClause {
-    /// See `Environment::in_scope_trait_ids`
-    pub fn in_scope_trait_id(&self) -> Option<TraitId> {
-        match self {
-            ProgramClause::Implies(implication) => implication.in_scope_trait_id(),
-            ProgramClause::ForAll(binders) => binders.value.in_scope_trait_id(),
-        }
-    }
 }
 
 impl ProgramClause {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -421,11 +421,11 @@ impl PlaceholderIndex {
         Lifetime::Placeholder(self)
     }
 
-    pub fn to_ty<TF: TypeFamily>(self) -> Ty<TF> {
-        Ty::Apply(ApplicationTy {
+    pub fn to_ty<TF: TypeFamily>(self) -> TF::Type {
+        TF::intern_ty(Ty::Apply(ApplicationTy {
             name: TypeName::Placeholder(self),
             parameters: vec![],
-        })
+        }))
     }
 }
 

--- a/chalk-ir/src/tls.rs
+++ b/chalk-ir/src/tls.rs
@@ -1,3 +1,4 @@
+use crate::family::ChalkIr;
 use crate::{ProjectionTy, TypeKindId};
 use std::cell::RefCell;
 use std::fmt;
@@ -16,7 +17,7 @@ pub trait DebugContext {
 
     fn debug_projection(
         &self,
-        projection: &ProjectionTy,
+        projection: &ProjectionTy<ChalkIr>,
         fmt: &mut fmt::Formatter,
     ) -> Result<(), fmt::Error>;
 }

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -232,7 +232,6 @@ enum_zip!(DomainGoal {
     WellFormed,
     FromEnv,
     Normalize,
-    InScope,
     IsLocal,
     IsUpstream,
     IsFullyVisible,

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -19,33 +19,37 @@ use std::sync::Arc;
 /// represented by two distinct `ItemId` values, and the impl for
 /// `ItemId` requires that all `ItemId` in the two zipped values match
 /// up.
-pub trait Zipper {
+pub trait Zipper<TF: TypeFamily> {
     /// Indicates that the two types `a` and `b` were found in
     /// matching spots, beneath `binders` levels of binders.
-    fn zip_tys(&mut self, a: &Ty, b: &Ty) -> Fallible<()>;
+    fn zip_tys(&mut self, a: &Ty<TF>, b: &Ty<TF>) -> Fallible<()>;
 
     /// Indicates that the two lifetimes `a` and `b` were found in
     /// matching spots, beneath `binders` levels of binders.
-    fn zip_lifetimes(&mut self, a: &Lifetime, b: &Lifetime) -> Fallible<()>;
+    fn zip_lifetimes(&mut self, a: &Lifetime<TF>, b: &Lifetime<TF>) -> Fallible<()>;
 
     /// Zips two values appearing beneath binders.
     fn zip_binders<T>(&mut self, a: &Binders<T>, b: &Binders<T>) -> Fallible<()>
     where
-        T: Zip + Fold<Result = T>;
+        T: Zip<TF> + Fold<TF, Result = T>;
 }
 
-impl<'f, Z: Zipper> Zipper for &'f mut Z {
-    fn zip_tys(&mut self, a: &Ty, b: &Ty) -> Fallible<()> {
+impl<'f, Z, TF> Zipper<TF> for &'f mut Z
+where
+    TF: TypeFamily,
+    Z: Zipper<TF>,
+{
+    fn zip_tys(&mut self, a: &Ty<TF>, b: &Ty<TF>) -> Fallible<()> {
         (**self).zip_tys(a, b)
     }
 
-    fn zip_lifetimes(&mut self, a: &Lifetime, b: &Lifetime) -> Fallible<()> {
+    fn zip_lifetimes(&mut self, a: &Lifetime<TF>, b: &Lifetime<TF>) -> Fallible<()> {
         (**self).zip_lifetimes(a, b)
     }
 
     fn zip_binders<T>(&mut self, a: &Binders<T>, b: &Binders<T>) -> Fallible<()>
     where
-        T: Zip + Fold<Result = T>,
+        T: Zip<TF> + Fold<TF, Result = T>,
     {
         (**self).zip_binders(a, b)
     }
@@ -58,30 +62,33 @@ impl<'f, Z: Zipper> Zipper for &'f mut Z {
 ///
 /// To implement the trait, typically you would use one of the macros
 /// like `eq_zip!`, `struct_zip!`, or `enum_zip!`.
-pub trait Zip: Debug {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()>;
+pub trait Zip<TF>: Debug
+where
+    TF: TypeFamily,
+{
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()>;
 }
 
-impl<'a, T: ?Sized + Zip> Zip for &'a T {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
-        <T as Zip>::zip_with(zipper, a, b)
+impl<'a, T: ?Sized + Zip<TF>, TF: TypeFamily> Zip<TF> for &'a T {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+        <T as Zip<TF>>::zip_with(zipper, a, b)
     }
 }
 
-impl Zip for () {
-    fn zip_with<Z: Zipper>(_: &mut Z, _: &Self, _: &Self) -> Fallible<()> {
+impl<TF: TypeFamily> Zip<TF> for () {
+    fn zip_with<Z: Zipper<TF>>(_: &mut Z, _: &Self, _: &Self) -> Fallible<()> {
         Ok(())
     }
 }
 
-impl<T: Zip> Zip for Vec<T> {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
-        <[T] as Zip>::zip_with(zipper, a, b)
+impl<T: Zip<TF>, TF: TypeFamily> Zip<TF> for Vec<T> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+        <[T] as Zip<TF>>::zip_with(zipper, a, b)
     }
 }
 
-impl<T: Zip> Zip for [T] {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+impl<T: Zip<TF>, TF: TypeFamily> Zip<TF> for [T] {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         if a.len() != b.len() {
             return Err(NoSolution);
         }
@@ -94,40 +101,40 @@ impl<T: Zip> Zip for [T] {
     }
 }
 
-impl<T: Zip> Zip for Arc<T> {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
-        <T as Zip>::zip_with(zipper, a, b)
+impl<T: Zip<TF>, TF: TypeFamily> Zip<TF> for Arc<T> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+        <T as Zip<TF>>::zip_with(zipper, a, b)
     }
 }
 
-impl<T: Zip> Zip for Box<T> {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
-        <T as Zip>::zip_with(zipper, a, b)
+impl<T: Zip<TF>, TF: TypeFamily> Zip<TF> for Box<T> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+        <T as Zip<TF>>::zip_with(zipper, a, b)
     }
 }
 
-impl<T: Zip, U: Zip> Zip for (T, U) {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+impl<T: Zip<TF>, U: Zip<TF>, TF: TypeFamily> Zip<TF> for (T, U) {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         Zip::zip_with(zipper, &a.0, &b.0)?;
         Zip::zip_with(zipper, &a.1, &b.1)?;
         Ok(())
     }
 }
 
-impl Zip for Ty {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+impl<TF: TypeFamily> Zip<TF> for Ty<TF> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         zipper.zip_tys(a, b)
     }
 }
 
-impl Zip for Lifetime {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+impl<TF: TypeFamily> Zip<TF> for Lifetime<TF> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         zipper.zip_lifetimes(a, b)
     }
 }
 
-impl<T: Zip + Fold<Result = T>> Zip for Binders<T> {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+impl<TF: TypeFamily, T: Zip<TF> + Fold<TF, Result = T>> Zip<TF> for Binders<T> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         zipper.zip_binders(a, b)
     }
 }
@@ -135,9 +142,9 @@ impl<T: Zip + Fold<Result = T>> Zip for Binders<T> {
 /// Generates a Zip impl that requires the two values be
 /// equal. Suitable for atomic, scalar values.
 macro_rules! eq_zip {
-    ($t:ty) => {
-        impl Zip for $t {
-            fn zip_with<Z: Zipper>(_zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+    ($TF:ident => $t:ty) => {
+        impl<$TF: TypeFamily> Zip<$TF> for $t {
+            fn zip_with<Z: Zipper<$TF>>(_zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
                 if a != b {
                     return Err(NoSolution);
                 }
@@ -147,22 +154,23 @@ macro_rules! eq_zip {
     };
 }
 
-eq_zip!(ItemId);
-eq_zip!(StructId);
-eq_zip!(TraitId);
-eq_zip!(TypeId);
-eq_zip!(TypeKindId);
-eq_zip!(TypeName);
-eq_zip!(Identifier);
-eq_zip!(QuantifierKind);
+eq_zip!(TF => ItemId);
+eq_zip!(TF => StructId);
+eq_zip!(TF => TraitId);
+eq_zip!(TF => TypeId);
+eq_zip!(TF => TypeKindId);
+eq_zip!(TF => TypeName);
+eq_zip!(TF => Identifier);
+eq_zip!(TF => QuantifierKind);
+eq_zip!(TF => PhantomData<TF>);
 
 /// Generates a Zip impl that zips each field of the struct in turn.
 macro_rules! struct_zip {
-    ($t:ident$([$($param:tt)*])* { $($field:ident),* $(,)* } $($w:tt)*) => {
-        impl$(<$($param)*>)* Zip for $t $(<$($param)*>)* $($w)* {
-            fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+    (impl[$($param:tt)*] Zip<$TF:ty> for $self:ty { $($field:ident),* $(,)* } $($w:tt)*) => {
+        impl<$($param)*> Zip<$TF> for $self $($w)* {
+            fn zip_with<Z: Zipper<$TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
                 // Validate that we have indeed listed all fields
-                let $t { $($field: _),* } = *a;
+                let Self { $($field: _),* } = *a;
                 $(
                     Zip::zip_with(zipper, &a.$field, &b.$field)?;
                 )*
@@ -172,26 +180,32 @@ macro_rules! struct_zip {
     }
 }
 
-struct_zip!(TraitRef {
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for TraitRef<TF> {
     trait_id,
     parameters,
 });
-struct_zip!(InEnvironment[T] { environment, goal } where T: Zip);
-struct_zip!(ApplicationTy { name, parameters });
-struct_zip!(ProjectionTy {
+struct_zip!(impl[
+    T: HasTypeFamily<TypeFamily = TF> + Zip<TF>,
+    TF: TypeFamily,
+] Zip<TF> for InEnvironment<T> {
+    environment,
+    goal,
+});
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for ApplicationTy<TF> { name, parameters });
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for ProjectionTy<TF> {
     associated_ty_id,
     parameters,
 });
-struct_zip!(Normalize { projection, ty });
-struct_zip!(ProjectionEq { projection, ty });
-struct_zip!(EqGoal { a, b });
-struct_zip!(ProgramClauseImplication {
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for Normalize<TF> { projection, ty });
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for ProjectionEq<TF> { projection, ty });
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for EqGoal<TF> { a, b });
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for ProgramClauseImplication<TF> {
     consequence,
     conditions
 });
 
-impl Zip for Environment {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+impl<TF: TypeFamily> Zip<TF> for Environment<TF> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         assert_eq!(a.clauses.len(), b.clauses.len()); // or different numbers of clauses
         Zip::zip_with(zipper, &a.clauses, &b.clauses)?;
         Ok(())
@@ -202,17 +216,17 @@ impl Zip for Environment {
 /// variant, then zips each field of the variant in turn. Only works
 /// if all variants have a single parenthesized value right now.
 macro_rules! enum_zip {
-    ($t:ident$([$($param:tt)*])* { $( $variant:ident ),* $(,)* } $($w:tt)*) => {
-        impl$(<$($param)*>)* Zip for $t $(<$($param)*>)* $($w)* {
-            fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+    (impl<$TF:ident $(, $param:ident)*> for $self:ty { $( $variant:ident ),* $(,)* } $($w:tt)*) => {
+        impl<$TF: TypeFamily, $(, $param)*> Zip<$TF> for $self $($w)* {
+            fn zip_with<Z: Zipper<$TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
                 match (a, b) {
                     $(
-                        (&$t :: $variant (ref f_a), &$t :: $variant (ref f_b)) => {
+                        (Self :: $variant (f_a), Self :: $variant (f_b)) => {
                             Zip::zip_with(zipper, f_a, f_b)
                         }
                     )*
 
-                    $((&$t :: $variant ( .. ), _))|* => {
+                    $((Self :: $variant ( .. ), _))|* => {
                         return Err(NoSolution);
                     }
                 }
@@ -221,13 +235,10 @@ macro_rules! enum_zip {
     }
 }
 
-enum_zip!(WhereClause {
-    Implemented,
-    ProjectionEq
-});
-enum_zip!(WellFormed { Trait, Ty });
-enum_zip!(FromEnv { Trait, Ty });
-enum_zip!(DomainGoal {
+enum_zip!(impl<TF> for WellFormed<TF> { Trait, Ty });
+enum_zip!(impl<TF> for FromEnv<TF> { Trait, Ty });
+enum_zip!(impl<TF> for WhereClause<TF> { Implemented, ProjectionEq });
+enum_zip!(impl<TF> for DomainGoal<TF> {
     Holds,
     WellFormed,
     FromEnv,
@@ -239,14 +250,14 @@ enum_zip!(DomainGoal {
     Compatible,
     DownstreamType
 });
-enum_zip!(LeafGoal { DomainGoal, EqGoal });
-enum_zip!(ProgramClause { Implies, ForAll });
+enum_zip!(impl<TF> for LeafGoal<TF> { DomainGoal, EqGoal });
+enum_zip!(impl<TF> for ProgramClause<TF> { Implies, ForAll });
 
 // Annoyingly, Goal cannot use `enum_zip` because some variants have
 // two parameters, and I'm too lazy to make the macro account for the
 // relevant name mangling.
-impl Zip for Goal {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+impl<TF: TypeFamily> Zip<TF> for Goal<TF> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         match (a, b) {
             (&Goal::Quantified(ref f_a, ref g_a), &Goal::Quantified(ref f_b, ref g_b)) => {
                 Zip::zip_with(zipper, f_a, f_b)?;
@@ -276,22 +287,20 @@ impl Zip for Goal {
 }
 
 // I'm too lazy to make `enum_zip` support type parameters.
-impl<T: Zip, L: Zip> Zip for ParameterKind<T, L> {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+impl<T: Zip<TF>, L: Zip<TF>, TF: TypeFamily> Zip<TF> for ParameterKind<T, L> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         match (a, b) {
-            (&ParameterKind::Ty(ref a), &ParameterKind::Ty(ref b)) => Zip::zip_with(zipper, a, b),
-            (&ParameterKind::Lifetime(ref a), &ParameterKind::Lifetime(ref b)) => {
-                Zip::zip_with(zipper, a, b)
-            }
-            (&ParameterKind::Ty(_), _) | (&ParameterKind::Lifetime(_), _) => {
+            (ParameterKind::Ty(a), ParameterKind::Ty(b)) => Zip::zip_with(zipper, a, b),
+            (ParameterKind::Lifetime(a), ParameterKind::Lifetime(b)) => Zip::zip_with(zipper, a, b),
+            (ParameterKind::Ty(_), _) | (ParameterKind::Lifetime(_), _) => {
                 panic!("zipping things of mixed kind")
             }
         }
     }
 }
 
-impl Zip for Parameter {
-    fn zip_with<Z: Zipper>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+impl<TF: TypeFamily> Zip<TF> for Parameter<TF> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         Zip::zip_with(zipper, &a.0, &b.0)
     }
 }

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -236,7 +236,6 @@ pub enum DomainGoal {
     TyWellFormed { ty: Ty },
     TyFromEnv { ty: Ty },
     TraitRefFromEnv { trait_ref: TraitRef },
-    TraitInScope { trait_name: Identifier },
     IsLocal { ty: Ty },
     IsUpstream { ty: Ty },
     IsFullyVisible { ty: Ty },

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -293,8 +293,6 @@ DomainGoal: DomainGoal = {
     // `<T as Foo>::U -> Bar` -- a normalization
     "Normalize" "(" <s:ProjectionTy> "->" <t:Ty> ")" => DomainGoal::Normalize { projection: s, ty: t },
 
-    "InScope" "(" <t:Id> ")" => DomainGoal::TraitInScope { trait_name: t },
-
     "IsLocal" "(" <ty:Ty> ")" => DomainGoal::IsLocal { ty },
     "IsUpstream" "(" <ty:Ty> ")" => DomainGoal::IsUpstream { ty },
     "IsFullyVisible" "(" <ty:Ty> ")" => DomainGoal::IsFullyVisible { ty },

--- a/chalk-rust-ir/src/cast.rs
+++ b/chalk-rust-ir/src/cast.rs
@@ -1,0 +1,25 @@
+use crate::WhereClause;
+use chalk_ir::cast::Cast;
+use chalk_ir::family::ChalkIr;
+use chalk_ir::{DomainGoal, ProjectionEq, TraitRef};
+
+impl Cast<WhereClause> for TraitRef<ChalkIr> {
+    fn cast(self) -> WhereClause {
+        WhereClause::Implemented(self)
+    }
+}
+
+impl Cast<WhereClause> for ProjectionEq<ChalkIr> {
+    fn cast(self) -> WhereClause {
+        WhereClause::ProjectionEq(self)
+    }
+}
+
+impl Cast<DomainGoal<ChalkIr>> for WhereClause {
+    fn cast(self) -> DomainGoal<ChalkIr> {
+        match self {
+            WhereClause::Implemented(t) => DomainGoal::Implemented(t),
+            WhereClause::ProjectionEq(t) => DomainGoal::ProjectionEq(t),
+        }
+    }
+}

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -228,7 +228,6 @@ fn program_clauses_that_could_match(
                 clauses,
             );
         }
-        DomainGoal::InScope(type_kind_id) => match_type_kind(db, *type_kind_id, clauses),
         DomainGoal::LocalImplAllowed(trait_ref) => db
             .trait_datum(trait_ref.trait_id)
             .to_program_clauses(db, clauses),

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -3,6 +3,7 @@ use self::program_clauses::ToProgramClauses;
 use crate::RustIrDatabase;
 use chalk_ir::cast::{Cast, Caster};
 use chalk_ir::could_match::CouldMatch;
+use chalk_ir::family::ChalkIr;
 use chalk_ir::*;
 use rustc_hash::FxHashSet;
 use std::sync::Arc;
@@ -44,7 +45,7 @@ pub fn push_auto_trait_impls(
     auto_trait_id: TraitId,
     struct_id: StructId,
     program: &dyn RustIrDatabase,
-    vec: &mut Vec<ProgramClause>,
+    vec: &mut Vec<ProgramClause<ChalkIr>>,
 ) {
     debug_heading!(
         "push_auto_trait_impls({:?}, {:?})",
@@ -108,9 +109,9 @@ pub fn push_auto_trait_impls(
 /// derived from the trait `Clone` and its impls.
 pub(crate) fn program_clauses_for_goal<'db>(
     db: &'db dyn RustIrDatabase,
-    environment: &Arc<Environment>,
-    goal: &DomainGoal,
-) -> Vec<ProgramClause> {
+    environment: &Arc<Environment<ChalkIr>>,
+    goal: &DomainGoal<ChalkIr>,
+) -> Vec<ProgramClause<ChalkIr>> {
     debug_heading!(
         "program_clauses_for_goal(goal={:?}, environment={:?})",
         goal,
@@ -134,9 +135,9 @@ pub(crate) fn program_clauses_for_goal<'db>(
 /// be.
 fn program_clauses_that_could_match(
     db: &dyn RustIrDatabase,
-    environment: &Arc<Environment>,
-    goal: &DomainGoal,
-    clauses: &mut Vec<ProgramClause>,
+    environment: &Arc<Environment<ChalkIr>>,
+    goal: &DomainGoal<ChalkIr>,
+    clauses: &mut Vec<ProgramClause<ChalkIr>>,
 ) {
     match goal {
         DomainGoal::Holds(WhereClause::Implemented(trait_ref)) => {
@@ -252,8 +253,8 @@ fn program_clauses_that_could_match(
 fn push_program_clauses_for_associated_type_values_in_impls_of(
     db: &dyn RustIrDatabase,
     trait_id: TraitId,
-    trait_parameters: &[Parameter],
-    clauses: &mut Vec<ProgramClause>,
+    trait_parameters: &[Parameter<ChalkIr>],
+    clauses: &mut Vec<ProgramClause<ChalkIr>>,
 ) {
     for impl_id in db.impls_for_trait(trait_id, trait_parameters) {
         let impl_datum = db.impl_datum(impl_id);
@@ -280,9 +281,9 @@ fn push_program_clauses_for_associated_type_values_in_impls_of(
 /// earlier parts of the logic should "flounder" in that case.
 fn match_ty(
     db: &dyn RustIrDatabase,
-    environment: &Arc<Environment>,
-    ty: &Ty,
-    clauses: &mut Vec<ProgramClause>,
+    environment: &Arc<Environment<ChalkIr>>,
+    ty: &Ty<ChalkIr>,
+    clauses: &mut Vec<ProgramClause<ChalkIr>>,
 ) {
     match ty {
         Ty::Apply(application_ty) => match application_ty.name {
@@ -305,7 +306,7 @@ fn match_ty(
 fn match_type_kind(
     db: &dyn RustIrDatabase,
     type_kind_id: TypeKindId,
-    clauses: &mut Vec<ProgramClause>,
+    clauses: &mut Vec<ProgramClause<ChalkIr>>,
 ) {
     match type_kind_id {
         TypeKindId::TypeId(type_id) => db
@@ -320,8 +321,8 @@ fn match_type_kind(
 
 fn program_clauses_for_env<'db>(
     db: &'db dyn RustIrDatabase,
-    environment: &Arc<Environment>,
-    clauses: &mut Vec<ProgramClause>,
+    environment: &Arc<Environment<ChalkIr>>,
+    clauses: &mut Vec<ProgramClause<ChalkIr>>,
 ) {
     let mut last_round = FxHashSet::default();
     elaborate_env_clauses(db, &environment.clauses, &mut last_round);

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -67,16 +67,6 @@ impl ToProgramClauses for AssociatedTyValue {
     ///         Implemented(Iter<'a, T>: 'a).   // (2)
     /// }
     /// ```
-    ///
-    /// and:
-    ///
-    /// ```notrust
-    /// forall<'a, T> {
-    ///     UnselectedNormalize(Vec<T>::IntoIter<'a> -> Iter<'a, T>) :-
-    ///         InScope(Iterable),
-    ///         Normalize(<Vec<T> as Iterable>::IntoIter<'a> -> Iter<'a, T>).
-    /// }
-    /// ```
     fn to_program_clauses(&self, db: &dyn RustIrDatabase, clauses: &mut Vec<ProgramClause>) {
         let impl_datum = db.impl_datum(self.impl_id);
         let associated_ty = db.associated_ty_data(self.associated_ty_id);

--- a/chalk-solve/src/coherence/orphan.rs
+++ b/chalk-solve/src/coherence/orphan.rs
@@ -3,6 +3,7 @@ use crate::ext::GoalExt;
 use crate::solve::SolverChoice;
 use crate::RustIrDatabase;
 use chalk_ir::cast::*;
+use chalk_ir::family::ChalkIr;
 use chalk_ir::*;
 
 // Test if a local impl violates the orphan rules.
@@ -22,7 +23,7 @@ pub fn perform_orphan_check(
     let impl_datum = db.impl_datum(impl_id);
     debug!("impl_datum={:#?}", impl_datum);
 
-    let impl_allowed: Goal = impl_datum
+    let impl_allowed: Goal<ChalkIr> = impl_datum
         .binders
         .map_ref(|bound_impl| {
             // Ignoring the polarization of the impl's polarized trait ref

--- a/chalk-solve/src/coherence/solve.rs
+++ b/chalk-solve/src/coherence/solve.rs
@@ -3,6 +3,7 @@ use crate::ext::*;
 use crate::RustIrDatabase;
 use crate::Solution;
 use chalk_ir::cast::*;
+use chalk_ir::family::ChalkIr;
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::*;
 use chalk_rust_ir::*;
@@ -223,6 +224,6 @@ where
     }
 }
 
-fn params(impl_datum: &ImplDatum) -> &[Parameter] {
+fn params(impl_datum: &ImplDatum) -> &[Parameter<ChalkIr>] {
     &impl_datum.binders.value.trait_ref.parameters
 }

--- a/chalk-solve/src/coinductive_goal.rs
+++ b/chalk-solve/src/coinductive_goal.rs
@@ -1,4 +1,5 @@
 use crate::RustIrDatabase;
+use chalk_ir::family::ChalkIr;
 use chalk_ir::*;
 
 pub trait IsCoinductive {
@@ -13,7 +14,7 @@ pub trait IsCoinductive {
     fn is_coinductive(&self, db: &dyn RustIrDatabase) -> bool;
 }
 
-impl IsCoinductive for Goal {
+impl IsCoinductive for Goal<ChalkIr> {
     fn is_coinductive(&self, db: &dyn RustIrDatabase) -> bool {
         match self {
             Goal::Leaf(LeafGoal::DomainGoal(DomainGoal::Holds(wca))) => match wca {
@@ -27,7 +28,7 @@ impl IsCoinductive for Goal {
     }
 }
 
-impl IsCoinductive for UCanonical<InEnvironment<Goal>> {
+impl IsCoinductive for UCanonical<InEnvironment<Goal<ChalkIr>>> {
     fn is_coinductive(&self, db: &dyn RustIrDatabase) -> bool {
         self.canonical.value.goal.is_coinductive(db)
     }

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -112,7 +112,7 @@ impl<'q> PlaceholderFolder<ChalkIr> for Canonicalizer<'q> {
         _binders: usize,
     ) -> Fallible<Lifetime<ChalkIr>> {
         self.max_universe = max(self.max_universe, universe.ui);
-        Ok(universe.to_lifetime())
+        Ok(universe.to_lifetime::<ChalkIr>())
     }
 }
 

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -103,7 +103,7 @@ impl<'q> PlaceholderFolder<ChalkIr> for Canonicalizer<'q> {
         _binders: usize,
     ) -> Fallible<Ty<ChalkIr>> {
         self.max_universe = max(self.max_universe, universe.ui);
-        Ok(universe.to_ty())
+        Ok(universe.to_ty::<ChalkIr>())
     }
 
     fn fold_free_placeholder_lifetime(

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -91,7 +91,7 @@ impl InferenceTable {
                         let lt = placeholder_idx.to_lifetime();
                         lt.cast()
                     }
-                    ParameterKind::Ty(()) => placeholder_idx.to_ty().cast(),
+                    ParameterKind::Ty(()) => placeholder_idx.to_ty::<ChalkIr>().cast(),
                 }
             })
             .collect();

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -88,7 +88,7 @@ impl InferenceTable {
                 let placeholder_idx = PlaceholderIndex { ui, idx };
                 match *pk {
                     ParameterKind::Lifetime(()) => {
-                        let lt = placeholder_idx.to_lifetime();
+                        let lt = placeholder_idx.to_lifetime::<ChalkIr>();
                         lt.cast()
                     }
                     ParameterKind::Ty(()) => placeholder_idx.to_ty::<ChalkIr>().cast(),

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -1,3 +1,4 @@
+use chalk_ir::family::ChalkIr;
 use chalk_ir::fold::*;
 use std::fmt::Debug;
 
@@ -9,7 +10,10 @@ impl InferenceTable {
     /// inference variable. This substitution can then be applied to
     /// C, which would be equivalent to
     /// `self.instantiate_canonical(v)`.
-    pub(crate) fn fresh_subst(&mut self, binders: &[ParameterKind<UniverseIndex>]) -> Substitution {
+    pub(crate) fn fresh_subst(
+        &mut self,
+        binders: &[ParameterKind<UniverseIndex>],
+    ) -> Substitution<ChalkIr> {
         Substitution {
             parameters: binders
                 .iter()
@@ -24,7 +28,7 @@ impl InferenceTable {
     /// Variant on `instantiate` that takes a `Canonical<T>`.
     pub(crate) fn instantiate_canonical<T>(&mut self, bound: &Canonical<T>) -> T::Result
     where
-        T: Fold + Debug,
+        T: Fold<ChalkIr> + Debug,
     {
         let subst = self.fresh_subst(&bound.binders);
         bound.value.fold_with(&mut &subst, 0).unwrap()
@@ -42,7 +46,7 @@ impl InferenceTable {
         arg: &T,
     ) -> T::Result
     where
-        T: Fold,
+        T: Fold<ChalkIr>,
         U: IntoIterator<Item = ParameterKind<()>>,
     {
         let binders: Vec<_> = binders
@@ -60,7 +64,7 @@ impl InferenceTable {
         arg: &impl BindersAndValue<Output = T>,
     ) -> T::Result
     where
-        T: Fold,
+        T: Fold<ChalkIr>,
     {
         let (binders, value) = arg.split();
         let max_universe = self.max_universe;
@@ -73,7 +77,7 @@ impl InferenceTable {
         arg: &impl BindersAndValue<Output = T>,
     ) -> T::Result
     where
-        T: Fold,
+        T: Fold<ChalkIr>,
     {
         let (binders, value) = arg.split();
         let ui = self.new_universe();

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -1,4 +1,5 @@
 use chalk_engine::fallible::*;
+use chalk_ir::family::ChalkIr;
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::fold::{
     DefaultFreeVarFolder, DefaultInferenceFolder, DefaultTypeFolder, Fold, PlaceholderFolder,
@@ -74,7 +75,7 @@ impl InferenceTable {
     /// `None`) until the second unification has occurred.)
     pub(crate) fn invert<T>(&mut self, value: &T) -> Option<T::Result>
     where
-        T: Fold<Result = T>,
+        T: Fold<ChalkIr, Result = T>,
     {
         let Canonicalized {
             free_vars,
@@ -115,12 +116,12 @@ impl<'q> Inverter<'q> {
 
 impl<'q> DefaultTypeFolder for Inverter<'q> {}
 
-impl<'q> PlaceholderFolder for Inverter<'q> {
+impl<'q> PlaceholderFolder<ChalkIr> for Inverter<'q> {
     fn fold_free_placeholder_ty(
         &mut self,
         universe: PlaceholderIndex,
         binders: usize,
-    ) -> Fallible<Ty> {
+    ) -> Fallible<Ty<ChalkIr>> {
         let table = &mut self.table;
         Ok(self
             .inverted_ty
@@ -134,7 +135,7 @@ impl<'q> PlaceholderFolder for Inverter<'q> {
         &mut self,
         universe: PlaceholderIndex,
         binders: usize,
-    ) -> Fallible<Lifetime> {
+    ) -> Fallible<Lifetime<ChalkIr>> {
         let table = &mut self.table;
         Ok(self
             .inverted_lifetime

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,4 +1,5 @@
 use chalk_engine::fallible::*;
+use chalk_ir::family::ChalkIr;
 use chalk_ir::fold::{
     DefaultFreeVarFolder, DefaultInferenceFolder, DefaultTypeFolder, Fold, PlaceholderFolder,
 };
@@ -7,7 +8,7 @@ use chalk_ir::*;
 use super::InferenceTable;
 
 impl InferenceTable {
-    pub(crate) fn u_canonicalize<T: Fold>(
+    pub(crate) fn u_canonicalize<T: Fold<ChalkIr>>(
         &mut self,
         value0: &Canonical<T>,
     ) -> UCanonicalized<T::Result> {
@@ -211,7 +212,7 @@ impl UniverseMap {
     /// of universes, since that determines visibility, and (b) that
     /// the universe we produce does not correspond to any of the
     /// other original universes.
-    pub(crate) fn map_from_canonical<T: Fold>(&self, value: &T) -> T::Result {
+    pub(crate) fn map_from_canonical<T: Fold<ChalkIr>>(&self, value: &T) -> T::Result {
         debug!("map_from_canonical(value={:?})", value);
         debug!("map_from_canonical: universes = {:?}", self.universes);
         value
@@ -228,12 +229,12 @@ struct UCollector<'q> {
 
 impl<'q> DefaultTypeFolder for UCollector<'q> {}
 
-impl<'q> PlaceholderFolder for UCollector<'q> {
+impl<'q> PlaceholderFolder<ChalkIr> for UCollector<'q> {
     fn fold_free_placeholder_ty(
         &mut self,
         universe: PlaceholderIndex,
         _binders: usize,
-    ) -> Fallible<Ty> {
+    ) -> Fallible<Ty<ChalkIr>> {
         self.universes.add(universe.ui);
         Ok(universe.to_ty())
     }
@@ -242,7 +243,7 @@ impl<'q> PlaceholderFolder for UCollector<'q> {
         &mut self,
         universe: PlaceholderIndex,
         _binders: usize,
-    ) -> Fallible<Lifetime> {
+    ) -> Fallible<Lifetime<ChalkIr>> {
         self.universes.add(universe.ui);
         Ok(universe.to_lifetime())
     }
@@ -268,12 +269,12 @@ impl<'q> DefaultInferenceFolder for UMapToCanonical<'q> {
     }
 }
 
-impl<'q> PlaceholderFolder for UMapToCanonical<'q> {
+impl<'q> PlaceholderFolder<ChalkIr> for UMapToCanonical<'q> {
     fn fold_free_placeholder_ty(
         &mut self,
         universe0: PlaceholderIndex,
         _binders: usize,
-    ) -> Fallible<Ty> {
+    ) -> Fallible<Ty<ChalkIr>> {
         let ui = self.universes.map_universe_to_canonical(universe0.ui);
         Ok(PlaceholderIndex {
             ui,
@@ -286,7 +287,7 @@ impl<'q> PlaceholderFolder for UMapToCanonical<'q> {
         &mut self,
         universe0: PlaceholderIndex,
         _binders: usize,
-    ) -> Fallible<Lifetime> {
+    ) -> Fallible<Lifetime<ChalkIr>> {
         let universe = self.universes.map_universe_to_canonical(universe0.ui);
         Ok(PlaceholderIndex {
             ui: universe,
@@ -304,12 +305,12 @@ struct UMapFromCanonical<'q> {
 
 impl<'q> DefaultTypeFolder for UMapFromCanonical<'q> {}
 
-impl<'q> PlaceholderFolder for UMapFromCanonical<'q> {
+impl<'q> PlaceholderFolder<ChalkIr> for UMapFromCanonical<'q> {
     fn fold_free_placeholder_ty(
         &mut self,
         universe0: PlaceholderIndex,
         _binders: usize,
-    ) -> Fallible<Ty> {
+    ) -> Fallible<Ty<ChalkIr>> {
         let ui = self.universes.map_universe_from_canonical(universe0.ui);
         Ok(PlaceholderIndex {
             ui,
@@ -322,7 +323,7 @@ impl<'q> PlaceholderFolder for UMapFromCanonical<'q> {
         &mut self,
         universe0: PlaceholderIndex,
         _binders: usize,
-    ) -> Fallible<Lifetime> {
+    ) -> Fallible<Lifetime<ChalkIr>> {
         let universe = self.universes.map_universe_from_canonical(universe0.ui);
         Ok(PlaceholderIndex {
             ui: universe,

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -245,7 +245,7 @@ impl<'q> PlaceholderFolder<ChalkIr> for UCollector<'q> {
         _binders: usize,
     ) -> Fallible<Lifetime<ChalkIr>> {
         self.universes.add(universe.ui);
-        Ok(universe.to_lifetime())
+        Ok(universe.to_lifetime::<ChalkIr>())
     }
 }
 
@@ -293,7 +293,7 @@ impl<'q> PlaceholderFolder<ChalkIr> for UMapToCanonical<'q> {
             ui: universe,
             idx: universe0.idx,
         }
-        .to_lifetime())
+        .to_lifetime::<ChalkIr>())
     }
 }
 
@@ -329,7 +329,7 @@ impl<'q> PlaceholderFolder<ChalkIr> for UMapFromCanonical<'q> {
             ui: universe,
             idx: universe0.idx,
         }
-        .to_lifetime())
+        .to_lifetime::<ChalkIr>())
     }
 }
 

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -236,7 +236,7 @@ impl<'q> PlaceholderFolder<ChalkIr> for UCollector<'q> {
         _binders: usize,
     ) -> Fallible<Ty<ChalkIr>> {
         self.universes.add(universe.ui);
-        Ok(universe.to_ty())
+        Ok(universe.to_ty::<ChalkIr>())
     }
 
     fn fold_free_placeholder_lifetime(
@@ -280,7 +280,7 @@ impl<'q> PlaceholderFolder<ChalkIr> for UMapToCanonical<'q> {
             ui,
             idx: universe0.idx,
         }
-        .to_ty())
+        .to_ty::<ChalkIr>())
     }
 
     fn fold_free_placeholder_lifetime(
@@ -316,7 +316,7 @@ impl<'q> PlaceholderFolder<ChalkIr> for UMapFromCanonical<'q> {
             ui,
             idx: universe0.idx,
         }
-        .to_ty())
+        .to_ty::<ChalkIr>())
     }
 
     fn fold_free_placeholder_lifetime(

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -442,12 +442,12 @@ impl<'u, 't> PlaceholderFolder<ChalkIr> for OccursCheck<'u, 't> {
 
             let tick_x = self.unifier.table.new_variable(self.universe_index);
             self.unifier
-                .push_lifetime_eq_constraint(tick_x.to_lifetime(), ui.to_lifetime());
+                .push_lifetime_eq_constraint(tick_x.to_lifetime(), ui.to_lifetime::<ChalkIr>());
             Ok(tick_x.to_lifetime())
         } else {
             // If the `ui` is higher than `self.universe_index`, then we can name
             // this lifetime, no problem.
-            Ok(ui.to_lifetime()) // no need to shift, not relative to depth
+            Ok(ui.to_lifetime::<ChalkIr>()) // no need to shift, not relative to depth
         }
     }
 }

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -417,7 +417,7 @@ impl<'u, 't> PlaceholderFolder<ChalkIr> for OccursCheck<'u, 't> {
         if self.universe_index < universe.ui {
             Err(NoSolution)
         } else {
-            Ok(universe.to_ty()) // no need to shift, not relative to depth
+            Ok(universe.to_ty::<ChalkIr>()) // no need to shift, not relative to depth
         }
     }
 

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -48,7 +48,7 @@ impl EnaVariable {
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a type (we can't check it).
     pub(crate) fn to_ty(self) -> Ty<ChalkIr> {
-        self.0.to_ty()
+        self.0.to_ty::<ChalkIr>()
     }
 
     /// Convert this inference variable into a lifetime. When using this

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -55,7 +55,7 @@ impl EnaVariable {
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a lifetime (we can't check it).
     pub(crate) fn to_lifetime(self) -> Lifetime<ChalkIr> {
-        self.0.to_lifetime()
+        self.0.to_lifetime::<ChalkIr>()
     }
 }
 

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -1,4 +1,5 @@
 use chalk_ir::cast::Cast;
+use chalk_ir::family::ChalkIr;
 use chalk_ir::*;
 use ena::unify::{UnifyKey, UnifyValue};
 use std::cmp::min;
@@ -46,14 +47,14 @@ impl EnaVariable {
     /// Convert this inference variable into a type. When using this
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a type (we can't check it).
-    pub(crate) fn to_ty(self) -> Ty {
+    pub(crate) fn to_ty(self) -> Ty<ChalkIr> {
         self.0.to_ty()
     }
 
     /// Convert this inference variable into a lifetime. When using this
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a lifetime (we can't check it).
-    pub(crate) fn to_lifetime(self) -> Lifetime {
+    pub(crate) fn to_lifetime(self) -> Lifetime<ChalkIr> {
         self.0.to_lifetime()
     }
 }
@@ -80,17 +81,17 @@ impl UnifyKey for EnaVariable {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum InferenceValue {
     Unbound(UniverseIndex),
-    Bound(Parameter),
+    Bound(Parameter<ChalkIr>),
 }
 
-impl From<Ty> for InferenceValue {
-    fn from(ty: Ty) -> Self {
+impl From<Ty<ChalkIr>> for InferenceValue {
+    fn from(ty: Ty<ChalkIr>) -> Self {
         InferenceValue::Bound(ty.cast())
     }
 }
 
-impl From<Lifetime> for InferenceValue {
-    fn from(lifetime: Lifetime) -> Self {
+impl From<Lifetime<ChalkIr>> for InferenceValue {
+    fn from(lifetime: Lifetime<ChalkIr>) -> Self {
         InferenceValue::Bound(lifetime.cast())
     }
 }

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -1,3 +1,4 @@
+use chalk_ir::family::ChalkIr;
 use chalk_ir::*;
 use chalk_rust_ir::*;
 use std::fmt::Debug;
@@ -17,7 +18,7 @@ pub mod wf;
 pub trait RustIrDatabase: Debug {
     /// Returns any "custom program clauses" that do not derive from
     /// Rust IR. Used only in testing the underlying solver.
-    fn custom_clauses(&self) -> Vec<ProgramClause>;
+    fn custom_clauses(&self) -> Vec<ProgramClause<ChalkIr>>;
 
     /// Returns the datum for the associated type with the given id.
     fn associated_ty_data(&self, ty: TypeId) -> Arc<AssociatedTyDatum>;
@@ -40,7 +41,7 @@ pub trait RustIrDatabase: Debug {
     /// apply. The parameters are provided as a "hint" to help the
     /// implementor do less work, but can be completely ignored if
     /// desired.
-    fn impls_for_trait(&self, trait_id: TraitId, parameters: &[Parameter]) -> Vec<ImplId>;
+    fn impls_for_trait(&self, trait_id: TraitId, parameters: &[Parameter<ChalkIr>]) -> Vec<ImplId>;
 
     /// Returns the impls that require coherence checking. This is not the
     /// full set of impls that exist:
@@ -75,8 +76,12 @@ pub trait RustIrDatabase: Debug {
     /// trait) and `['x]` (from the type).
     fn split_projection<'p>(
         &self,
-        projection: &'p ProjectionTy,
-    ) -> (Arc<AssociatedTyDatum>, &'p [Parameter], &'p [Parameter]);
+        projection: &'p ProjectionTy<ChalkIr>,
+    ) -> (
+        Arc<AssociatedTyDatum>,
+        &'p [Parameter<ChalkIr>],
+        &'p [Parameter<ChalkIr>],
+    );
 }
 
 pub use solve::Guidance;

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -1,6 +1,7 @@
 use crate::solve::slg::SlgContext;
 use crate::RustIrDatabase;
 use chalk_engine::forest::Forest;
+use chalk_ir::family::ChalkIr;
 use chalk_ir::*;
 use std::fmt;
 
@@ -13,7 +14,7 @@ pub enum Solution {
     /// The goal indeed holds, and there is a unique value for all existential
     /// variables. In this case, we also record a set of lifetime constraints
     /// which must also hold for the goal to be valid.
-    Unique(Canonical<ConstrainedSubst>),
+    Unique(Canonical<ConstrainedSubst<ChalkIr>>),
 
     /// The goal may be provable in multiple ways, but regardless we may have some guidance
     /// for type inference. In this case, we don't return any lifetime
@@ -29,12 +30,12 @@ pub enum Guidance {
     /// The existential variables *must* have the given values if the goal is
     /// ever to hold, but that alone isn't enough to guarantee the goal will
     /// actually hold.
-    Definite(Canonical<Substitution>),
+    Definite(Canonical<Substitution<ChalkIr>>),
 
     /// There are multiple plausible values for the existentials, but the ones
     /// here are suggested as the preferred choice heuristically. These should
     /// be used for inference fallback only.
-    Suggested(Canonical<Substitution>),
+    Suggested(Canonical<Substitution<ChalkIr>>),
 
     /// There's no useful information to feed back to type inference
     Unknown,
@@ -122,7 +123,7 @@ impl Solver {
     pub fn solve(
         &mut self,
         program: &dyn RustIrDatabase,
-        goal: &UCanonical<InEnvironment<Goal>>,
+        goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>,
     ) -> Option<Solution> {
         let ops = self.forest.context().ops(program);
         self.forest.solve(&ops, goal)
@@ -166,7 +167,7 @@ impl TestSolver {
     pub fn force_answers(
         &mut self,
         program: &dyn RustIrDatabase,
-        goal: &UCanonical<InEnvironment<Goal>>,
+        goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>,
         num_answers: usize,
     ) -> Box<dyn std::fmt::Debug> {
         let ops = self.forest.context().ops(program);
@@ -185,7 +186,7 @@ impl TestSolver {
     pub fn num_cached_answers_for_goal(
         &mut self,
         program: &dyn RustIrDatabase,
-        goal: &UCanonical<InEnvironment<Goal>>,
+        goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>,
     ) -> usize {
         let ops = self.forest.context().ops(program);
         self.forest.num_cached_answers_for_goal(&ops, goal)

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -8,6 +8,7 @@ use chalk_ir::fold::{
     self, DefaultFreeVarFolder, DefaultInferenceFolder, DefaultPlaceholderFolder, Fold, TypeFolder,
 };
 use chalk_ir::*;
+use std::fmt::Debug;
 
 pub(crate) fn truncate<T>(
     infer: &mut InferenceTable,
@@ -16,6 +17,7 @@ pub(crate) fn truncate<T>(
 ) -> Truncated<T::Result>
 where
     T: Fold<ChalkIr>,
+    T::Result: Debug,
 {
     debug_heading!("truncate(max_size={}, value={:?})", max_size, value);
 

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -502,18 +502,6 @@ impl LowerDomainGoal for DomainGoal {
             DomainGoal::TraitRefFromEnv { trait_ref } => vec![chalk_ir::DomainGoal::FromEnv(
                 chalk_ir::FromEnv::Trait(trait_ref.lower(env)?),
             )],
-            DomainGoal::TraitInScope { trait_name } => {
-                let id = match env.lookup(*trait_name)? {
-                    NameLookup::Type(id) => id,
-                    NameLookup::Parameter(_) => Err(RustIrError::NotTrait(*trait_name))?,
-                };
-
-                if env.type_kind(id).sort != rust_ir::TypeSort::Trait {
-                    Err(RustIrError::NotTrait(*trait_name))?;
-                }
-
-                vec![chalk_ir::DomainGoal::InScope(id.into())]
-            }
             DomainGoal::IsLocal { ty } => vec![chalk_ir::DomainGoal::IsLocal(ty.lower(env)?)],
             DomainGoal::IsUpstream { ty } => vec![chalk_ir::DomainGoal::IsUpstream(ty.lower(env)?)],
             DomainGoal::IsFullyVisible { ty } => {

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -1,5 +1,6 @@
 use crate::program::Program as LoweredProgram;
 use chalk_ir::cast::{Cast, Caster};
+use chalk_ir::family::ChalkIr;
 use chalk_ir::{self, ImplId, StructId, TraitId, TypeId, TypeKindId};
 use chalk_parse::ast::*;
 use chalk_rust_ir as rust_ir;
@@ -276,7 +277,7 @@ trait LowerParameterMap {
          */
     }
 
-    fn parameter_refs(&self) -> Vec<chalk_ir::Parameter> {
+    fn parameter_refs(&self) -> Vec<chalk_ir::Parameter<ChalkIr>> {
         self.all_parameters()
             .anonymize()
             .iter()
@@ -375,7 +376,10 @@ impl LowerParameterKind for ParameterKind {
 trait LowerWhereClauses {
     fn where_clauses(&self) -> &[QuantifiedWhereClause];
 
-    fn lower_where_clauses(&self, env: &Env) -> Fallible<Vec<chalk_ir::QuantifiedWhereClause>> {
+    fn lower_where_clauses(
+        &self,
+        env: &Env,
+    ) -> Fallible<Vec<chalk_ir::QuantifiedWhereClause<ChalkIr>>> {
         self.where_clauses().lower(env)
     }
 }
@@ -427,11 +431,11 @@ impl LowerWhereClauses for Impl {
 }
 
 trait LowerWhereClauseVec {
-    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::QuantifiedWhereClause>>;
+    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::QuantifiedWhereClause<ChalkIr>>>;
 }
 
 impl LowerWhereClauseVec for [QuantifiedWhereClause] {
-    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::QuantifiedWhereClause>> {
+    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::QuantifiedWhereClause<ChalkIr>>> {
         self.iter()
             .flat_map(|wc| match wc.lower(env) {
                 Ok(v) => v.into_iter().map(Ok).collect(),
@@ -449,8 +453,8 @@ trait LowerWhereClause<T> {
     fn lower(&self, env: &Env) -> Fallible<Vec<T>>;
 }
 
-impl LowerWhereClause<chalk_ir::WhereClause> for WhereClause {
-    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::WhereClause>> {
+impl LowerWhereClause<chalk_ir::WhereClause<ChalkIr>> for WhereClause {
+    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::WhereClause<ChalkIr>>> {
         let where_clauses = match self {
             WhereClause::Implemented { trait_ref } => {
                 vec![chalk_ir::WhereClause::Implemented(trait_ref.lower(env)?)]
@@ -466,8 +470,8 @@ impl LowerWhereClause<chalk_ir::WhereClause> for WhereClause {
         Ok(where_clauses)
     }
 }
-impl LowerWhereClause<chalk_ir::QuantifiedWhereClause> for QuantifiedWhereClause {
-    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::QuantifiedWhereClause>> {
+impl LowerWhereClause<chalk_ir::QuantifiedWhereClause<ChalkIr>> for QuantifiedWhereClause {
+    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::QuantifiedWhereClause<ChalkIr>>> {
         let parameter_kinds = self.parameter_kinds.iter().map(|pk| pk.lower());
         let binders = env.in_binders(parameter_kinds, |env| Ok(self.where_clause.lower(env)?))?;
         Ok(binders.into_iter().collect())
@@ -475,11 +479,11 @@ impl LowerWhereClause<chalk_ir::QuantifiedWhereClause> for QuantifiedWhereClause
 }
 
 trait LowerDomainGoal {
-    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::DomainGoal>>;
+    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::DomainGoal<ChalkIr>>>;
 }
 
 impl LowerDomainGoal for DomainGoal {
-    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::DomainGoal>> {
+    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::DomainGoal<ChalkIr>>> {
         let goals = match self {
             DomainGoal::Holds { where_clause } => {
                 where_clause.lower(env)?.into_iter().casted().collect()
@@ -522,11 +526,11 @@ impl LowerDomainGoal for DomainGoal {
 }
 
 trait LowerLeafGoal {
-    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::LeafGoal>>;
+    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::LeafGoal<ChalkIr>>>;
 }
 
 impl LowerLeafGoal for LeafGoal {
-    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::LeafGoal>> {
+    fn lower(&self, env: &Env) -> Fallible<Vec<chalk_ir::LeafGoal<ChalkIr>>> {
         let goals = match self {
             LeafGoal::DomainGoal { goal } => goal
                 .lower(env)?
@@ -614,11 +618,11 @@ fn check_type_kinds<A: Kinded, B: Kinded>(msg: &str, expected: &A, actual: &B) -
 }
 
 trait LowerTraitRef {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::TraitRef>;
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::TraitRef<ChalkIr>>;
 }
 
 impl LowerTraitRef for TraitRef {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::TraitRef> {
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::TraitRef<ChalkIr>> {
         let without_self = TraitBound {
             trait_name: self.trait_name,
             args_no_self: self.args.iter().cloned().skip(1).collect(),
@@ -800,11 +804,11 @@ impl LowerTraitFlags for TraitFlags {
 }
 
 trait LowerProjectionTy {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::ProjectionTy>;
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::ProjectionTy<ChalkIr>>;
 }
 
 impl LowerProjectionTy for ProjectionTy {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::ProjectionTy> {
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::ProjectionTy<ChalkIr>> {
         let ProjectionTy {
             ref trait_ref,
             ref name,
@@ -847,11 +851,11 @@ impl LowerProjectionTy for ProjectionTy {
 }
 
 trait LowerTy {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Ty>;
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Ty<ChalkIr>>;
 }
 
 impl LowerTy for Ty {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Ty> {
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Ty<ChalkIr>> {
         match *self {
             Ty::Id { name } => match env.lookup(name)? {
                 NameLookup::Type(id) => {
@@ -950,11 +954,11 @@ impl LowerTy for Ty {
 }
 
 trait LowerParameter {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Parameter>;
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Parameter<ChalkIr>>;
 }
 
 impl LowerParameter for Parameter {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Parameter> {
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Parameter<ChalkIr>> {
         match *self {
             Parameter::Ty(ref t) => Ok(t.lower(env)?.cast()),
             Parameter::Lifetime(ref l) => Ok(l.lower(env)?.cast()),
@@ -963,11 +967,11 @@ impl LowerParameter for Parameter {
 }
 
 trait LowerLifetime {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Lifetime>;
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Lifetime<ChalkIr>>;
 }
 
 impl LowerLifetime for Lifetime {
-    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Lifetime> {
+    fn lower(&self, env: &Env) -> Fallible<chalk_ir::Lifetime<ChalkIr>> {
         match *self {
             Lifetime::Id { name } => match env.lookup_lifetime(name)? {
                 LifetimeLookup::Parameter(d) => Ok(chalk_ir::Lifetime::BoundVar(d)),
@@ -1015,15 +1019,15 @@ impl LowerImpl for Impl {
 }
 
 trait LowerClause {
-    fn lower_clause(&self, env: &Env) -> Fallible<Vec<chalk_ir::ProgramClause>>;
+    fn lower_clause(&self, env: &Env) -> Fallible<Vec<chalk_ir::ProgramClause<ChalkIr>>>;
 }
 
 impl LowerClause for Clause {
-    fn lower_clause(&self, env: &Env) -> Fallible<Vec<chalk_ir::ProgramClause>> {
+    fn lower_clause(&self, env: &Env) -> Fallible<Vec<chalk_ir::ProgramClause<ChalkIr>>> {
         let implications = env.in_binders(self.all_parameters(), |env| {
-            let consequences: Vec<chalk_ir::DomainGoal> = self.consequence.lower(env)?;
+            let consequences: Vec<chalk_ir::DomainGoal<ChalkIr>> = self.consequence.lower(env)?;
 
-            let conditions: Vec<chalk_ir::Goal> = self
+            let conditions: Vec<chalk_ir::Goal<ChalkIr>> = self
                 .conditions
                 .iter()
                 .map(|g| g.lower(env).map(|g| *g))
@@ -1047,7 +1051,7 @@ impl LowerClause for Clause {
         let clauses = implications
             .into_iter()
             .map(
-                |implication: chalk_ir::Binders<chalk_ir::ProgramClauseImplication>| {
+                |implication: chalk_ir::Binders<chalk_ir::ProgramClauseImplication<ChalkIr>>| {
                     if implication.binders.is_empty() {
                         chalk_ir::ProgramClause::Implies(implication.value)
                     } else {
@@ -1132,11 +1136,11 @@ impl LowerTrait for TraitDefn {
 }
 
 pub trait LowerGoal<A> {
-    fn lower(&self, arg: &A) -> Fallible<Box<chalk_ir::Goal>>;
+    fn lower(&self, arg: &A) -> Fallible<Box<chalk_ir::Goal<ChalkIr>>>;
 }
 
 impl LowerGoal<LoweredProgram> for Goal {
-    fn lower(&self, program: &LoweredProgram) -> Fallible<Box<chalk_ir::Goal>> {
+    fn lower(&self, program: &LoweredProgram) -> Fallible<Box<chalk_ir::Goal<ChalkIr>>> {
         let associated_ty_infos: BTreeMap<_, _> = program
             .associated_ty_data
             .iter()
@@ -1165,7 +1169,7 @@ impl LowerGoal<LoweredProgram> for Goal {
 }
 
 impl<'k> LowerGoal<Env<'k>> for Goal {
-    fn lower(&self, env: &Env<'k>) -> Fallible<Box<chalk_ir::Goal>> {
+    fn lower(&self, env: &Env<'k>) -> Fallible<Box<chalk_ir::Goal<ChalkIr>>> {
         match self {
             Goal::ForAll(ids, g) => g.lower_quantified(env, chalk_ir::QuantifierKind::ForAll, ids),
             Goal::Exists(ids, g) => g.lower_quantified(env, chalk_ir::QuantifierKind::Exists, ids),
@@ -1208,7 +1212,7 @@ trait LowerQuantifiedGoal {
         env: &Env,
         quantifier_kind: chalk_ir::QuantifierKind,
         parameter_kinds: &[ParameterKind],
-    ) -> Fallible<Box<chalk_ir::Goal>>;
+    ) -> Fallible<Box<chalk_ir::Goal<ChalkIr>>>;
 }
 
 impl LowerQuantifiedGoal for Goal {
@@ -1217,7 +1221,7 @@ impl LowerQuantifiedGoal for Goal {
         env: &Env,
         quantifier_kind: chalk_ir::QuantifierKind,
         parameter_kinds: &[ParameterKind],
-    ) -> Fallible<Box<chalk_ir::Goal>> {
+    ) -> Fallible<Box<chalk_ir::Goal<ChalkIr>>> {
         if parameter_kinds.is_empty() {
             return self.lower(env);
         }
@@ -1278,7 +1282,7 @@ impl<T, L> Kinded for chalk_ir::ParameterKind<T, L> {
     }
 }
 
-impl Kinded for chalk_ir::Parameter {
+impl Kinded for chalk_ir::Parameter<ChalkIr> {
     fn kind(&self) -> Kind {
         self.0.kind()
     }

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,4 +1,5 @@
 use chalk_ir::debug::Angle;
+use chalk_ir::family::ChalkIr;
 use chalk_ir::tls;
 use chalk_ir::{
     Identifier, ImplId, Parameter, ProgramClause, ProjectionTy, StructId, TraitId, TypeId,
@@ -30,7 +31,7 @@ pub struct Program {
     pub(crate) associated_ty_data: BTreeMap<TypeId, Arc<AssociatedTyDatum>>,
 
     /// For each user-specified clause
-    pub(crate) custom_clauses: Vec<ProgramClause>,
+    pub(crate) custom_clauses: Vec<ProgramClause<ChalkIr>>,
 }
 
 impl Program {
@@ -43,8 +44,12 @@ impl Program {
     /// Used primarily for debugging output.
     pub(crate) fn split_projection<'p>(
         &self,
-        projection: &'p ProjectionTy,
-    ) -> (Arc<AssociatedTyDatum>, &'p [Parameter], &'p [Parameter]) {
+        projection: &'p ProjectionTy<ChalkIr>,
+    ) -> (
+        Arc<AssociatedTyDatum>,
+        &'p [Parameter<ChalkIr>],
+        &'p [Parameter<ChalkIr>],
+    ) {
         let ProjectionTy {
             associated_ty_id,
             ref parameters,
@@ -94,7 +99,7 @@ impl tls::DebugContext for Program {
 
     fn debug_projection(
         &self,
-        projection_ty: &ProjectionTy,
+        projection_ty: &ProjectionTy<ChalkIr>,
         fmt: &mut fmt::Formatter,
     ) -> Result<(), fmt::Error> {
         let (associated_ty_data, trait_params, other_params) = self.split_projection(projection_ty);

--- a/src/program_environment.rs
+++ b/src/program_environment.rs
@@ -1,13 +1,14 @@
+use chalk_ir::family::ChalkIr;
 use chalk_ir::ProgramClause;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProgramEnvironment {
     /// Compiled forms of the above:
-    pub program_clauses: Vec<ProgramClause>,
+    pub program_clauses: Vec<ProgramClause<ChalkIr>>,
 }
 
 impl ProgramEnvironment {
-    pub fn new(program_clauses: Vec<ProgramClause>) -> Self {
+    pub fn new(program_clauses: Vec<ProgramClause<ChalkIr>>) -> Self {
         Self { program_clauses }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -122,26 +122,3 @@ mod negation;
 mod projection;
 mod unify;
 mod wf_goals;
-
-#[test]
-fn inscope() {
-    test! {
-        program {
-            trait Foo { }
-        }
-
-        goal {
-            InScope(Foo)
-        } yields {
-            "No possible solution"
-        }
-
-        goal {
-            if (InScope(Foo)) {
-                InScope(Foo)
-            }
-        } yields {
-            "Unique; substitution [], lifetime constraints []"
-        }
-    }
-}


### PR DESCRIPTION
This is a largely mechanical refactoring that introduces the `TypeFamily` trait and makes chalk-ir generic over it. It doesn't (yet) do anything interesting with the fact that chalk-ir is generic.

r? @tmandry 