### PR TITLE
Implement lowering errors manually

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,6 @@ dependencies = [
  "chalk-solve 0.1.0",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,8 +195,6 @@ dependencies = [
  "chalk-parse 0.1.0",
  "chalk-rust-ir 0.1.0",
  "chalk-solve 0.1.0",
- "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "salsa 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ bench = []
 [dependencies]
 diff = "0.1.11"
 docopt = "1.0.0"
-failure = "0.1"
 itertools = "0.8.0"
 lalrpop-intern = "0.15.1"
 rustyline = "1.0"

--- a/chalk-integration/Cargo.toml
+++ b/chalk-integration/Cargo.toml
@@ -9,9 +9,7 @@ keywords = ["compiler", "traits", "prolog"]
 edition = "2018"
 
 [dependencies]
-derive-new = "0.5.6"
 itertools = "0.7.8"
-failure = "0.1"
 lalrpop-intern = "0.15.1"
 salsa = "0.10.0"
 

--- a/chalk-integration/src/error.rs
+++ b/chalk-integration/src/error.rs
@@ -1,7 +1,6 @@
 use crate::lowering::RustIrError;
 use chalk_solve::coherence::CoherenceError;
 use chalk_solve::wf::WfError;
-use failure::Error;
 
 /// Wrapper type for the various errors that can occur during chalk
 /// processing.
@@ -10,14 +9,6 @@ pub struct ChalkError {
     /// For now, we just convert the error into a string, which makes
     /// it trivially hashable etc.
     error_text: String,
-}
-
-impl From<Error> for ChalkError {
-    fn from(value: Error) -> Self {
-        ChalkError {
-            error_text: value.to_string(),
-        }
-    }
 }
 
 impl From<Box<dyn std::error::Error>> for ChalkError {

--- a/chalk-integration/src/error.rs
+++ b/chalk-integration/src/error.rs
@@ -1,4 +1,5 @@
-use crate::lowering::RustIrError;
+use chalk_parse::ast::{Identifier, Kind};
+use chalk_rust_ir::LangItem;
 use chalk_solve::coherence::CoherenceError;
 use chalk_solve::wf::WfError;
 
@@ -50,3 +51,134 @@ impl std::fmt::Display for ChalkError {
 }
 
 impl std::error::Error for ChalkError {}
+
+#[derive(Debug)]
+pub enum RustIrError {
+    InvalidTypeName(Identifier),
+    InvalidLifetimeName(Identifier),
+    DuplicateLangItem(LangItem),
+    NotTrait(Identifier),
+    DuplicateOrShadowedParameters,
+    AutoTraitAssociatedTypes(Identifier),
+    AutoTraitParameters(Identifier),
+    AutoTraitWhereClauses(Identifier),
+    InvalidFundamentalTypesParameters(Identifier),
+    NegativeImplAssociatedValues(Identifier),
+    MissingAssociatedType(Identifier),
+    IncorrectNumberOfTypeParameters {
+        identifier: Identifier,
+        expected: usize,
+        actual: usize,
+    },
+    IncorrectNumberOfAssociatedTypeParameters {
+        identifier: Identifier,
+        expected: usize,
+        actual: usize,
+    },
+    IncorrectParameterKind {
+        identifier: Identifier,
+        expected: Kind,
+        actual: Kind,
+    },
+    IncorrectTraitParameterKind {
+        identifier: Identifier,
+        expected: Kind,
+        actual: Kind,
+    },
+    IncorrectAssociatedTypeParameterKind {
+        identifier: Identifier,
+        expected: Kind,
+        actual: Kind,
+    },
+    CannotApplyTypeParameter(Identifier),
+}
+
+impl std::fmt::Display for RustIrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RustIrError::InvalidTypeName(name) => write!(f, "invalid type name `{}`", name),
+            RustIrError::InvalidLifetimeName(name) => write!(f, "invalid lifetime name `{}`", name),
+            RustIrError::DuplicateLangItem(item) => write!(f, "duplicate lang item `{:?}`", item),
+            RustIrError::NotTrait(name) => write!(
+                f,
+                "expected a trait, found `{}`, which is not a trait",
+                name
+            ),
+            RustIrError::DuplicateOrShadowedParameters => {
+                write!(f, "duplicate or shadowed parameters")
+            }
+            RustIrError::AutoTraitAssociatedTypes(name) => {
+                write!(f, "auto trait `{}` cannot define associated types", name)
+            }
+            RustIrError::AutoTraitParameters(name) => {
+                write!(f, "auto trait `{}` cannot have parameters", name)
+            }
+            RustIrError::AutoTraitWhereClauses(name) => {
+                write!(f, "auto trait `{}` cannot have where clauses", name)
+            }
+            RustIrError::InvalidFundamentalTypesParameters(name) => write!(
+                f,
+                "only a single parameter supported for fundamental type `{}`",
+                name
+            ),
+            RustIrError::NegativeImplAssociatedValues(name) => write!(
+                f,
+                "negative impl for trait `{}` cannot define associated values",
+                name
+            ),
+            RustIrError::MissingAssociatedType(name) => {
+                write!(f, "no associated type `{}` defined in trait", name)
+            }
+            RustIrError::IncorrectNumberOfTypeParameters {
+                identifier,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "`{}` takes {} type parameters, not {}",
+                identifier, expected, actual
+            ),
+            RustIrError::IncorrectNumberOfAssociatedTypeParameters {
+                identifier,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "wrong number of parameters for associated type `{}` (expected {}, got {})",
+                identifier, expected, actual
+            ),
+            RustIrError::IncorrectParameterKind {
+                identifier,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "incorrect parameter kind for `{}`: expected {}, found {}",
+                identifier, expected, actual
+            ),
+            RustIrError::IncorrectTraitParameterKind {
+                identifier,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "incorrect parameter kind for trait `{}`: expected {}, found {}",
+                identifier, expected, actual
+            ),
+            RustIrError::IncorrectAssociatedTypeParameterKind {
+                identifier,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "incorrect associated type parameter kind for `{}`: expected {}, found {}",
+                identifier, expected, actual
+            ),
+            RustIrError::CannotApplyTypeParameter(name) => {
+                write!(f, "cannot apply type parameter `{}`", name)
+            }
+        }
+    }
+}
+
+impl std::error::Error for RustIrError {}

