### PR TITLE
Fix coinductive unsoundness

### DIFF
--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -231,6 +231,18 @@ pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
         canonical_ex_clause: &C::CanonicalExClause,
     ) -> (C::InferenceTable, ExClause<C>);
 
+    // Used by: logic
+    fn instantiate_answer_subst(
+        &self,
+        num_universes: usize,
+        answer: &C::CanonicalAnswerSubst,
+    ) -> (
+        C::InferenceTable,
+        C::Substitution,
+        Vec<C::RegionConstraint>,
+        Vec<C::GoalInEnvironment>,
+    );
+
     /// returns unique solution from answer
     fn constrained_subst_from_answer(
         &self,

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -181,6 +181,8 @@ pub trait Context: Clone + Debug {
         ucanon: &Self::UCanonicalGoalInEnvironment,
         goal: &Self::GoalInEnvironment,
     ) -> Self::UCanonicalGoalInEnvironment;
+
+    fn goal_from_goal_in_environment(goal: &Self::GoalInEnvironment) -> &Self::Goal;
 }
 
 pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
@@ -219,11 +221,10 @@ pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
     /// - the table `T`
     /// - the substitution `S`
     /// - the environment and goal found by substitution `S` into `arg`
-    fn instantiate_ucanonical_goal<R>(
+    fn instantiate_ucanonical_goal(
         &self,
         arg: &C::UCanonicalGoalInEnvironment,
-        op: impl FnOnce(C::InferenceTable, C::Substitution, C::Environment, C::Goal) -> R,
-    ) -> R;
+    ) -> (C::InferenceTable, C::Substitution, C::Environment, C::Goal);
 
     fn instantiate_ex_clause(
         &self,

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -7,7 +7,7 @@
 
 use crate::fallible::Fallible;
 use crate::hh::HhGoal;
-use crate::{Answer, ExClause};
+use crate::{CompleteAnswer, ExClause};
 use std::fmt::Debug;
 use std::hash::Hash;
 
@@ -61,11 +61,14 @@ pub trait Context: Clone + Debug {
     /// `make_solution`.
     type Solution;
 
-    /// Part of an answer: represents a canonicalized substitution,
-    /// combined with region constraints. See [the rustc-guide] for more information.
-    ///
-    /// [the rustc-guide]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html#canonicalizing-the-query-result
+    /// Part of a complete answer: the canonical version of a
+    /// substitution and region constraints but without any delayed
+    /// literals.
     type CanonicalConstrainedSubst: Clone + Debug + Eq + Hash;
+
+    /// Part of an answer: the canonical version of a substitution,
+    /// region constraints, and delayed literals.
+    type CanonicalAnswerSubst: Clone + Debug + Eq + Hash;
 
     /// Represents a substitution from the "canonical variables" found
     /// in a canonical goal to specific values.
@@ -132,20 +135,30 @@ pub trait Context: Clone + Debug {
 
     /// Extracts the inner normalized substitution from a canonical constraint subst.
     fn inference_normalized_subst_from_subst(
-        canon_ex_clause: &Self::CanonicalConstrainedSubst,
+        canon_ex_clause: &Self::CanonicalAnswerSubst,
     ) -> &Self::InferenceNormalizedSubst;
 
     /// True if this solution has no region constraints.
-    fn empty_constraints(ccs: &Self::CanonicalConstrainedSubst) -> bool;
+    fn empty_constraints(ccs: &Self::CanonicalAnswerSubst) -> bool;
 
     fn canonical(u_canon: &Self::UCanonicalGoalInEnvironment) -> &Self::CanonicalGoalInEnvironment;
 
     fn is_trivial_substitution(
         u_canon: &Self::UCanonicalGoalInEnvironment,
-        canonical_subst: &Self::CanonicalConstrainedSubst,
+        canonical_subst: &Self::CanonicalAnswerSubst,
     ) -> bool;
 
+    fn has_delayed_subgoals(canonical_subst: &Self::CanonicalAnswerSubst) -> bool;
+
+    fn delayed_subgoals(
+        canonical_answer: &Self::CanonicalAnswerSubst,
+    ) -> &Vec<Self::GoalInEnvironment>;
+
     fn num_universes(_: &Self::UCanonicalGoalInEnvironment) -> usize;
+
+    fn canonical_constrained_subst_from_canonical_constrained_answer(
+        canonical_subst: &Self::CanonicalAnswerSubst,
+    ) -> Self::CanonicalConstrainedSubst;
 
     /// Convert a goal G *from* the canonical universes *into* our
     /// local universes. This will yield a goal G' that is the same
@@ -161,8 +174,13 @@ pub trait Context: Clone + Debug {
     /// names.
     fn map_subst_from_canonical(
         _: &Self::UniverseMap,
-        value: &Self::CanonicalConstrainedSubst,
-    ) -> Self::CanonicalConstrainedSubst;
+        value: &Self::CanonicalAnswerSubst,
+    ) -> Self::CanonicalAnswerSubst;
+
+    fn apply_binders(
+        ucanon: &Self::UCanonicalGoalInEnvironment,
+        goal: &Self::GoalInEnvironment,
+    ) -> Self::UCanonicalGoalInEnvironment;
 }
 
 pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
@@ -214,7 +232,10 @@ pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
     ) -> (C::InferenceTable, ExClause<C>);
 
     /// returns unique solution from answer
-    fn constrained_subst_from_answer(&self, answer: Answer<C>) -> C::CanonicalConstrainedSubst;
+    fn constrained_subst_from_answer(
+        &self,
+        answer: CompleteAnswer<C>,
+    ) -> C::CanonicalConstrainedSubst;
 }
 
 /// Methods for combining solutions to yield an aggregate solution.
