### PR TITLE
Add TypeName::Error variant

### DIFF
--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -65,6 +65,7 @@ impl Debug for TypeName {
             TypeName::TypeKindId(id) => write!(fmt, "{:?}", id),
             TypeName::Placeholder(index) => write!(fmt, "{:?}", index),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
+            TypeName::Error => write!(fmt, "{{error}}"),
         }
     }
 }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -380,7 +380,7 @@ where
                     folder.fold_free_placeholder_ty(ui, binders)
                 }
 
-                TypeName::TypeKindId(_) | TypeName::AssociatedType(_) => {
+                TypeName::TypeKindId(_) | TypeName::AssociatedType(_) | TypeName::Error => {
                     let parameters = parameters.fold_with(folder, binders)?;
                     Ok(ApplicationTy { name, parameters }.cast().intern())
                 }

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -128,6 +128,10 @@ pub enum TypeName {
 
     /// an associated type like `Iterator::Item`; see `AssociatedType` for details
     AssociatedType(TypeId),
+
+    /// This can be used to represent an error, e.g. during name resolution of a type.
+    /// Chalk itself will not produce this, just pass it through when given.
+    Error,
 }
 
 /// An universe index is how a universally quantified parameter is

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -288,7 +288,7 @@ fn match_ty(
     match ty {
         Ty::Apply(application_ty) => match application_ty.name {
             TypeName::TypeKindId(type_kind_id) => match_type_kind(db, type_kind_id, clauses),
-            TypeName::Placeholder(_) => {}
+            TypeName::Placeholder(_) | TypeName::Error => {}
             TypeName::AssociatedType(type_id) => db
                 .associated_ty_data(type_id)
                 .to_program_clauses(db, clauses),

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -55,7 +55,7 @@ impl<'db, 'set> EnvElaborator<'db, 'set> {
                 TypeName::TypeKindId(type_kind_id) => {
                     match_type_kind(self.db, type_kind_id, &mut clauses)
                 }
-                TypeName::Placeholder(_) => (),
+                TypeName::Placeholder(_) | TypeName::Error => (),
                 TypeName::AssociatedType(type_id) => {
                     self.db
                         .associated_ty_data(type_id)


### PR DESCRIPTION
This can be used (e.g. by rust-analyzer) as a placeholder for types where there
was an error e.g. during name resolution.

(I also considered making it a variant of `Ty`, but this seemed simpler.)