### PR TITLE
Convert ensure_answer_recursively to be iterative instead of recursive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,6 @@ version = "0.9.0"
 dependencies = [
  "chalk-macros 0.1.1",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "stacker 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -10,11 +10,9 @@ keywords = ["compiler", "traits", "prolog"]
 edition = "2018"
 
 [features]
-default = ["stack_protection"]
-stack_protection = ["stacker"]
+default = []
 
 [dependencies]
-stacker = { version = "0.1.2", optional = true }
 rustc-hash = { version = "1.0.0" }
 
 [dependencies.chalk-macros]

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -21,7 +21,7 @@ pub(crate) mod prelude;
 /// active. First, there is always the *global* context, but when we
 /// are in the midst of pursuing some particular strand, we will
 /// instantiate a second context just for that work, via the
-/// `instantiate_ucanonical_goal` method.
+/// `instantiate_ucanonical_goal` and `instantiate_ex_clause` methods.
 ///
 /// In the chalk implementation, these two contexts are mapped to the
 /// same type. But in the rustc implementation, this second context
@@ -33,6 +33,8 @@ pub(crate) mod prelude;
 /// FIXME: Clone and Debug bounds are just for easy derive, they are
 /// not actually necessary. But dang are they convenient.
 pub trait Context: Clone + Debug {
+    type CanonicalExClause: Debug;
+
     /// A map between universes. These are produced when
     /// u-canonicalizing something; they map canonical results back to
     /// the universes from the original.
@@ -123,10 +125,15 @@ pub trait Context: Clone + Debug {
         goal: Self::Goal,
     ) -> Self::GoalInEnvironment;
 
+    /// Extracts the inner normalized substitution from a canonical ex-clause.
+    fn inference_normalized_subst_from_ex_clause(
+        canon_ex_clause: &Self::CanonicalExClause,
+    ) -> &Self::InferenceNormalizedSubst;
+
     /// Extracts the inner normalized substitution from a canonical constraint subst.
-    fn subst_from_canonical_subst(
+    fn inference_normalized_subst_from_subst(
         canon_ex_clause: &Self::CanonicalConstrainedSubst,
-    ) -> &Self::Substitution;
+    ) -> &Self::InferenceNormalizedSubst;
 
     /// True if this solution has no region constraints.
     fn empty_constraints(ccs: &Self::CanonicalConstrainedSubst) -> bool;
@@ -137,6 +144,8 @@ pub trait Context: Clone + Debug {
         u_canon: &Self::UCanonicalGoalInEnvironment,
         canonical_subst: &Self::CanonicalConstrainedSubst,
     ) -> bool;
+
+    fn num_universes(_: &Self::UCanonicalGoalInEnvironment) -> usize;
 
     /// Convert a goal G *from* the canonical universes *into* our
     /// local universes. This will yield a goal G' that is the same
@@ -198,6 +207,12 @@ pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
         op: impl FnOnce(C::InferenceTable, C::Substitution, C::Environment, C::Goal) -> R,
     ) -> R;
 
+    fn instantiate_ex_clause(
+        &self,
+        num_universes: usize,
+        canonical_ex_clause: &C::CanonicalExClause,
+    ) -> (C::InferenceTable, ExClause<C>);
+
     /// returns unique solution from answer
     fn constrained_subst_from_answer(&self, answer: Answer<C>) -> C::CanonicalConstrainedSubst;
 }
@@ -256,6 +271,9 @@ pub trait UnificationOps<C: Context> {
         &mut self,
         value: &C::GoalInEnvironment,
     ) -> (C::UCanonicalGoalInEnvironment, C::UniverseMap);
+
+    // Used by: logic
+    fn canonicalize_ex_clause(&mut self, value: &ExClause<C>) -> C::CanonicalExClause;
 
     // Used by: logic
     fn canonicalize_constrained_subst(
@@ -335,5 +353,6 @@ pub trait AnswerStream<C: Context> {
 
     /// Invokes `test` with each possible future answer, returning true immediately
     /// if we find any answer for which `test` returns true.
-    fn any_future_answer(&mut self, test: impl FnMut(&C::Substitution) -> bool) -> bool;
+    fn any_future_answer(&mut self, test: impl FnMut(&C::InferenceNormalizedSubst) -> bool)
+        -> bool;
 }

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -237,7 +237,10 @@ impl<'me, C: Context, CO: ContextOps<C>> AnswerStream<C> for ForestSolver<'me, C
         })
     }
 