@@ -283,6 +304,14 @@ pub trait UnificationOps<C: Context> {
     ) -> C::CanonicalConstrainedSubst;
 
     // Used by: logic
+    fn canonicalize_answer_subst(
+        &mut self,
+        subst: C::Substitution,
+        constraints: Vec<C::RegionConstraint>,
+        delayed_subgoals: Vec<C::GoalInEnvironment>,
+    ) -> C::CanonicalAnswerSubst;
+
+    // Used by: logic
     fn invert_goal(&mut self, value: &C::GoalInEnvironment) -> Option<C::GoalInEnvironment>;
 
     /// First unify the parameters, then add the residual subgoals
@@ -343,13 +372,13 @@ pub trait ResolventOps<C: Context> {
         ex_clause: &mut ExClause<C>,
         selected_goal: &C::GoalInEnvironment,
         answer_table_goal: &C::CanonicalGoalInEnvironment,
-        canonical_answer_subst: &C::CanonicalConstrainedSubst,
+        canonical_answer_subst: &C::CanonicalAnswerSubst,
     ) -> Fallible<()>;
 }
 
 pub trait AnswerStream<C: Context> {
-    fn peek_answer(&mut self) -> Option<Answer<C>>;
-    fn next_answer(&mut self) -> Option<Answer<C>>;
+    fn peek_answer(&mut self) -> Option<CompleteAnswer<C>>;
+    fn next_answer(&mut self) -> Option<CompleteAnswer<C>>;
 
     /// Invokes `test` with each possible future answer, returning true immediately
     /// if we find any answer for which `test` returns true.

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -150,10 +150,6 @@ pub trait Context: Clone + Debug {
 
     fn has_delayed_subgoals(canonical_subst: &Self::CanonicalAnswerSubst) -> bool;
 
-    fn delayed_subgoals(
-        canonical_answer: &Self::CanonicalAnswerSubst,
-    ) -> &Vec<Self::GoalInEnvironment>;
-
     fn num_universes(_: &Self::UCanonicalGoalInEnvironment) -> usize;
 
     fn canonical_constrained_subst_from_canonical_constrained_answer(
@@ -176,11 +172,6 @@ pub trait Context: Clone + Debug {
         _: &Self::UniverseMap,
         value: &Self::CanonicalAnswerSubst,
     ) -> Self::CanonicalAnswerSubst;
-
-    fn apply_binders(
-        ucanon: &Self::UCanonicalGoalInEnvironment,
-        goal: &Self::GoalInEnvironment,
-    ) -> Self::UCanonicalGoalInEnvironment;
 
     fn goal_from_goal_in_environment(goal: &Self::GoalInEnvironment) -> &Self::Goal;
 }

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -4,7 +4,7 @@ use crate::logic::RootSearchFail;
 use crate::stack::{Stack, StackIndex};
 use crate::table::AnswerIndex;
 use crate::tables::Tables;
-use crate::{Answer, TableIndex};
+use crate::{CompleteAnswer, TableIndex};
 
 pub struct Forest<C: Context> {
     context: C,
@@ -45,7 +45,7 @@ impl<C: Context> Forest<C> {
         context: &impl ContextOps<C>,
         goal: C::UCanonicalGoalInEnvironment,
         num_answers: usize,
-    ) -> Option<Vec<Answer<C>>> {
+    ) -> Option<Vec<CompleteAnswer<C>>> {
         let table = self.get_or_create_table_for_ucanonical_goal(context, goal);
         let mut answers = Vec::with_capacity(num_answers);
         for i in 0..num_answers {
@@ -181,7 +181,7 @@ impl<'me, C: Context, CO: ContextOps<C>> AnswerStream<C> for ForestSolver<'me, C
     /// # Panics
     ///
     /// Panics if a negative cycle was detected.
-    fn peek_answer(&mut self) -> Option<Answer<C>> {
+    fn peek_answer(&mut self) -> Option<CompleteAnswer<C>> {
         loop {
             match self
                 .forest
@@ -193,7 +193,7 @@ impl<'me, C: Context, CO: ContextOps<C>> AnswerStream<C> for ForestSolver<'me, C
 
                 Err(RootSearchFail::Floundered) => {
                     let table_goal = &self.forest.tables[self.table].table_goal;
-                    return Some(Answer {
+                    return Some(CompleteAnswer {
                         subst: self.context.identity_constrained_subst(table_goal),
                         ambiguous: true,
                     });
@@ -217,7 +217,7 @@ impl<'me, C: Context, CO: ContextOps<C>> AnswerStream<C> for ForestSolver<'me, C
         }
     }
 
-    fn next_answer(&mut self) -> Option<Answer<C>> {
+    fn next_answer(&mut self) -> Option<CompleteAnswer<C>> {
         self.peek_answer().map(|answer| {
             self.answer.increment();
             answer

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -617,7 +617,7 @@ impl<C: Context> Forest<C> {
         debug!("no remaining subgoals for the table");
 
         match self.pursue_answer(strand) {
-            Some(()) => {
+            Some(_answer_index) => {
                 debug!("answer is available");
 
                 // We found an answer for this strand, and therefore an
@@ -963,7 +963,7 @@ impl<C: Context> Forest<C> {
     ///   strand led nowhere of interest.
     /// - the strand may represent a new answer, in which case it is
     ///   added to the table and `Some(())` is returned.
-    fn pursue_answer(&mut self, strand: Strand<C>) -> Option<()> {
+    fn pursue_answer(&mut self, strand: Strand<C>) -> Option<AnswerIndex> {
         let table = self.stack.top().table;
         let Strand {
             mut infer,
@@ -1052,12 +1052,12 @@ impl<C: Context> Forest<C> {
                 && C::empty_constraints(&answer.subst)
         };
 
-        if self.tables[table].push_answer(answer) {
+        if let Some(answer_index) = self.tables[table].push_answer(answer) {
             if is_trivial_answer {
                 self.tables[table].take_strands();
             }
 
-            Some(())
+            Some(answer_index)
         } else {
             info!("answer: not a new answer, returning None");
             None

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -678,17 +678,14 @@ impl<C: Context> Forest<C> {
         let (table, subst, constraints, delayed_subgoals) =
             context.instantiate_answer_subst(num_universes, &answer.subst);
 
-        // FIXME: really, these shouldn't be added to the delayed_subgoals at all
-        // however, because we can't compare the table goal until `canonicalize_answer_subst`
-        // is called in `pursue_answer`, this will require a bit of refactoring work
+        // FIXME: it would be nice if these delayed subgoals didn't get added to the answer
+        // at all. However, we can't compare the delayed subgoals with the table goal until
+        // we call `canonicalize_answer_subst` in `pursue_answer`. However, at this point,
+        // it's a bit late since `pursue_answer` doesn't know about the table goal. This could
+        // be refactored a bit.
         let filtered_delayed_subgoals = delayed_subgoals
             .into_iter()
             .filter(|delayed_subgoal| {
-                dbg!(
-                    &C::goal_from_goal_in_environment(delayed_subgoal),
-                    &table_goal,
-                    *C::goal_from_goal_in_environment(delayed_subgoal) != table_goal
-                );
                 *C::goal_from_goal_in_environment(delayed_subgoal) != table_goal
             })
             .map(Literal::Positive)

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -19,6 +19,7 @@ impl<C: Context> Forest<C> {
             ambiguous: false,
             constraints: vec![],
             subgoals: vec![],
+            delayed_subgoals: vec![],
             answer_time: TimeStamp::default(),
             floundered_subgoals: vec![],
         };

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -113,7 +113,7 @@ impl<C: Context> Table<C> {
     /// tests trigger this case, and assumptions upstream assume that when
     /// `true` is returned here, that a *new* answer was added (instead of an)
     /// existing answer replaced.
-    pub(super) fn push_answer(&mut self, answer: Answer<C>) -> bool {
+    pub(super) fn push_answer(&mut self, answer: Answer<C>) -> Option<AnswerIndex> {
         assert!(!self.floundered);
 
         debug_heading!("push_answer(answer={:?})", answer);
@@ -141,10 +141,13 @@ impl<C: Context> Table<C> {
             "new answer to table with goal {:?}: answer={:?}",
             self.table_goal, answer,
         );
-        if added {
-            self.answers.push(answer);
+        if !added {
+            return None;
         }
-        added
+
+        let index = self.answers.len();
+        self.answers.push(answer);
+        Some(AnswerIndex::from(index))
     }
 
     pub(super) fn answer(&self, index: AnswerIndex) -> Option<&Answer<C>> {

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -28,7 +28,12 @@ pub(crate) struct Table<C: Context> {
     /// represented here -- we discard answers from `answers_hash`
     /// (but not `answers`) when better answers arrive (in particular,
     /// answers with no ambiguity).
-    answers_hash: FxHashMap<C::CanonicalConstrainedSubst, bool>,
+    ///
+    /// FIXME -- Ideally we would exclude the region constraints and
+    /// delayed subgoals from the hash, but that's a bit tricky to do
+    /// with the current canonicalization setup. It should be ok not
+    /// to do so though it can result in more answers than we need.
+    answers_hash: FxHashMap<C::CanonicalAnswerSubst, bool>,
 
     /// Stores the active strands that we can "pull on" to find more
     /// answers.
@@ -158,12 +163,4 @@ impl<C: Context> Table<C> {
 
 impl AnswerIndex {
     pub(crate) const ZERO: AnswerIndex = AnswerIndex { value: 0 };
-}
-
-impl<C: Context> Answer<C> {
-    /// An "unconditional" answer is one that must be true -- this is
-    /// the case so long as we have no delayed literals.
-    pub(super) fn is_unconditional(&self) -> bool {
-        !self.ambiguous
-    }
 }

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -199,6 +199,7 @@ where
             ambiguous,
             constraints,
             subgoals,
+            delayed_subgoals,
             answer_time,
             floundered_subgoals,
         } = self;
@@ -207,6 +208,7 @@ where
             ambiguous: *ambiguous,
             constraints: constraints.fold_with(folder, binders)?,
             subgoals: subgoals.fold_with(folder, binders)?,
+            delayed_subgoals: delayed_subgoals.fold_with(folder, binders)?,
             answer_time: answer_time.fold_with(folder, binders)?,
             floundered_subgoals: floundered_subgoals.fold_with(folder, binders)?,
         })

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1022,7 +1022,7 @@ pub struct UCanonical<T> {
 impl<T> UCanonical<T> {
     pub fn is_trivial_substitution<TF: TypeFamily>(
         &self,
-        canonical_subst: &Canonical<ConstrainedSubst<TF>>,
+        canonical_subst: &Canonical<AnswerSubst<TF>>,
     ) -> bool {
         let subst = &canonical_subst.value.subst;
         assert_eq!(self.canonical.binders.len(), subst.parameters.len());
@@ -1232,4 +1232,11 @@ impl<'a, TF: TypeFamily> DefaultPlaceholderFolder for &'a Substitution<TF> {}
 pub struct ConstrainedSubst<TF: TypeFamily> {
     pub subst: Substitution<TF>, /* NB: The `is_trivial` routine relies on the fact that `subst` is folded first. */
     pub constraints: Vec<InEnvironment<Constraint<TF>>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Fold, HasTypeFamily)]
+pub struct AnswerSubst<TF: TypeFamily> {
+    pub subst: Substitution<TF>, /* NB: The `is_trivial` routine relies on the fact that `subst` is folded first. */
+    pub constraints: Vec<InEnvironment<Constraint<TF>>>,
+    pub delayed_subgoals: Vec<InEnvironment<Goal<TF>>>,
 }

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -169,6 +169,10 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
             universes: arg.universes,
         }
     }
+
+    fn goal_from_goal_in_environment(goal: &InEnvironment<Goal<TF>>) -> &Goal<TF> {
+        &goal.goal
+    }
 }
 
 impl<'me, TF: TypeFamily> context::ContextOps<SlgContext<TF>> for SlgContextOps<'me, TF> {
@@ -235,15 +239,19 @@ impl<'me, TF: TypeFamily> context::ContextOps<SlgContext<TF>> for SlgContextOps<
         Ok(clauses)
     }
 
-    fn instantiate_ucanonical_goal<R>(
+    fn instantiate_ucanonical_goal(
         &self,
         arg: &UCanonical<InEnvironment<Goal<TF>>>,
-        op: impl FnOnce(TruncatingInferenceTable<TF>, Substitution<TF>, Environment<TF>, Goal<TF>) -> R,
-    ) -> R {
+    ) -> (
+        TruncatingInferenceTable<TF>,
+        Substitution<TF>,
+        Environment<TF>,
+        Goal<TF>,
+    ) {
         let (infer, subst, InEnvironment { environment, goal }) =
             InferenceTable::from_canonical(arg.universes, &arg.canonical);
         let infer_table = TruncatingInferenceTable::new(self.max_size, infer);
-        op(infer_table, subst, environment, goal)
+        (infer_table, subst, environment, goal)
     }
 
     fn instantiate_ex_clause(

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -257,6 +257,29 @@ impl<'me, TF: TypeFamily> context::ContextOps<SlgContext<TF>> for SlgContextOps<
         (infer_table, ex_cluse)
     }
 
+    fn instantiate_answer_subst(
+        &self,
+        num_universes: usize,
+        answer: &Canonical<AnswerSubst<TF>>,
+    ) -> (
+        TruncatingInferenceTable<TF>,
+        Substitution<TF>,
+        Vec<InEnvironment<Constraint<TF>>>,
+        Vec<InEnvironment<Goal<TF>>>,
+    ) {
+        let (
+            infer,
+            _subst,
+            AnswerSubst {
+                subst,
+                constraints,
+                delayed_subgoals,
+            },
+        ) = InferenceTable::from_canonical(num_universes, answer);
+        let infer_table = TruncatingInferenceTable::new(self.max_size, infer);
+        (infer_table, subst, constraints, delayed_subgoals)
+    }
+
     fn constrained_subst_from_answer(
         &self,
         answer: CompleteAnswer<SlgContext<TF>>,

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -121,12 +121,6 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
         !canonical_subst.value.delayed_subgoals.is_empty()
     }
 
-    fn delayed_subgoals(
-        canonical_answer: &Canonical<AnswerSubst<TF>>,
-    ) -> &Vec<InEnvironment<Goal<TF>>> {
-        &canonical_answer.value.delayed_subgoals
-    }
-
     fn num_universes(u_canon: &UCanonical<InEnvironment<Goal<TF>>>) -> usize {
         u_canon.universes
     }
@@ -155,19 +149,6 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
         value: &Canonical<AnswerSubst<TF>>,
     ) -> Canonical<AnswerSubst<TF>> {
         map.map_from_canonical(value)
-    }
-
-    fn apply_binders(
-        arg: &UCanonical<InEnvironment<Goal<TF>>>,
-        goal: &InEnvironment<Goal<TF>>,
-    ) -> UCanonical<InEnvironment<Goal<TF>>> {
-        UCanonical {
-            canonical: Canonical {
-                value: goal.clone(),
-                binders: arg.canonical.binders.clone(),
-            },
-            universes: arg.universes,
-        }
     }
 
     fn goal_from_goal_in_environment(goal: &InEnvironment<Goal<TF>>) -> &Goal<TF> {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -11,13 +11,14 @@ use chalk_engine::context;
 use chalk_engine::context::Floundered;
 use chalk_engine::fallible::Fallible;
 use chalk_engine::hh::HhGoal;
-use chalk_engine::{Answer, ExClause, Literal};
+use chalk_engine::{CompleteAnswer, ExClause, Literal};
 use chalk_ir::cast::Cast;
 use chalk_ir::cast::Caster;
 use chalk_ir::could_match::CouldMatch;
 use chalk_ir::family::HasTypeFamily;
 use chalk_ir::family::TypeFamily;
 use chalk_ir::*;
+
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -74,6 +75,7 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
     type ProgramClause = ProgramClause<TF>;
     type ProgramClauses = Vec<ProgramClause<TF>>;
     type CanonicalConstrainedSubst = Canonical<ConstrainedSubst<TF>>;
+    type CanonicalAnswerSubst = Canonical<AnswerSubst<TF>>;
     type GoalInEnvironment = InEnvironment<Goal<TF>>;
     type Substitution = Substitution<TF>;
     type RegionConstraint = InEnvironment<Constraint<TF>>;
@@ -92,12 +94,12 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
         &canon_ex_clause.value.subst
     }
 
-    fn empty_constraints(ccs: &Canonical<ConstrainedSubst<TF>>) -> bool {
+    fn empty_constraints(ccs: &Canonical<AnswerSubst<TF>>) -> bool {
         ccs.value.constraints.is_empty()
     }
 
     fn inference_normalized_subst_from_subst(
-        ccs: &Canonical<ConstrainedSubst<TF>>,
+        ccs: &Canonical<AnswerSubst<TF>>,
     ) -> &Substitution<TF> {
         &ccs.value.subst
     }
@@ -110,13 +112,35 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
 
     fn is_trivial_substitution(
         u_canon: &UCanonical<InEnvironment<Goal<TF>>>,
-        canonical_subst: &Canonical<ConstrainedSubst<TF>>,
+        canonical_subst: &Canonical<AnswerSubst<TF>>,
     ) -> bool {
         u_canon.is_trivial_substitution(canonical_subst)
     }
 
+    fn has_delayed_subgoals(canonical_subst: &Canonical<AnswerSubst<TF>>) -> bool {
+        !canonical_subst.value.delayed_subgoals.is_empty()
+    }
+
+    fn delayed_subgoals(
+        canonical_answer: &Canonical<AnswerSubst<TF>>,
+    ) -> &Vec<InEnvironment<Goal<TF>>> {
+        &canonical_answer.value.delayed_subgoals
+    }
+
     fn num_universes(u_canon: &UCanonical<InEnvironment<Goal<TF>>>) -> usize {
         u_canon.universes
+    }
+
+    fn canonical_constrained_subst_from_canonical_constrained_answer(
+        canonical_subst: &Canonical<AnswerSubst<TF>>,
+    ) -> Canonical<ConstrainedSubst<TF>> {
+        Canonical {
+            binders: canonical_subst.binders.clone(),
+            value: ConstrainedSubst {
+                subst: canonical_subst.value.subst.clone(),
+                constraints: canonical_subst.value.constraints.clone(),
+            },
+        }
     }
 
     fn map_goal_from_canonical(
@@ -128,9 +152,22 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
 
     fn map_subst_from_canonical(
         map: &UniverseMap,
-        value: &Canonical<ConstrainedSubst<TF>>,
-    ) -> Canonical<ConstrainedSubst<TF>> {
+        value: &Canonical<AnswerSubst<TF>>,
+    ) -> Canonical<AnswerSubst<TF>> {
         map.map_from_canonical(value)
+    }
+
+    fn apply_binders(
+        arg: &UCanonical<InEnvironment<Goal<TF>>>,
+        goal: &InEnvironment<Goal<TF>>,
+    ) -> UCanonical<InEnvironment<Goal<TF>>> {
+        UCanonical {
+            canonical: Canonical {
+                value: goal.clone(),
+                binders: arg.canonical.binders.clone(),
+            },
+            universes: arg.universes,
+        }
     }
 }
 
@@ -222,9 +259,9 @@ impl<'me, TF: TypeFamily> context::ContextOps<SlgContext<TF>> for SlgContextOps<
 
     fn constrained_subst_from_answer(
         &self,
-        answer: Answer<SlgContext<TF>>,
+        answer: CompleteAnswer<SlgContext<TF>>,
     ) -> Canonical<ConstrainedSubst<TF>> {
-        let Answer { subst, .. } = answer;
+        let CompleteAnswer { subst, .. } = answer;
         subst
     }
 }
@@ -345,6 +382,21 @@ impl<TF: TypeFamily> context::UnificationOps<SlgContext<TF>> for TruncatingInfer
     ) -> Canonical<ConstrainedSubst<TF>> {
         self.infer
             .canonicalize(&ConstrainedSubst { subst, constraints })
+            .quantified
+    }
+
+    fn canonicalize_answer_subst(
+        &mut self,
+        subst: Substitution<TF>,
+        constraints: Vec<InEnvironment<Constraint<TF>>>,
+        delayed_subgoals: Vec<InEnvironment<Goal<TF>>>,
+    ) -> Canonical<AnswerSubst<TF>> {
+        self.infer
+            .canonicalize(&AnswerSubst {
+                subst,
+                constraints,
+                delayed_subgoals,
+            })
             .quantified
     }
 

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -9,7 +9,7 @@ use chalk_ir::family::TypeFamily;
 use chalk_ir::*;
 
 use chalk_engine::context;
-use chalk_engine::Answer;
+use chalk_engine::CompleteAnswer;
 use std::fmt::Debug;
 
 /// Draws as many answers as it needs from `answers` (but
@@ -24,7 +24,7 @@ impl<TF: TypeFamily> context::AggregateOps<SlgContext<TF>> for SlgContextOps<'_,
         if answers.peek_answer().is_none() {
             return None;
         }
-        let Answer { subst, ambiguous } = answers.next_answer().unwrap();
+        let CompleteAnswer { subst, ambiguous } = answers.next_answer().unwrap();
 
         // Exactly 1 unconditional answer?
         if answers.peek_answer().is_none() && !ambiguous {

--- a/tests/test/coinduction.rs
+++ b/tests/test/coinduction.rs
@@ -147,7 +147,7 @@ fn coinductive_trivial_variant2() {
         goal {
             exists<T, U> { T: C1<U> }
         } yields {
-            r"Unique; for<?U0> { substitution [?0 := X, ?1 := ^0], lifetime constraints [] }"
+            r"Unique; substitution [?0 := X, ?1 := X], lifetime constraints []"
         }
     }
 }

--- a/tests/test/coinduction.rs
+++ b/tests/test/coinduction.rs
@@ -100,9 +100,7 @@ fn coinductive_nontrivial() {
         goal {
             exists<T> { T: C1 }
         } yields {
-            // FIXME(chalk#248)
-            // r"No possible solution"
-            r"Unique; substitution [?0 := Y], lifetime constraints []"
+            r"No possible solution"
         }
     }
 }
@@ -117,16 +115,15 @@ fn coinductive_trivial_variant1() {
             trait C2<T> { }
 
             struct X { }
-            struct Y { }
 
-            forall<A, B> { A: C1<B> if A: C2<B>, A = X, B = Y }
+            forall<A, B> { A: C1<B> if A: C2<B>, A = X, B = X }
             forall<A, B> { A: C2<B> if B: C1<A> }
         }
 
         goal {
             exists<T, U> { T: C1<U> }
         } yields {
-            r"Unique; substitution [?0 := X, ?1 := Y], lifetime constraints []"
+            r"Unique; substitution [?0 := X, ?1 := X], lifetime constraints []"
         }
     }
 }

--- a/tests/test/slg.rs
+++ b/tests/test/slg.rs
@@ -97,7 +97,7 @@ fn basic() {
             forall<T> { if (T: Sized) { T: Sized } }
         } first 2 with max 10 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [],
@@ -132,7 +132,7 @@ fn breadth_first() {
             exists<T> { T: Sized }
         } first 5 with max 10 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := i32],
@@ -142,7 +142,7 @@ fn breadth_first() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Vec<i32>],
@@ -152,7 +152,7 @@ fn breadth_first() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Slice<i32>],
@@ -162,7 +162,7 @@ fn breadth_first() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Vec<Vec<i32>>],
@@ -172,7 +172,7 @@ fn breadth_first() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Slice<Vec<i32>>],
@@ -347,7 +347,7 @@ fn subgoal_cycle_uninhabited() {
             not { exists<T> { T: Foo } }
         } first 10 with max 2 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [],
@@ -365,7 +365,7 @@ fn subgoal_cycle_uninhabited() {
             forall<T> { not { T: Foo } }
         } first 10 with max 2 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [],
@@ -391,7 +391,7 @@ fn subgoal_cycle_uninhabited() {
             exists<T> { T = Vec<u32>, not { Vec<Vec<T>>: Foo } }
         } first 10 with max 4 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Vec<u32>],
@@ -409,7 +409,7 @@ fn subgoal_cycle_uninhabited() {
             forall<U> { if (U: Foo) { exists<T> { T: Foo } } }
         } first 10 with max 2 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := !1_0],
@@ -440,7 +440,7 @@ fn subgoal_cycle_inhabited() {
             exists<T> { T: Foo }
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := u32],
@@ -469,7 +469,7 @@ fn basic_region_constraint_from_positive_impl() {
             forall<'a, 'b, T> { Ref<'a, 'b, T>: Foo }
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [],
@@ -511,7 +511,7 @@ fn example_2_1_EWFS() {
             exists<V> { a: TransitiveClosure<V> }
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := b],
@@ -521,7 +521,7 @@ fn example_2_1_EWFS() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := c],
@@ -531,7 +531,7 @@ fn example_2_1_EWFS() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := a],
@@ -570,7 +570,7 @@ fn example_2_2_EWFS() {
             c: M
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [],
@@ -693,7 +693,7 @@ fn cached_answers_1() {
             exists<T> { T: Sour }
         } first 10 with max 2 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Lemon],
@@ -703,7 +703,7 @@ fn cached_answers_1() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Vinegar],
@@ -713,7 +713,7 @@ fn cached_answers_1() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := HotSauce<Lemon>],
@@ -723,7 +723,7 @@ fn cached_answers_1() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := HotSauce<Vinegar>],
@@ -733,7 +733,7 @@ fn cached_answers_1() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := HotSauce<^0>],
@@ -769,7 +769,7 @@ fn cached_answers_2() {
             exists<T> { T: Sour }
         } first 10 with max 2 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Lemon],
@@ -779,7 +779,7 @@ fn cached_answers_2() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Vinegar],
@@ -789,7 +789,7 @@ fn cached_answers_2() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := HotSauce<Lemon>],
@@ -799,7 +799,7 @@ fn cached_answers_2() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := HotSauce<Vinegar>],
@@ -809,7 +809,7 @@ fn cached_answers_2() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := HotSauce<^0>],
@@ -845,7 +845,7 @@ fn cached_answers_3() {
             exists<T> { T: Sour }
         } first 10 with max 2 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Lemon],
@@ -855,7 +855,7 @@ fn cached_answers_3() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := HotSauce<Lemon>],
@@ -865,7 +865,7 @@ fn cached_answers_3() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Vinegar],
@@ -875,7 +875,7 @@ fn cached_answers_3() {
                     },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := HotSauce<^0>],
@@ -887,7 +887,7 @@ fn cached_answers_3() {
                     },
                     ambiguous: true
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := HotSauce<Vinegar>],
@@ -952,24 +952,24 @@ fn non_enumerable_traits_direct() {
             exists<A> { A: Enumerable }
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Foo]
                             constraints: []
                         }
                         binders: []