--- a/chalk-integration/src/error.rs
+++ b/chalk-integration/src/error.rs
@@ -1,3 +1,4 @@
+use crate::lowering::RustIrError;
 use chalk_solve::coherence::CoherenceError;
 use chalk_solve::wf::WfError;
 use failure::Error;
@@ -37,6 +38,14 @@ impl From<WfError> for ChalkError {
 
 impl From<CoherenceError> for ChalkError {
     fn from(value: CoherenceError) -> Self {
+        ChalkError {
+            error_text: value.to_string(),
+        }
+    }
+}
+
+impl From<RustIrError> for ChalkError {
+    fn from(value: RustIrError) -> Self {
         ChalkError {
             error_text: value.to_string(),
         }

--- a/chalk-integration/src/lib.rs
+++ b/chalk-integration/src/lib.rs
@@ -2,9 +2,6 @@
 #![cfg_attr(feature = "bench", feature(test))]
 
 #[macro_use]
-extern crate failure;
-
-#[macro_use]
 extern crate chalk_macros;
 
 pub mod db;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,10 +65,7 @@ impl LoadedProgram {
         multiple_answers: bool,
     ) -> Result<()> {
         let program = self.db.checked_program()?;
-        use failure::Fail;
-        let goal = chalk_parse::parse_goal(text)?
-            .lower(&*program)
-            .map_err(|e| e.compat())?;
+        let goal = chalk_parse::parse_goal(text)?.lower(&*program)?;
         let peeled_goal = goal.into_peeled_goal();
         if multiple_answers {
             if self.db.solve_multiple(&peeled_goal, |v, has_next| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,10 @@ impl LoadedProgram {
         multiple_answers: bool,
     ) -> Result<()> {
         let program = self.db.checked_program()?;
-        let goal = chalk_parse::parse_goal(text)?.lower(&*program)?;
+        use failure::Fail;
+        let goal = chalk_parse::parse_goal(text)?
+            .lower(&*program)
+            .map_err(|e| e.compat())?;
         let peeled_goal = goal.into_peeled_goal();
         if multiple_answers {
             if self.db.solve_multiple(&peeled_goal, |v, has_next| {

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -34,7 +34,7 @@ fn auto_trait() {
             #[auto] trait Foo<T> { }
         }
         error_msg {
-            "auto trait cannot have parameters"
+            "auto trait `Foo` cannot have parameters"
         }
     }
 
@@ -44,7 +44,7 @@ fn auto_trait() {
             #[auto] trait Foo where Self: Bar { }
         }
         error_msg {
-            "auto trait cannot have where clauses"
+            "auto trait `Foo` cannot have where clauses"
         }
     }
 
@@ -55,7 +55,7 @@ fn auto_trait() {
             }
         }
         error_msg {
-            "auto trait cannot define associated types"
+            "auto trait `Foo` cannot define associated types"
         }
     }
 
@@ -81,7 +81,7 @@ fn negative_impl() {
             }
         }
         error_msg {
-            "negative impls cannot define associated values"
+            "negative impl for trait `Foo` cannot define associated values"
         }
     }
 
@@ -421,7 +421,7 @@ fn fundamental_multiple_type_parameters() {
         }
 
         error_msg {
-            "only fundamental types with a single parameter are supported"
+            "only a single parameter supported for fundamental type `Boxes`"
         }
     }
 }

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -234,7 +234,7 @@ fn check_parameter_kinds() {
             impl Bar for Foo<i32> { }
         }
         error_msg {
-            "incorrect parameter kind: expected lifetime, found type"
+            "incorrect parameter kind for `Foo`: expected lifetime, found type"
         }
     };
 
@@ -245,7 +245,7 @@ fn check_parameter_kinds() {
             impl<'a> Bar for Foo<'a> { }
         }
         error_msg {
-            "incorrect parameter kind: expected type, found lifetime"
+            "incorrect parameter kind for `Foo`: expected type, found lifetime"
         }
     };
 