-    fn any_future_answer(&mut self, test: impl FnMut(&C::Substitution) -> bool) -> bool {
+    fn any_future_answer(
+        &mut self,
+        test: impl FnMut(&C::InferenceNormalizedSubst) -> bool,
+    ) -> bool {
         self.forest.any_future_answer(self.table, self.answer, test)
     }
 }

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -199,18 +199,15 @@ impl<'me, C: Context, CO: ContextOps<C>> AnswerStream<C> for ForestSolver<'me, C
     /// Panics if a negative cycle was detected.
     fn peek_answer(&mut self) -> Option<Answer<C>> {
         loop {
-            dbg!(&self.table, &self.answer);
             match self
                 .forest
                 .root_answer(self.context, self.table, self.answer)
             {
                 Ok(answer) => {
-                    dbg!(&answer);
                     return Some(answer.clone());
                 }
 
                 Err(RootSearchFail::Floundered) => {
-                    dbg!("Floundered");
                     let table_goal = &self.forest.tables[self.table].table_goal;
                     return Some(Answer {
                         subst: self.context.identity_constrained_subst(table_goal),

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -67,8 +67,11 @@ impl<C: Context> Forest<C> {
         for i in 0..num_answers {
             let i = AnswerIndex::from(i);
             loop {
-                match self.ensure_root_answer(context, table, i) {
-                    Ok(()) => break,
+                match self.root_answer(context, table, i) {
+                    Ok(answer) => {
+                        answers.push(answer.clone());
+                        break;
+                    }
                     Err(RootSearchFail::Floundered) => return None,
                     Err(RootSearchFail::QuantumExceeded) => continue,
                     Err(RootSearchFail::NoMoreSolutions) => return Some(answers),
@@ -82,8 +85,6 @@ impl<C: Context> Forest<C> {
                     }
                 }
             }
-
-            answers.push(self.answer(table, i).clone());
         }
 
         Some(answers)
@@ -200,10 +201,9 @@ impl<'me, C: Context, CO: ContextOps<C>> AnswerStream<C> for ForestSolver<'me, C
         loop {
             match self
                 .forest
-                .ensure_root_answer(self.context, self.table, self.answer)
+                .root_answer(self.context, self.table, self.answer)
             {
-                Ok(()) => {
-                    let answer = self.forest.answer(self.table, self.answer);
+                Ok(answer) => {
                     return Some(answer.clone());
                 }
 

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -4,15 +4,18 @@ use crate::logic::RootSearchFail;
 use crate::stack::{Stack, StackIndex};
 use crate::table::AnswerIndex;
 use crate::tables::Tables;
-use crate::{Answer, DepthFirstNumber, TableIndex, TimeStamp};
+use crate::{Answer, TableIndex, TimeStamp};
 
 pub struct Forest<C: Context> {
     context: C,
     pub(crate) tables: Tables<C>,
     pub(crate) stack: Stack<C>,
 
-    dfn: DepthFirstNumber,
-    work: TimeStamp,
+    /// This is a clock which always increases. It is
+    /// incremented every time a new subgoal is followed.
+    /// This effectively gives us way to track what depth
+    /// and loop a table or strand was last followed.
+    clock: TimeStamp,
 }
 
 impl<C: Context> Forest<C> {
@@ -21,8 +24,7 @@ impl<C: Context> Forest<C> {
             context,
             tables: Tables::new(),
             stack: Stack::default(),
-            dfn: DepthFirstNumber::MIN,
-            work: TimeStamp::default(),
+            clock: TimeStamp::default(),
         }
     }
 
@@ -36,15 +38,10 @@ impl<C: Context> Forest<C> {
         &self.context
     }
 
-    // Gets the next depth-first number. This number never decreases.
-    pub(super) fn next_dfn(&mut self) -> DepthFirstNumber {
-        self.dfn.next()
-    }
-
-    // Gets the next work TimeStamp. This will never decrease.
-    pub(super) fn increment_work(&mut self) -> TimeStamp {
-        self.work.increment();
-        self.work
+    // Gets the next clock TimeStamp. This will never decrease.
+    pub(super) fn increment_clock(&mut self) -> TimeStamp {
+        self.clock.increment();
+        self.clock
     }
 
     /// Finds the first N answers, looping as much as needed to get

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -233,10 +233,7 @@ impl<'me, C: Context, CO: ContextOps<C>> AnswerStream<C> for ForestSolver<'me, C
         })
     }
 
-    fn any_future_answer(
-        &mut self,
-        test: impl FnMut(&C::InferenceNormalizedSubst) -> bool,
-    ) -> bool {
+    fn any_future_answer(&mut self, test: impl FnMut(&C::Substitution) -> bool) -> bool {
         self.forest.any_future_answer(self.table, self.answer, test)
     }
 }

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -9,7 +9,7 @@ use crate::{Answer, DepthFirstNumber, TableIndex, TimeStamp};
 pub struct Forest<C: Context> {
     context: C,
     pub(crate) tables: Tables<C>,
-    pub(crate) stack: Stack,
+    pub(crate) stack: Stack<C>,
 
     dfn: DepthFirstNumber,
     work: TimeStamp,
@@ -199,15 +199,18 @@ impl<'me, C: Context, CO: ContextOps<C>> AnswerStream<C> for ForestSolver<'me, C
     /// Panics if a negative cycle was detected.
     fn peek_answer(&mut self) -> Option<Answer<C>> {
         loop {
+            dbg!(&self.table, &self.answer);
             match self
                 .forest
                 .root_answer(self.context, self.table, self.answer)
             {
                 Ok(answer) => {
+                    dbg!(&answer);
                     return Some(answer.clone());
                 }
 
                 Err(RootSearchFail::Floundered) => {
+                    dbg!("Floundered");
                     let table_goal = &self.forest.tables[self.table].table_goal;
                     return Some(Answer {
                         subst: self.context.identity_constrained_subst(table_goal),

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -4,8 +4,7 @@ use crate::logic::RootSearchFail;
 use crate::stack::{Stack, StackIndex};
 use crate::table::AnswerIndex;
 use crate::tables::Tables;
-use crate::Answer;
-use crate::{DepthFirstNumber, TableIndex};
+use crate::{Answer, DepthFirstNumber, TableIndex, TimeStamp};
 
 pub struct Forest<C: Context> {
     context: C,
@@ -13,6 +12,7 @@ pub struct Forest<C: Context> {
     pub(crate) stack: Stack,
 
     dfn: DepthFirstNumber,
+    work: TimeStamp,
 }
 
 impl<C: Context> Forest<C> {
@@ -22,6 +22,7 @@ impl<C: Context> Forest<C> {
             tables: Tables::new(),
             stack: Stack::default(),
             dfn: DepthFirstNumber::MIN,
+            work: TimeStamp::default(),
         }
     }
 
@@ -38,6 +39,12 @@ impl<C: Context> Forest<C> {
     // Gets the next depth-first number. This number never decreases.
     pub(super) fn next_dfn(&mut self) -> DepthFirstNumber {
         self.dfn.next()
+    }
+
+    // Gets the next work TimeStamp. This will never decrease.
+    pub(super) fn increment_work(&mut self) -> TimeStamp {
+        self.work.increment();
+        self.work
     }
 
     /// Finds the first N answers, looping as much as needed to get

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -4,18 +4,12 @@ use crate::logic::RootSearchFail;
 use crate::stack::{Stack, StackIndex};
 use crate::table::AnswerIndex;
 use crate::tables::Tables;
-use crate::{Answer, TableIndex, TimeStamp};
+use crate::{Answer, TableIndex};
 
 pub struct Forest<C: Context> {
     context: C,
     pub(crate) tables: Tables<C>,
     pub(crate) stack: Stack<C>,
-
-    /// This is a clock which always increases. It is
-    /// incremented every time a new subgoal is followed.
-    /// This effectively gives us way to track what depth
-    /// and loop a table or strand was last followed.
-    clock: TimeStamp,
 }
 
 impl<C: Context> Forest<C> {
@@ -24,7 +18,6 @@ impl<C: Context> Forest<C> {
             context,
             tables: Tables::new(),
             stack: Stack::default(),
-            clock: TimeStamp::default(),
         }
     }
 
@@ -36,12 +29,6 @@ impl<C: Context> Forest<C> {
     /// term in here).
     pub fn context(&self) -> &C {
         &self.context
-    }
-
-    // Gets the next clock TimeStamp. This will never decrease.
-    pub(super) fn increment_clock(&mut self) -> TimeStamp {
-        self.clock.increment();
-        self.clock
     }
 
     /// Finds the first N answers, looping as much as needed to get

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -290,25 +290,3 @@ impl DepthFirstNumber {
         DepthFirstNumber { value }
     }
 }
-
-/// Because we recurse so deeply, we rely on stacker to
-/// avoid overflowing the stack.
-#[cfg(feature = "stack_protection")]
-fn maybe_grow_stack<F, R>(op: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    // These numbers are somewhat randomly chosen to make tests work
-    // well enough on my system. In particular, because we only test
-    // for growing the stack in `new_clause`, a red zone of 32K was
-    // insufficient to prevent stack overflow. - nikomatsakis
-    stacker::maybe_grow(256 * 1024, 2 * 1024 * 1024, op)
-}
-
-#[cfg(not(feature = "stack_protection"))]
-fn maybe_grow_stack<F, R>(op: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    op()
-}

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -118,8 +118,9 @@ pub struct ExClause<C: Context> {
     /// floundered subgoals may no longer be floundered: we record the
     /// current time when we add something to the list of floundered
     /// subgoals, and then we can compare whether its value has
-    /// changed since then.
-    pub current_time: TimeStamp,
+    /// changed since then. This is not the same `TimeStamp` of
+    /// `Forest`'s clock.
+    pub answer_time: TimeStamp,
 
     /// List of subgoals that have floundered. See `FlounderedSubgoal`
     /// for more information.

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -94,16 +94,6 @@ index_struct! {
     }
 }
 
-/// The `DepthFirstNumber` (DFN) is a sequential number assigned to
-/// each goal when it is first encountered. The naming (taken from
-/// EWFS) refers to the idea that this number tracks the index of when
-/// we encounter the goal during a depth-first traversal of the proof
-/// tree.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct DepthFirstNumber {
-    value: u64,
-}
-
 /// The paper describes these as `A :- D | G`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ExClause<C: Context> {
@@ -146,6 +136,10 @@ pub struct TimeStamp {
 }
 
 impl TimeStamp {
+    const MAX: TimeStamp = TimeStamp {
+        clock: ::std::u64::MAX,
+    };
+
     fn increment(&mut self) {
         self.clock += 1;
     }
@@ -255,14 +249,14 @@ pub enum Literal<C: Context> {
 /// however, this value must be updated.
 #[derive(Copy, Clone, Debug)]
 struct Minimums {
-    positive: DepthFirstNumber,
-    negative: DepthFirstNumber,
+    positive: TimeStamp,
+    negative: TimeStamp,
 }
 
 impl Minimums {
     const MAX: Minimums = Minimums {
-        positive: DepthFirstNumber::MAX,
-        negative: DepthFirstNumber::MAX,
+        positive: TimeStamp::MAX,
+        negative: TimeStamp::MAX,
     };
 
     /// Update our fields to be the minimum of our current value
@@ -272,21 +266,7 @@ impl Minimums {
         self.negative = min(self.negative, other.negative);
     }
 
-    fn minimum_of_pos_and_neg(&self) -> DepthFirstNumber {
+    fn minimum_of_pos_and_neg(&self) -> TimeStamp {
         min(self.positive, self.negative)
-    }
-}
-
-impl DepthFirstNumber {
-    const MIN: DepthFirstNumber = DepthFirstNumber { value: 0 };
-    const MAX: DepthFirstNumber = DepthFirstNumber {
-        value: ::std::u64::MAX,
-    };
-
-    fn next(&mut self) -> DepthFirstNumber {
-        let value = self.value;
-        assert!(value < ::std::u64::MAX);
-        self.value += 1;
-        DepthFirstNumber { value }
     }
 }

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -455,8 +455,14 @@ impl<C: Context> Forest<C> {
         }
     }
 
-    /// This is called if the selected subgoal for a `Strand` is
+    /// This is called if the selected subgoal for `strand` is
     /// a positive, non-coinductive cycle.
+    ///
+    /// # Parameters
+    ///
+    /// * `depth` is the depth in the stack of where the subgoal appears
+    /// * `strand` the strand from the top of the stack we are pursuing
+    /// * `minimums` is the collected minimum clock times
     fn on_positive_cycle(
         &mut self,
         depth: StackIndex,
@@ -499,6 +505,15 @@ impl<C: Context> Forest<C> {
         Ok(depth)
     }
 
+    /// Invoked after we've selected a (new) subgoal for the top-most
+    /// strand. Attempts to pursue this selected subgoal.
+    ///
+    /// Returns:
+    ///
+    /// * `Ok(top_depth)` if we should keep searching. `top_depth` is
+    ///   the new depth of the stack. If may be greater than the old
+    ///   depth if we pushed a new table onto the stack.
+    /// * `Err` if the subgoal failed in some way such that the strand can be abandoned.
     fn on_subgoal_selected(
         &mut self,
         mut depth: StackIndex,

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -480,12 +480,12 @@ impl<C: Context> Forest<C> {
                 // answer for this table. Now, this table was either a
                 // subgoal for another strand, or was the root table.
                 let mut strand = {
-                    let prev_index = self.stack.pop(depth);
-                    if let Some(index) = prev_index {
+                    self.stack.pop(depth);
+                    if let Some(prev_depth) = self.stack.top_depth() {
                         // The table was a subgoal for another strand,
                         // which is still active.
                         // We need to merge the answer into it.
-                        depth = index;
+                        depth = prev_depth;
                         self.stack[depth].active_strand.take().unwrap()
                     } else {
                         // That was the root table, so we are done.
@@ -536,12 +536,12 @@ impl<C: Context> Forest<C> {
             debug!("Marking table {:?} as floundered!", table);
             self.tables[table].mark_floundered();
 
-            let prev_index = self.stack.pop(depth);
-            if let Some(index) = prev_index {
+            self.stack.pop(depth);
+            if let Some(prev_depth) = self.stack.top_depth() {
                 // The table was a subgoal for another strand,
                 // which is still active.
                 // We need to decide what a floundered subgoal means
-                depth = index;
+                depth = prev_depth;
             } else {
                 // That was the root table, so we are done.
                 return RootSearchFail::Floundered;
@@ -580,11 +580,11 @@ impl<C: Context> Forest<C> {
             // This table has no solutions, so we have to check what
             // this means for the subgoal containing this strand
             let strand = {
-                let prev_index = self.stack.pop(depth);
-                if let Some(index) = prev_index {
+                self.stack.pop(depth);
+                if let Some(prev_depth) = self.stack.top_depth() {
                     // The table was a subgoal for another strand,
                     // which is still active.
-                    depth = index;
+                    depth = prev_depth;
                     self.stack[depth].active_strand.as_mut().unwrap()
                 } else {
                     debug!("no more solutions");
@@ -653,12 +653,12 @@ impl<C: Context> Forest<C> {
             // to check what this means for the subgoal containing
             // this strand
             let strand = {
-                let prev_index = self.stack.pop(depth);
-                if let Some(index) = prev_index {
+                self.stack.pop(depth);
+                if let Some(prev_depth) = self.stack.top_depth() {
                     // The table was a subgoal for another strand,
                     // which is still active.
                     // We need to merge the answer into it.
-                    depth = index;
+                    depth = prev_depth;
                     self.stack[depth].active_strand.as_mut().unwrap()
                 } else {
                     panic!("nothing on the stack but cyclic result");
@@ -700,9 +700,9 @@ impl<C: Context> Forest<C> {
 
     fn unwind_stack(&mut self, mut depth: StackIndex) {
         loop {
-            let next_index = self.stack.pop(depth);
-            if let Some(index) = next_index {
-                depth = index;
+            self.stack.pop(depth);
+            if let Some(prev_depth) = self.stack.top_depth() {
+                depth = prev_depth;
             } else {
                 return;
             }

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -304,12 +304,9 @@ impl<C: Context> Forest<C> {
     /// - If the strand was negatively dependent on the subgoal, then strand
     ///   has led nowhere of interest and we return `true`. This strand should
     ///   be discarded.
-    /// 
+    ///
     /// In other words, we return whether this strand flounders.
-    fn should_strand_flounder(
-        &mut self,
-        strand: &mut Strand<C>,
-    ) -> bool {
+    fn should_strand_flounder(&mut self, strand: &mut Strand<C>) -> bool {
         // This subgoal selection for the strand is finished, so take it
         let selected_subgoal = strand.selected_subgoal.take().unwrap();
         match strand.ex_clause.subgoals[selected_subgoal.subgoal_index] {
@@ -621,7 +618,7 @@ impl<C: Context> Forest<C> {
                                         // Now we yield with `QuantumExceeded`
                                         self.unwind_stack(depth);
                                         return Err(RootSearchFail::QuantumExceeded);
-                                    },
+                                    }
                                     true => {
                                         // This strand will never lead anywhere of interest
                                         drop(strand);
@@ -849,7 +846,8 @@ impl<C: Context> Forest<C> {
                 }
             }
 
-            if self.tables[strand.selected_subgoal.as_ref().unwrap().subgoal_table].is_floundered() {
+            if self.tables[strand.selected_subgoal.as_ref().unwrap().subgoal_table].is_floundered()
+            {
                 match self.should_strand_flounder(strand) {
                     false => {
                         // This subgoal has floundered and has been marked.
@@ -857,7 +855,7 @@ impl<C: Context> Forest<C> {
                         // floundered too, and maybe come back to it. Now, we
                         // try to see if any other subgoals can be pursued first.
                         continue;
-                    },
+                    }
                     true => {
                         // This strand will never lead anywhere of interest.
                         return SubGoalSelection::Floundered;
@@ -867,7 +865,6 @@ impl<C: Context> Forest<C> {
                 return SubGoalSelection::Selected;
             }
         }
-
     }
 
     /// Invoked when a strand represents an **answer**. This means

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -115,8 +115,7 @@ impl<C: Context> Forest<C> {
             initial_answer
         );
 
-        let next_clock = self.increment_clock();
-        let mut depth = self.stack.push(initial_table, next_clock, Minimums::MAX);
+        let mut depth = self.stack.push(initial_table, Minimums::MAX);
         loop {
             // FIXME: use depth for debug/info printing
 
@@ -582,9 +581,8 @@ impl<C: Context> Forest<C> {
         // Set this strand as active and push it onto the stack.
         self.stack[depth].active_strand = Some(strand);
 
-        let clock = self.increment_clock();
         let cyclic_minimums = Minimums::MAX;
-        depth = self.stack.push(subgoal_table, clock, cyclic_minimums);
+        depth = self.stack.push(subgoal_table, cyclic_minimums);
         Ok(depth)
     }
 

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -600,15 +600,17 @@ impl<C: Context> Forest<C> {
                 // We found an answer for this strand, and therefore an
                 // answer for this table. Now, this table was either a
                 // subgoal for another strand, or was the root table.
-                let mut strand = {
-                    self.stack.pop(depth);
-                    if let Some(prev_depth) = self.stack.top_depth() {
+                self.stack.pop(depth);
+                let mut strand = match self.stack.top_depth() {
+                    Some(prev_depth) => {
                         // The table was a subgoal for another strand,
                         // which is still active.
                         // We need to merge the answer into it.
                         depth = prev_depth;
                         self.stack[depth].active_strand.take().unwrap()
-                    } else {
+                    }
+
+                    None => {
                         // That was the root table, so we are done.
                         return NoRemainingSubgoalsResult::RootAnswerAvailable;
                     }
@@ -775,15 +777,17 @@ impl<C: Context> Forest<C> {
             // This table resulted in a positive cycle, so we have
             // to check what this means for the subgoal containing
             // this strand
-            let strand = {
-                self.stack.pop(depth);
-                if let Some(prev_depth) = self.stack.top_depth() {
+            self.stack.pop(depth);
+            let strand = match self.stack.top_depth() {
+                Some(prev_depth) => {
                     // The table was a subgoal for another strand,
                     // which is still active.
                     // We need to merge the answer into it.
                     depth = prev_depth;
                     self.stack[depth].active_strand.as_mut().unwrap()
-                } else {
+                }
+
+                None => {
                     panic!("nothing on the stack but cyclic result");
                 }
             };

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -130,7 +130,7 @@ impl<C: Context> Forest<C> {
             };
             let table = self.stack[*depth].table;
             let canonical_next_strand = Self::canonicalize_strand(next_strand);
-            self.tables[table].push_strand(canonical_next_strand);
+            self.tables[table].enqueue_strand(canonical_next_strand);
         }
 
         // Deselect and remove the selected subgoal, now that we have an answer for it.
@@ -385,7 +385,7 @@ impl<C: Context> Forest<C> {
         // because the stack above us might change.
         let table = self.stack[depth].table;
         let canonical_strand = Self::canonicalize_strand(strand);
-        self.tables[table].push_strand(canonical_strand);
+        self.tables[table].enqueue_strand(canonical_strand);
 
         // The strand isn't active, but the table is, so just continue
         Ok(depth)
@@ -556,7 +556,7 @@ impl<C: Context> Forest<C> {
                 // We want to maybe pursue this strand later
                 let table = self.stack[depth].table;
                 let canonical_strand = Self::canonicalize_strand(strand);
-                self.tables[table].push_strand(canonical_strand);
+                self.tables[table].enqueue_strand(canonical_strand);
 
                 // Now we yield with `QuantumExceeded`
                 self.unwind_stack(depth);
@@ -691,7 +691,7 @@ impl<C: Context> Forest<C> {
             let active_strand = self.stack[depth].active_strand.take().unwrap();
             let table = self.stack[depth].table;
             let canonical_active_strand = Self::canonicalize_strand(active_strand);
-            self.tables[table].push_strand(canonical_active_strand);
+            self.tables[table].enqueue_strand(canonical_active_strand);
 
             // The strand isn't active, but the table is, so just continue
             return Ok(depth);
@@ -710,7 +710,7 @@ impl<C: Context> Forest<C> {
             let active_strand = self.stack[depth].active_strand.take().unwrap();
             let table = self.stack[depth].table;
             let canonical_active_strand = Self::canonicalize_strand(active_strand);
-            self.tables[table].push_strand(canonical_active_strand);
+            self.tables[table].enqueue_strand(canonical_active_strand);
         }
     }
 
@@ -764,7 +764,7 @@ impl<C: Context> Forest<C> {
             // answer for the table.
             let next_strand = self.stack[depth].active_strand.take().or_else(|| {
                 self.tables[table]
-                    .pop_next_strand_if(|strand| strand.last_pursued_time < clock)
+                    .dequeue_next_strand_if(|strand| strand.last_pursued_time < clock)
                     .map(|canonical_strand| {
                         let num_universes = C::num_universes(&self.tables[table].table_goal);
                         let CanonicalStrand {
@@ -1181,7 +1181,7 @@ impl<C: Context> Forest<C> {
                                     last_pursued_time: TimeStamp::default(),
                                 };
                                 let canonical_strand = Self::canonicalize_strand(strand);
-                                table_ref.push_strand(canonical_strand);
+                                table_ref.enqueue_strand(canonical_strand);
                             }
                         }
                     }
@@ -1215,7 +1215,7 @@ impl<C: Context> Forest<C> {
                         last_pursued_time: TimeStamp::default(),
                     };
                     let canonical_strand = Self::canonicalize_strand(strand);
-                    table_ref.push_strand(canonical_strand);
+                    table_ref.enqueue_strand(canonical_strand);
                 }
             }
         }

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -726,16 +726,17 @@ impl<C: Context> Forest<C> {
                     // There is no solution for this strand, so discard it
                     self.stack[depth].active_strand.take();
 
-                    // Now we yield with `QuantumExceeded`
+                    // Now we yield with `QuantumExceeded`, as the
+                    // table may have other strands
                     self.unwind_stack(depth);
                     return Err(RootSearchFail::QuantumExceeded);
                 }
                 Literal::Negative(_) => {
                     debug!("subgoal was proven because negative literal");
 
-                    // There is no solution for this strand
-                    // But, this is what we want, so can remove
-                    // this subgoal
+                    // There is no solution for this strand. But, this
+                    // is what we want, so can remove this subgoal and
+                    // keep going.
                     strand
                         .ex_clause
                         .subgoals

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -106,16 +106,16 @@ impl<C: Context> Forest<C> {
     /// given table. This may require activating a strand. Returns
     /// `Ok(())` if the answer is available and otherwise a
     /// `RootSearchFail` result.
-    pub(super) fn ensure_root_answer(
+    pub(super) fn root_answer(
         &mut self,
         context: &impl ContextOps<C>,
         table: TableIndex,
         answer: AnswerIndex,
-    ) -> RootSearchResult<()> {
+    ) -> RootSearchResult<&Answer<C>> {
         assert!(self.stack.is_empty());
 
         match self.ensure_answer_recursively(context, table, answer) {
-            Ok(EnsureSuccess::AnswerAvailable) => Ok(()),
+            Ok(EnsureSuccess::AnswerAvailable) => Ok(self.tables[table].answer(answer).unwrap()),
             Err(RecursiveSearchFail::Floundered) => Err(RootSearchFail::Floundered),
             Err(RecursiveSearchFail::NoMoreSolutions) => Err(RootSearchFail::NoMoreSolutions),
             Err(RecursiveSearchFail::QuantumExceeded) => Err(RootSearchFail::QuantumExceeded),
@@ -124,7 +124,7 @@ impl<C: Context> Forest<C> {
             // Things involving cycles should be impossible since our
             // stack was empty on entry:
             Ok(EnsureSuccess::Coinductive) | Err(RecursiveSearchFail::PositiveCycle(..)) => {
-                panic!("ensure_root_answer: nothing on the stack but cyclic result")
+                panic!("root_answer: nothing on the stack but cyclic result")
             }
         }
     }

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -92,9 +92,10 @@ impl<C: Context> Forest<C> {
         initial_table: TableIndex,
         initial_answer: AnswerIndex,
     ) -> RootSearchResult<()> {
-        info!(
+        info_heading!(
             "ensure_answer(table={:?}, answer={:?})",
-            initial_table, initial_answer
+            initial_table,
+            initial_answer
         );
         info!("table goal = {:#?}", self.tables[initial_table].table_goal);
         // Check if this table has floundered.

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -700,8 +700,8 @@ impl<C: Context> Forest<C> {
             };
 
             // This subgoal selection for the strand is finished, so take it
-            let selected_subgoal = caller_strand.selected_subgoal.take().unwrap();
-            return match caller_strand.ex_clause.subgoals[selected_subgoal.subgoal_index] {
+            let caller_selected_subgoal = caller_strand.selected_subgoal.take().unwrap();
+            return match caller_strand.ex_clause.subgoals[caller_selected_subgoal.subgoal_index] {
                 // T' wanted an answer from T, but none is
                 // forthcoming.  Therefore, the active strand from T'
                 // has failed and can be discarded.
@@ -722,7 +722,7 @@ impl<C: Context> Forest<C> {
                     caller_strand
                         .ex_clause
                         .subgoals
-                        .remove(selected_subgoal.subgoal_index);
+                        .remove(caller_selected_subgoal.subgoal_index);
 
                     // This strand is still active, so continue
                     Ok(depth)
@@ -766,8 +766,8 @@ impl<C: Context> Forest<C> {
             };
 
             // We can't take this because we might need it later to clear the cycle
-            let selected_subgoal = caller_strand.selected_subgoal.as_ref().unwrap();
-            match caller_strand.ex_clause.subgoals[selected_subgoal.subgoal_index] {
+            let caller_selected_subgoal = caller_strand.selected_subgoal.as_ref().unwrap();
+            match caller_strand.ex_clause.subgoals[caller_selected_subgoal.subgoal_index] {
                 Literal::Positive(_) => {
                     self.stack[depth]
                         .cyclic_minimums

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -19,7 +19,7 @@ impl<C: Context> Forest<C> {
             ambiguous: false,
             constraints: vec![],
             subgoals: vec![],
-            current_time: TimeStamp::default(),
+            answer_time: TimeStamp::default(),
             floundered_subgoals: vec![],
         };
 

--- a/chalk-engine/src/stack.rs
+++ b/chalk-engine/src/stack.rs
@@ -1,4 +1,4 @@
-use crate::{DepthFirstNumber, TableIndex};
+use crate::{DepthFirstNumber, Minimums, TableIndex, TimeStamp};
 use std::ops::{Index, IndexMut, Range};
 
 /// See `Forest`.
@@ -24,6 +24,10 @@ pub(crate) struct StackEntry {
 
     /// The DFN of this computation.
     pub(super) dfn: DepthFirstNumber,
+
+    pub(super) work: TimeStamp,
+
+    pub(super) cyclic_minimums: Minimums,
 }
 
 impl Stack {
@@ -51,9 +55,9 @@ impl Stack {
         depth..StackIndex::from(self.stack.len())
     }
 
-    pub(super) fn push(&mut self, table: TableIndex, dfn: DepthFirstNumber) -> StackIndex {
+    pub(super) fn push(&mut self, table: TableIndex, dfn: DepthFirstNumber, work: TimeStamp, cyclic_minimums: Minimums) -> StackIndex {
         let old_len = self.stack.len();
-        self.stack.push(StackEntry { table, dfn });
+        self.stack.push(StackEntry { table, dfn, work, cyclic_minimums });
         StackIndex::from(old_len)
     }
 

--- a/chalk-engine/src/stack.rs
+++ b/chalk-engine/src/stack.rs
@@ -1,6 +1,5 @@
 use crate::context::Context;
 use crate::strand::Strand;
-use crate::table::AnswerIndex;
 use crate::{DepthFirstNumber, Minimums, TableIndex, TimeStamp};
 use std::ops::{Index, IndexMut, Range};
 
@@ -31,8 +30,6 @@ index_struct! {
 pub(crate) struct StackEntry<C: Context> {
     /// The goal G from the stack entry `A :- G` represented here.
     pub(super) table: TableIndex,
-
-    pub(super) answer: AnswerIndex,
 
     /// The DFN of this computation.
     pub(super) dfn: DepthFirstNumber,
@@ -75,7 +72,6 @@ impl<C: Context> Stack<C> {
     pub(super) fn push(
         &mut self,
         table: TableIndex,
-        answer: AnswerIndex,
         dfn: DepthFirstNumber,
         work: TimeStamp,
         cyclic_minimums: Minimums,
@@ -83,7 +79,6 @@ impl<C: Context> Stack<C> {
         let old_len = self.stack.len();
         self.stack.push(StackEntry {
             table,
-            answer,
             dfn,
             work,
             cyclic_minimums,

--- a/chalk-engine/src/stack.rs
+++ b/chalk-engine/src/stack.rs
@@ -1,6 +1,6 @@
 use crate::context::Context;
 use crate::strand::Strand;
-use crate::{DepthFirstNumber, Minimums, TableIndex, TimeStamp};
+use crate::{Minimums, TableIndex, TimeStamp};
 use std::ops::{Index, IndexMut, Range};
 
 /// See `Forest`.
@@ -31,10 +31,8 @@ pub(crate) struct StackEntry<C: Context> {
     /// The goal G from the stack entry `A :- G` represented here.
     pub(super) table: TableIndex,
 
-    /// The DFN of this computation.
-    pub(super) dfn: DepthFirstNumber,
-
-    pub(super) work: TimeStamp,
+    /// The clock TimeStamp of this stack entry.
+    pub(super) clock: TimeStamp,
 
     pub(super) cyclic_minimums: Minimums,
 
@@ -72,15 +70,13 @@ impl<C: Context> Stack<C> {
     pub(super) fn push(
         &mut self,
         table: TableIndex,
-        dfn: DepthFirstNumber,
-        work: TimeStamp,
+        clock: TimeStamp,
         cyclic_minimums: Minimums,
     ) -> StackIndex {
         let old_len = self.stack.len();
         self.stack.push(StackEntry {
             table,
-            dfn,
-            work,
+            clock,
             cyclic_minimums,
             active_strand: None,
         });

--- a/chalk-engine/src/stack.rs
+++ b/chalk-engine/src/stack.rs
@@ -8,11 +8,20 @@ use std::ops::{Index, IndexMut, Range};
 pub(crate) struct Stack<C: Context> {
     /// Stack: as described above, stores the in-progress goals.
     stack: Vec<StackEntry<C>>,
+
+    /// This is a clock which always increases. It is
+    /// incremented every time a new subgoal is followed.
+    /// This effectively gives us way to track what depth
+    /// and loop a table or strand was last followed.
+    clock: TimeStamp,
 }
 
 impl<C: Context> Default for Stack<C> {
     fn default() -> Self {
-        Stack { stack: vec![] }
+        Stack {
+            stack: vec![],
+            clock: Default::default(),
+        }
     }
 }
 
@@ -67,13 +76,15 @@ impl<C: Context> Stack<C> {
         depth..StackIndex::from(self.stack.len())
     }
 
-    pub(super) fn push(
-        &mut self,
-        table: TableIndex,
-        clock: TimeStamp,
-        cyclic_minimums: Minimums,
-    ) -> StackIndex {
+    // Gets the next clock TimeStamp. This will never decrease.
+    fn increment_clock(&mut self) -> TimeStamp {
+        self.clock.increment();
+        self.clock
+    }
+
+    pub(super) fn push(&mut self, table: TableIndex, cyclic_minimums: Minimums) -> StackIndex {
         let old_len = self.stack.len();
+        let clock = self.increment_clock();
         self.stack.push(StackEntry {
             table,
             clock,

--- a/chalk-engine/src/stack.rs
+++ b/chalk-engine/src/stack.rs
@@ -83,9 +83,15 @@ impl<C: Context> Stack<C> {
         StackIndex::from(old_len)
     }
 
-    pub(super) fn pop(&mut self, depth: StackIndex) -> Option<StackIndex> {
+    /// Pops the top-most entry from the stack.
+    pub(super) fn pop(&mut self, depth: StackIndex) {
         assert_eq!(self.stack.len(), depth.value + 1);
         self.stack.pop();
+    }
+
+    /// Returns the index of the top of the stack, or None if the
+    /// stack is empty.
+    pub(super) fn top_depth(&self) -> Option<StackIndex> {
         if !self.stack.is_empty() {
             Some(StackIndex::from(self.stack.len() - 1))
         } else {

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -3,6 +3,16 @@ use crate::table::AnswerIndex;
 use crate::{ExClause, TableIndex, TimeStamp};
 use std::fmt::{Debug, Error, Formatter};
 
+#[derive(Debug)]
+pub(crate) struct CanonicalStrand<C: Context> {
+    pub(super) canonical_ex_clause: C::CanonicalExClause,
+
+    /// Index into `ex_clause.subgoals`.
+    pub(crate) selected_subgoal: Option<SelectedSubgoal<C>>,
+
+    pub(crate) last_pursued_time: TimeStamp,
+}
+
 pub(crate) struct Strand<C: Context> {
     pub(super) infer: C::InferenceTable,
 

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -1,6 +1,6 @@
 use crate::context::Context;
 use crate::table::AnswerIndex;
-use crate::{ExClause, TableIndex};
+use crate::{ExClause, TableIndex, TimeStamp};
 use std::fmt::{Debug, Error, Formatter};
 
 pub(crate) struct Strand<C: Context> {
@@ -10,6 +10,8 @@ pub(crate) struct Strand<C: Context> {
 
     /// Index into `ex_clause.subgoals`.
     pub(crate) selected_subgoal: Option<SelectedSubgoal<C>>,
+
+    pub(crate) last_pursued_time: TimeStamp,
 }
 
 #[derive(Clone, Debug)]

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -3,14 +3,6 @@ use crate::table::AnswerIndex;
 use crate::{ExClause, TableIndex};
 use std::fmt::{Debug, Error, Formatter};
 
-#[derive(Debug)]
-pub(crate) struct CanonicalStrand<C: Context> {
-    pub(super) canonical_ex_clause: C::CanonicalExClause,
-
-    /// Index into `ex_clause.subgoals`.
-    pub(crate) selected_subgoal: Option<SelectedSubgoal<C>>,
-}
-
 pub(crate) struct Strand<C: Context> {
     pub(super) infer: C::InferenceTable,
 

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -56,7 +56,8 @@ impl<C: Context> Table<C> {
         }
     }
 
-    pub(crate) fn push_strand(&mut self, strand: CanonicalStrand<C>) {
+    /// Push a strand to the back of the queue of strands to be processed.
+    pub(crate) fn enqueue_strand(&mut self, strand: CanonicalStrand<C>) {
         self.strands.push_back(strand);
     }
 
@@ -68,7 +69,9 @@ impl<C: Context> Table<C> {
         mem::replace(&mut self.strands, VecDeque::new())
     }
 
-    pub(crate) fn pop_next_strand_if(
+    /// Remove the next strand from the queue as long as it meets the
+    /// given criteria.
+    pub(crate) fn dequeue_next_strand_if(
         &mut self,
         test: impl Fn(&CanonicalStrand<C>) -> bool,
     ) -> Option<CanonicalStrand<C>> {

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -1,5 +1,5 @@
 use crate::context::prelude::*;
-use crate::strand::CanonicalStrand;
+use crate::strand::Strand;
 use crate::Answer;
 use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
@@ -32,7 +32,7 @@ pub(crate) struct Table<C: Context> {
 
     /// Stores the active strands that we can "pull on" to find more
     /// answers.
-    strands: VecDeque<CanonicalStrand<C>>,
+    strands: VecDeque<Strand<C>>,
 }
 
 index_struct! {
@@ -56,23 +56,23 @@ impl<C: Context> Table<C> {
         }
     }
 
-    pub(crate) fn push_strand(&mut self, strand: CanonicalStrand<C>) {
+    pub(crate) fn push_strand(&mut self, strand: Strand<C>) {
         self.strands.push_back(strand);
     }
 
-    pub(crate) fn extend_strands(&mut self, strands: impl IntoIterator<Item = CanonicalStrand<C>>) {
+    pub(crate) fn extend_strands(&mut self, strands: impl IntoIterator<Item = Strand<C>>) {
         self.strands.extend(strands);
     }
 
-    pub(crate) fn strands_mut(&mut self) -> impl Iterator<Item = &mut CanonicalStrand<C>> {
+    pub(crate) fn strands_mut(&mut self) -> impl Iterator<Item = &mut Strand<C>> {
         self.strands.iter_mut()
     }
 
-    pub(crate) fn take_strands(&mut self) -> VecDeque<CanonicalStrand<C>> {
+    pub(crate) fn take_strands(&mut self) -> VecDeque<Strand<C>> {
         mem::replace(&mut self.strands, VecDeque::new())
     }
 
-    pub(crate) fn pop_next_strand(&mut self) -> Option<CanonicalStrand<C>> {
+    pub(crate) fn pop_next_strand(&mut self) -> Option<Strand<C>> {
         self.strands.pop_front()
     }
 

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -1,5 +1,5 @@
 use crate::context::prelude::*;
-use crate::strand::Strand;
+use crate::strand::CanonicalStrand;
 use crate::Answer;
 use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
@@ -32,7 +32,7 @@ pub(crate) struct Table<C: Context> {
 
     /// Stores the active strands that we can "pull on" to find more
     /// answers.
-    strands: VecDeque<Strand<C>>,
+    strands: VecDeque<CanonicalStrand<C>>,
 }
 
 index_struct! {
@@ -56,22 +56,22 @@ impl<C: Context> Table<C> {
         }
     }
 
-    pub(crate) fn push_strand(&mut self, strand: Strand<C>) {
+    pub(crate) fn push_strand(&mut self, strand: CanonicalStrand<C>) {
         self.strands.push_back(strand);
     }
 
-    pub(crate) fn strands_mut(&mut self) -> impl Iterator<Item = &mut Strand<C>> {
+    pub(crate) fn strands_mut(&mut self) -> impl Iterator<Item = &mut CanonicalStrand<C>> {
         self.strands.iter_mut()
     }
 
-    pub(crate) fn take_strands(&mut self) -> VecDeque<Strand<C>> {
+    pub(crate) fn take_strands(&mut self) -> VecDeque<CanonicalStrand<C>> {
         mem::replace(&mut self.strands, VecDeque::new())
     }
 
     pub(crate) fn pop_next_strand_if(
         &mut self,
-        test: impl Fn(&Strand<C>) -> bool,
-    ) -> Option<Strand<C>> {
+        test: impl Fn(&CanonicalStrand<C>) -> bool,
+    ) -> Option<CanonicalStrand<C>> {
         let strand = self.strands.pop_front();
         if let Some(strand) = strand {
             if test(&strand) {

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -60,10 +60,6 @@ impl<C: Context> Table<C> {
         self.strands.push_back(strand);
     }
 
-    pub(crate) fn extend_strands(&mut self, strands: impl IntoIterator<Item = Strand<C>>) {
-        self.strands.extend(strands);
-    }
-
     pub(crate) fn strands_mut(&mut self) -> impl Iterator<Item = &mut Strand<C>> {
         self.strands.iter_mut()
     }
@@ -72,8 +68,18 @@ impl<C: Context> Table<C> {
         mem::replace(&mut self.strands, VecDeque::new())
     }
 
-    pub(crate) fn pop_next_strand(&mut self) -> Option<Strand<C>> {
-        self.strands.pop_front()
+    pub(crate) fn pop_next_strand_if(
+        &mut self,
+        test: impl Fn(&Strand<C>) -> bool,
+    ) -> Option<Strand<C>> {
+        let strand = self.strands.pop_front();
+        if let Some(strand) = strand {
+            if test(&strand) {
+                return Some(strand);
+            }
+            self.strands.push_front(strand);
+        }
+        None
     }
 
     /// Mark the table as floundered -- this also discards all pre-existing answers,

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -662,7 +662,7 @@ where
             ambiguous,
             constraints,
             subgoals,
-            current_time,
+            answer_time,
             floundered_subgoals,
         } = self;
         Ok(ExClause {
@@ -670,7 +670,7 @@ where
             ambiguous: *ambiguous,
             constraints: constraints.fold_with(folder, binders)?,
             subgoals: subgoals.fold_with(folder, binders)?,
-            current_time: current_time.fold_with(folder, binders)?,
+            answer_time: answer_time.fold_with(folder, binders)?,
             floundered_subgoals: floundered_subgoals.fold_with(folder, binders)?,
         })
     }

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -60,6 +60,7 @@ pub struct TruncatingInferenceTable<TF: TypeFamily> {
 
 impl<TF: TypeFamily> context::Context for SlgContext<TF> {
     type CanonicalGoalInEnvironment = Canonical<InEnvironment<Goal<TF>>>;
+    type CanonicalExClause = Canonical<ExClause<Self>>;
     type UCanonicalGoalInEnvironment = UCanonical<InEnvironment<Goal<TF>>>;
     type UniverseMap = UniverseMap;
     type InferenceNormalizedSubst = Substitution<TF>;
@@ -85,11 +86,17 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
         InEnvironment::new(environment, goal)
     }
 
+    fn inference_normalized_subst_from_ex_clause(
+        canon_ex_clause: &Canonical<ExClause<SlgContext<TF>>>,
+    ) -> &Substitution<TF> {
+        &canon_ex_clause.value.subst
+    }
+
     fn empty_constraints(ccs: &Canonical<ConstrainedSubst<TF>>) -> bool {
         ccs.value.constraints.is_empty()
     }
 
-    fn subst_from_canonical_subst(
+    fn inference_normalized_subst_from_subst(
         ccs: &Canonical<ConstrainedSubst<TF>>,
     ) -> &Substitution<TF> {
         &ccs.value.subst
@@ -106,6 +113,10 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
         canonical_subst: &Canonical<ConstrainedSubst<TF>>,
     ) -> bool {
         u_canon.is_trivial_substitution(canonical_subst)
+    }
+
+    fn num_universes(u_canon: &UCanonical<InEnvironment<Goal<TF>>>) -> usize {
+        u_canon.universes
     }
 
     fn map_goal_from_canonical(
@@ -196,6 +207,17 @@ impl<'me, TF: TypeFamily> context::ContextOps<SlgContext<TF>> for SlgContextOps<
             InferenceTable::from_canonical(arg.universes, &arg.canonical);
         let infer_table = TruncatingInferenceTable::new(self.max_size, infer);
         op(infer_table, subst, environment, goal)
+    }
+
+    fn instantiate_ex_clause(
+        &self,
+        num_universes: usize,
+        canonical_ex_clause: &Canonical<ExClause<SlgContext<TF>>>,
+    ) -> (TruncatingInferenceTable<TF>, ExClause<SlgContext<TF>>) {
+        let (infer, _subst, ex_cluse) =
+            InferenceTable::from_canonical(num_universes, canonical_ex_clause);
+        let infer_table = TruncatingInferenceTable::new(self.max_size, infer);
+        (infer_table, ex_cluse)
     }
 
     fn constrained_subst_from_answer(
@@ -303,6 +325,13 @@ impl<TF: TypeFamily> context::UnificationOps<SlgContext<TF>> for TruncatingInfer
         (quantified, universes)
     }
 
+    fn canonicalize_ex_clause(
+        &mut self,
+        value: &ExClause<SlgContext<TF>>,
+    ) -> Canonical<ExClause<SlgContext<TF>>> {
+        self.infer.canonicalize(value).quantified
+    }
+
     fn canonicalize_constrained_subst(
         &mut self,
         subst: Substitution<TF>,
@@ -378,27 +407,35 @@ impl MayInvalidate {
     // Returns true if the two types could be unequal.
     fn aggregate_tys<TF: TypeFamily>(&mut self, new: &Ty<TF>, current: &Ty<TF>) -> bool {
         match (new.data(), current.data()) {
-            (_, TyData::InferenceVar(_)) => {
+            (_, TyData::BoundVar(_)) => {
                 // If the aggregate solution already has an inference
                 // variable here, then no matter what type we produce,
                 // the aggregate cannot get 'more generalized' than it
                 // already is. So return false, we cannot invalidate.
+                //
+                // (Note that "inference variables" show up as *bound
+                // variables* here, because we are looking at the
+                // canonical form.)
                 false
             }
 
-            (TyData::InferenceVar(_), _) => {
+            (TyData::BoundVar(_), _) => {
                 // If we see a type variable in the potential future
                 // solution, we have to be conservative. We don't know
                 // what type variable will wind up being! Remember
                 // that the future solution could be any instantiation
                 // of `ty0` -- or it could leave this variable
                 // unbound, if the result is true for all types.
+                //
+                // (Note that "inference variables" show up as *bound
+                // variables* here, because we are looking at the
+                // canonical form.)
                 true
             }
 
-            (TyData::BoundVar(_), _) | (_, TyData::BoundVar(_)) => {
+            (TyData::InferenceVar(_), _) | (_, TyData::InferenceVar(_)) => {
                 panic!(
-                    "unexpected bound variable in may-invalidate: {:?} vs {:?}",
+                    "unexpected free inference variable in may-invalidate: {:?} vs {:?}",
                     new, current,
                 );
             }

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -61,7 +61,7 @@ impl<TF: TypeFamily> context::ResolventOps<SlgContext<TF>> for TruncatingInferen
         goal: &DomainGoal<TF>,
         subst: &Substitution<TF>,
         clause: &ProgramClause<TF>,
-    ) -> Fallible<Canonical<ExClause<SlgContext<TF>>>> {
+    ) -> Fallible<ExClause<SlgContext<TF>>> {
         // Relating the above description to our situation:
         //
         // - `goal` G, except with binders for any existential variables.
@@ -75,8 +75,6 @@ impl<TF: TypeFamily> context::ResolventOps<SlgContext<TF>> for TruncatingInferen
             goal,
             clause,
         );
-
-        let snapshot = self.infer.snapshot();
 
         // C' in the description above is `consequence :- conditions`.
         //
@@ -117,11 +115,7 @@ impl<TF: TypeFamily> context::ResolventOps<SlgContext<TF>> for TruncatingInferen
                 c => Literal::Positive(InEnvironment::new(environment, c)),
             }));
 
-        let canonical_ex_clause = self.infer.canonicalize(&ex_clause).quantified;
-
-        self.infer.rollback_to(snapshot);
-
-        Ok(canonical_ex_clause)
+        Ok(ex_clause)
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -100,7 +100,7 @@ impl<TF: TypeFamily> context::ResolventOps<SlgContext<TF>> for TruncatingInferen
             ambiguous: false,
             constraints: vec![],
             subgoals: vec![],
-            current_time: TimeStamp::default(),
+            answer_time: TimeStamp::default(),
             floundered_subgoals: vec![],
         };
 

--- a/tests/test/slg.rs
+++ b/tests/test/slg.rs
@@ -84,7 +84,7 @@ fn solve_goal_fixed_num_answers(program_text: &str, goals: Vec<(usize, usize, &s
 }
 
 #[test]
-fn basic1() {
+fn basic() {
     test! {
         program {
             trait Sized { }

--- a/tests/test/slg.rs
+++ b/tests/test/slg.rs
@@ -294,7 +294,8 @@ fn only_draw_so_many_blow_up() {
 
         goal {
             exists<T> { T: Foo }
-        } fixed 2 with max 10 {
+        } fixed 767 with max 10 {
+            // FIXME: should be 2?
             "Some(Ambig(Definite(Canonical { value: [?0 := Vec<^0>], binders: [Ty(U0)] })))"
         }
     }

--- a/tests/test/slg.rs
+++ b/tests/test/slg.rs
@@ -294,8 +294,7 @@ fn only_draw_so_many_blow_up() {
 
         goal {
             exists<T> { T: Foo }
-        } fixed 767 with max 10 {
-            // FIXME: should be 2?
+        } fixed 2 with max 10 {
             "Some(Ambig(Definite(Canonical { value: [?0 := Vec<^0>], binders: [Ty(U0)] })))"
         }
     }

--- a/tests/test/slg.rs
+++ b/tests/test/slg.rs
@@ -84,7 +84,7 @@ fn solve_goal_fixed_num_answers(program_text: &str, goals: Vec<(usize, usize, &s
 }
 
 #[test]
-fn basic() {
+fn basic1() {
     test! {
         program {
             trait Sized { }


### PR DESCRIPTION
Basically all of `pursue_strand`, `pursue_next_strand`, `incorporate_result_from_positive_subgoal`, and `incorporate_result_from_negative_subgoal` got merged into the one function, with changes made to make it iterative.

Right now, a lot of code has not been moved into separate functions, but I'm definitely working on this. All in all, it's a bit more LOC, but I've also added in a lot of documentation/comments to help follow what's happening.