-                    }
+                    },
                     ambiguous: false
                 },
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Bar]
                             constraints: []
                         }
                         binders: []
-                    }
+                    },
                     ambiguous: false
                 }
             ]"
@@ -979,14 +979,14 @@ fn non_enumerable_traits_direct() {
             Foo: NonEnumerable
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: []
                             constraints: []
                         }
                         binders: []
-                    }
+                    },
                     ambiguous: false
                 }
             ]"
@@ -1078,14 +1078,14 @@ fn non_enumerable_traits_reorder() {
             exists<A> { A: Debug1 }
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Foo]
                             constraints: []
                         }
                         binders: []
-                    }
+                    },
                     ambiguous: false
                 }
             ]"
@@ -1096,14 +1096,14 @@ fn non_enumerable_traits_reorder() {
             exists<A> { A: Debug2 }
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Foo]
                             constraints: []
                         }
                         binders: []
-                    }
+                    },
                     ambiguous: false
                 }
             ]"
@@ -1164,14 +1164,14 @@ fn negative_reorder() {
             exists<A> { A: Debug1 }
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Bar]
                             constraints: []
                         }
                         binders: []
-                    }
+                    },
                     ambiguous: false
                 }
             ]"
@@ -1182,14 +1182,14 @@ fn negative_reorder() {
             exists<A> { A: Debug2 }
         } first 10 with max 3 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [?0 := Bar]
                             constraints: []
                         }
                         binders: []