@@ -256,7 +256,7 @@ fn check_parameter_kinds() {
             impl<X, T> Foo for <X as Iterator>::Item<T> where X: Iterator { }
         }
         error_msg {
-            "incorrect kind for associated type parameter: expected lifetime, found type"
+            "incorrect associated type parameter kind for `Item`: expected lifetime, found type"
         }
     };
 
@@ -267,7 +267,7 @@ fn check_parameter_kinds() {
             impl<X, 'a> Foo for <X as Iterator>::Item<'a> where X: Iterator { }
         }
         error_msg {
-            "incorrect kind for associated type parameter: expected type, found lifetime"
+            "incorrect associated type parameter kind for `Item`: expected type, found lifetime"
         }
     };
 
@@ -278,7 +278,7 @@ fn check_parameter_kinds() {
             impl<'a> Into<'a> for Foo {}
         }
         error_msg {
-            "incorrect kind for trait parameter: expected type, found lifetime"
+            "incorrect parameter kind for trait `Into`: expected type, found lifetime"
         }
     }
 
@@ -289,7 +289,7 @@ fn check_parameter_kinds() {
             impl<T> IntoTime<T> for Foo {}
         }
         error_msg {
-            "incorrect kind for trait parameter: expected lifetime, found type"
+            "incorrect parameter kind for trait `IntoTime`: expected lifetime, found type"
         }
     }
 }
@@ -421,7 +421,7 @@ fn fundamental_multiple_type_parameters() {
         }
 
         error_msg {
-            "Only fundamental types with a single parameter are supported"
+            "only fundamental types with a single parameter are supported"
         }
     }
 }


### PR DESCRIPTION
Fixes #233, but there's one more `failure` in the tree via `lalrpop -> (ascii-canvas ->) term -> dirs -> redox_users`. Bumping `term` should fix it. See also https://rustsec.org/advisories/RUSTSEC-2018-0015.html.

Should be reviewed one commit at a time. Note that I might have messed up some of the messages. Sorry for the churn.