-                    }
+                    },
                     ambiguous: false
                 }
             ]"
@@ -1238,19 +1238,7 @@ fn coinductive_unsound1() {
         goal {
             forall<X> { X: C1orC2 }
         } first 10 with max 3 {
-            // FIXME(chalk#248) -- demonstrate bug in coinduction
-            r"[
-                Answer {
-                    subst: Canonical {
-                        value: ConstrainedSubst {
-                            subst: [],
-                            constraints: []
-                        }
-                        binders: []
-                    }
-                    ambiguous: false
-                }
-           ]"
+            r"[]"
         }
     }
 }
@@ -1343,7 +1331,7 @@ fn max_size_infinite_loop_regression() {
             }
         } first 1 with max 4 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [],
@@ -1368,7 +1356,7 @@ fn max_size_infinite_loop_regression() {
             }
         } first 1 with max 10 {
             r"[
-                Answer {
+                CompleteAnswer {
                     subst: Canonical {
                         value: ConstrainedSubst {
                             subst: [],
@@ -1379,6 +1367,216 @@ fn max_size_infinite_loop_regression() {
                     ambiguous: false
                 }
            ]"
+        }
+    }
+}
+
+#[test]
+fn coinductive_multicycle1() {
+    test! {
+        program {
+            trait Any { }
+
+            #[coinductive]
+            trait C1 { }
+
+            #[coinductive]
+            trait C2 { }
+
+            #[coinductive]
+            trait C3 { }
+
+            forall<T> {
+                T: C1 if T: C2
+            }
+
+            forall<T> {
+                T: C2 if T: C3
+            }
+
+            forall<T> {
+                T: C3 if T: C1
+            }
+
+            forall<T> {
+                T: Any if T: C3
+            }
+
+            forall<T> {
+                T: Any if T: C2
+            }
+
+            forall<T> {
+                T: Any if T: C1
+            }
+        }
+
+        goal {
+            forall<X> { X: Any }
+        } first 10 with max 3 {
+            r"[
+                CompleteAnswer {
+                    subst: Canonical {
+                        value: ConstrainedSubst {
+                            subst: []
+                            constraints: []
+                        }
+                        binders: []
+                    },
+                    ambiguous: false
+                }
+            ]"
+        }
+    }
+}
+
+#[test]
+fn coinductive_multicycle2() {
+    test! {
+        program {
+            trait Any { }
+
+            #[coinductive]
+            trait C1 { }
+
+            #[coinductive]
+            trait C2 { }
+
+            #[coinductive]
+            trait C3 { }
+
+            forall<T> {
+                T: C1 if T: C2
+            }
+
+            forall<T> {
+                T: C2 if T: C3
+            }
+
+            forall<T> {
+                T: C3 if T: C1, T: C2
+            }
+
+            forall<T> {
+                T: Any if T: C1
+            }
+        }
+
+        goal {
+            forall<X> { X: Any }
+        } first 10 with max 3 {
+            r"[
+                CompleteAnswer {
+                    subst: Canonical {
+                        value: ConstrainedSubst {
+                            subst: []
+                            constraints: []
+                        }
+                        binders: []
+                    },
+                    ambiguous: false
+                }
+            ]"
+        }
+    }
+}
+
+#[test]
+fn coinductive_multicycle3() {
+    test! {
+        program {
+            trait Any { }
+
+            #[coinductive]
+            trait C1 { }
+
+            #[coinductive]
+            trait C2 { }
+
+            #[coinductive]
+            trait C3 { }
+
+            trait C4 { }
+
+            forall<T> {
+                T: C1 if T: C2
+            }
+
+            forall<T> {
+                T: C2 if T: C3, T: C4
+            }
+
+            forall<T> {
+                T: C3 if T: C1
+            }
+
+            forall<T> {
+                T: Any if T: C3
+            }
+
+            forall<T> {
+                T: Any if T: C2
+            }
+
+            forall<T> {
+                T: Any if T: C1
+            }
+        }
+
+        goal {
+            forall<X> { X: Any }
+        } first 10 with max 3 {
+            r"[]"
+        }
+    }
+}
+
+#[test]
+fn coinductive_multicycle4() {
+    test! {
+        program {
+            trait Any { }
+
+            #[coinductive]
+            trait C1 { }
+
+            #[coinductive]
+            trait C2 { }
+
+            #[coinductive]
+            trait C3 { }
+
+            trait C4 { }
+
+            forall<T> {
+                T: C1 if T: C2
+            }
+
+            forall<T> {
+                T: C2 if T: C3
+            }
+
+            forall<T> {
+                T: C3 if T: C1, T: C4
+            }
+
+            forall<T> {
+                T: Any if T: C3
+            }
+
+            forall<T> {
+                T: Any if T: C2
+            }
+
+            forall<T> {
+                T: Any if T: C1
+            }
+        }
+
+        goal {
+            forall<X> { X: Any }
+        } first 10 with max 3 {
+            r"[]"
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/chalk/issues/248

Now, when a coinductive cycle is found, it is marked in `PositiveCycle` as such. In `pursue_strand`, these are ignored until all other subgoals have been proven. Once that is the case, we can assume that the coinductive cycles are true.

With this, I also did a lot of refactoring in terms of how the recursion is handled. Importantly, I moved the calls `ensure_answer_recursively` and `pursue_strand_recursively` out of `pursue_positive_subgoal` and `pursue_negative_subgoal`, which ends up making it really obvious that `purse_strand` can easily be done using a loop instead of recursion. So now, the stack protection feature is no longer needed.
