### PR TITLE
Change QuantifiedTy to QuantifiedApply

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1037,7 +1037,7 @@ impl LowerTy for Ty {
                         .map(|id| chalk_ir::ParameterKind::Lifetime(id.str)),
                 )?;
 
-                let quantified_ty = chalk_ir::QuantifiedApply {
+                let quantified_ty = chalk_ir::Fn {
                     num_binders: lifetime_names.len(),
                     parameters: vec![ty.lower(&quantified_env)?.cast()],
                 };

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1041,7 +1041,7 @@ impl LowerTy for Ty {
                     num_binders: lifetime_names.len(),
                     parameters: vec![ty.lower(&quantified_env)?.cast()],
                 };
-                Ok(chalk_ir::TyData::ForAll(quantified_ty).intern())
+                Ok(chalk_ir::TyData::Function(quantified_ty).intern())
             }
         }
     }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1037,10 +1037,9 @@ impl LowerTy for Ty {
                         .map(|id| chalk_ir::ParameterKind::Lifetime(id.str)),
                 )?;
 
-                let ty = ty.lower(&quantified_env)?;
-                let quantified_ty = chalk_ir::QuantifiedTy {
+                let quantified_ty = chalk_ir::QuantifiedApply {
                     num_binders: lifetime_names.len(),
-                    ty,
+                    parameters: vec![ty.lower(&quantified_env)?.cast()],
                 };
                 Ok(chalk_ir::TyData::ForAll(quantified_ty).intern())
             }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1037,11 +1037,11 @@ impl LowerTy for Ty {
                         .map(|id| chalk_ir::ParameterKind::Lifetime(id.str)),
                 )?;
 
-                let quantified_ty = chalk_ir::Fn {
+                let function = chalk_ir::Fn {
                     num_binders: lifetime_names.len(),
                     parameters: vec![ty.lower(&quantified_env)?.cast()],
                 };
-                Ok(chalk_ir::TyData::Function(quantified_ty).intern())
+                Ok(chalk_ir::TyData::Function(function).intern())
             }
         }
     }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -81,10 +81,10 @@ impl Debug for InferenceVar {
     }
 }
 
-impl<TF: TypeFamily> Debug for QuantifiedApply<TF> {
+impl<TF: TypeFamily> Debug for Fn<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         // FIXME -- we should introduce some names or something here
-        let QuantifiedApply {
+        let Fn {
             num_binders,
             parameters,
         } = self;

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -63,7 +63,7 @@ impl<TF: TypeFamily> Debug for TyData<TF> {
             TyData::Apply(apply) => write!(fmt, "{:?}", apply),
             TyData::Projection(proj) => write!(fmt, "{:?}", proj),
             TyData::Placeholder(index) => write!(fmt, "{:?}", index),
-            TyData::ForAll(quantified_ty) => write!(fmt, "{:?}", quantified_ty),
+            TyData::Function(quantified_ty) => write!(fmt, "{:?}", quantified_ty),
         }
     }
 }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -81,11 +81,14 @@ impl Debug for InferenceVar {
     }
 }
 
-impl<TF: TypeFamily> Debug for QuantifiedTy<TF> {
+impl<TF: TypeFamily> Debug for QuantifiedApply<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         // FIXME -- we should introduce some names or something here
-        let QuantifiedTy { num_binders, ty } = self;
-        write!(fmt, "for<{}> {:?}", num_binders, ty)
+        let QuantifiedApply {
+            num_binders,
+            parameters,
+        } = self;
+        write!(fmt, "for<{}> {:?}", num_binders, parameters)
     }
 }
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -63,7 +63,7 @@ impl<TF: TypeFamily> Debug for TyData<TF> {
             TyData::Apply(apply) => write!(fmt, "{:?}", apply),
             TyData::Projection(proj) => write!(fmt, "{:?}", proj),
             TyData::Placeholder(index) => write!(fmt, "{:?}", index),
-            TyData::Function(quantified_ty) => write!(fmt, "{:?}", quantified_ty),
+            TyData::Function(function) => write!(fmt, "{:?}", function),
         }
     }
 }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -324,9 +324,7 @@ where
         TyData::Projection(proj) => {
             Ok(TyData::Projection(proj.fold_with(folder, binders)?).intern())
         }
-        TyData::Function(quantified_ty) => {
-            Ok(TyData::Function(quantified_ty.fold_with(folder, binders)?).intern())
-        }
+        TyData::Function(fun) => Ok(TyData::Function(fun.fold_with(folder, binders)?).intern()),
     }
 }
 

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -324,8 +324,8 @@ where
         TyData::Projection(proj) => {
             Ok(TyData::Projection(proj.fold_with(folder, binders)?).intern())
         }
-        TyData::ForAll(quantified_ty) => {
-            Ok(TyData::ForAll(quantified_ty.fold_with(folder, binders)?).intern())
+        TyData::Function(quantified_ty) => {
+            Ok(TyData::Function(quantified_ty.fold_with(folder, binders)?).intern())
         }
     }
 }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -345,7 +345,7 @@ impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for Ty<TF> {
     }
 }
 
-pub fn super_fold_lifetime<TF: TypeFamily, TTF: TargetTypeFamily<TF>>(
+pub fn super_fold_lifetime<TF: TypeFamily, TTF: TypeFamily>(
     folder: &mut dyn Folder<TF, TTF>,
     lifetime: &Lifetime<TF>,
     binders: usize,

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -6,18 +6,18 @@
 use crate::family::TargetTypeFamily;
 use crate::*;
 
-impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for QuantifiedApply<TF> {
-    type Result = QuantifiedApply<TTF>;
+impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for Fn<TF> {
+    type Result = Fn<TTF>;
     fn fold_with(
         &self,
         folder: &mut dyn Folder<TF, TTF>,
         binders: usize,
     ) -> Fallible<Self::Result> {
-        let QuantifiedApply {
+        let Fn {
             num_binders,
             ref parameters,
         } = *self;
-        Ok(QuantifiedApply {
+        Ok(Fn {
             num_binders,
             parameters: parameters.fold_with(folder, binders + num_binders)?,
         })

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -6,20 +6,20 @@
 use crate::family::TargetTypeFamily;
 use crate::*;
 
-impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for QuantifiedTy<TF> {
-    type Result = QuantifiedTy<TTF>;
+impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for QuantifiedApply<TF> {
+    type Result = QuantifiedApply<TTF>;
     fn fold_with(
         &self,
         folder: &mut dyn Folder<TF, TTF>,
         binders: usize,
     ) -> Fallible<Self::Result> {
-        let QuantifiedTy {
+        let QuantifiedApply {
             num_binders,
-            ref ty,
+            ref parameters,
         } = *self;
-        Ok(QuantifiedTy {
+        Ok(QuantifiedApply {
             num_binders,
-            ty: ty.fold_with(folder, binders + num_binders)?,
+            parameters: parameters.fold_with(folder, binders + num_binders)?,
         })
     }
 }

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -14,21 +14,6 @@ impl<'s, TF: TypeFamily> Subst<'s, TF> {
     }
 }
 
-impl<TF: TypeFamily> QuantifiedApply<TF> {
-    pub fn substitute(&self, parameters: &[Parameter<TF>]) -> Ty<TF> {
-        assert_eq!(self.num_binders, parameters.len());
-        TyData::ForAll(Self {
-            num_binders: self.num_binders,
-            parameters: self
-                .parameters
-                .iter()
-                .map(|p| Subst::apply(parameters, &p))
-                .collect(),
-        })
-        .intern()
-    }
-}
-
 impl<'b, TF: TypeFamily> DefaultTypeFolder for Subst<'b, TF> {}
 
 impl<'b, TF: TypeFamily> FreeVarFolder<TF> for Subst<'b, TF> {

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -14,10 +14,18 @@ impl<'s, TF: TypeFamily> Subst<'s, TF> {
     }
 }
 
-impl<TF: TypeFamily> QuantifiedTy<TF> {
+impl<TF: TypeFamily> QuantifiedApply<TF> {
     pub fn substitute(&self, parameters: &[Parameter<TF>]) -> Ty<TF> {
         assert_eq!(self.num_binders, parameters.len());
-        Subst::apply(parameters, &self.ty)
+        TyData::ForAll(Self {
+            num_binders: self.num_binders,
+            parameters: self
+                .parameters
+                .iter()
+                .map(|p| Subst::apply(parameters, &p))
+                .collect(),
+        })
+        .intern()
     }
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -267,7 +267,7 @@ pub enum TyData<TF: TypeFamily> {
     /// from the underlying type, so technically we can represent
     /// things like `for<'a> SomeStruct<'a>`, although that has no
     /// meaning in Rust.
-    ForAll(QuantifiedApply<TF>),
+    ForAll(Fn<TF>),
 
     /// References the binding at the given depth. The index is a [de
     /// Bruijn index], so it counts back through the in-scope binders,
@@ -345,7 +345,7 @@ impl InferenceVar {
 /// for<'a...'z> X -- all binders are instantiated at once,
 /// and we use deBruijn indices within `self.ty`
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasTypeFamily)]
-pub struct QuantifiedApply<TF: TypeFamily> {
+pub struct Fn<TF: TypeFamily> {
     pub num_binders: usize,
     pub parameters: Vec<Parameter<TF>>,
 }

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -267,7 +267,7 @@ pub enum TyData<TF: TypeFamily> {
     /// from the underlying type, so technically we can represent
     /// things like `for<'a> SomeStruct<'a>`, although that has no
     /// meaning in Rust.
-    ForAll(Fn<TF>),
+    Function(Fn<TF>),
 
     /// References the binding at the given depth. The index is a [de
     /// Bruijn index], so it counts back through the in-scope binders,

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -267,7 +267,7 @@ pub enum TyData<TF: TypeFamily> {
     /// from the underlying type, so technically we can represent
     /// things like `for<'a> SomeStruct<'a>`, although that has no
     /// meaning in Rust.
-    ForAll(QuantifiedTy<TF>),
+    ForAll(QuantifiedApply<TF>),
 
     /// References the binding at the given depth. The index is a [de
     /// Bruijn index], so it counts back through the in-scope binders,
@@ -345,9 +345,9 @@ impl InferenceVar {
 /// for<'a...'z> X -- all binders are instantiated at once,
 /// and we use deBruijn indices within `self.ty`
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasTypeFamily)]
-pub struct QuantifiedTy<TF: TypeFamily> {
+pub struct QuantifiedApply<TF: TypeFamily> {
     pub num_binders: usize,
-    pub ty: Ty<TF>,
+    pub parameters: Vec<Parameter<TF>>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasTypeFamily)]

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -260,13 +260,10 @@ pub enum TyData<TF: TypeFamily> {
     /// trait and all its parameters are fully known.
     Projection(ProjectionTy<TF>),
 
-    /// A "higher-ranked" type. In the Rust surface syntax, this can
-    /// only be a function type (e.g., `for<'a> fn(&'a u32)`) or a dyn
-    /// type (e.g., `dyn for<'a> SomeTrait<&'a u32>`). However, in
-    /// Chalk's representation, we separate out the `for<'a>` part
-    /// from the underlying type, so technically we can represent
-    /// things like `for<'a> SomeStruct<'a>`, although that has no
-    /// meaning in Rust.
+    /// A function type such as `for<'a> fn(&'a u32)`.
+    /// Note that "higher-ranked" types (starting with `for<>`) are either
+    /// function types or dyn types, and do not appear otherwise in Rust
+    /// surface syntax.
     Function(Fn<TF>),
 
     /// References the binding at the given depth. The index is a [de

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -9,9 +9,10 @@ macro_rules! ty {
         }).intern()
     };
 
-    (for_all $n:tt $t:tt) => {
-        $crate::TyData::ForAll(QuantifiedTy {
+    (for_all $n:tt ($arg:tt)*) => {
+        $crate::TyData::ForAll(Fn {
             num_binders: $n,
+            parameters: vec![$(arg!($arg)),*],
             ty: ty!($t),
         }).intern()
     };

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -9,11 +9,10 @@ macro_rules! ty {
         }).intern()
     };
 
-    (for_all $n:tt ($arg:tt)*) => {
-        $crate::TyData::ForAll(Fn {
+    (function $n:tt $($arg:tt)*) => {
+        $crate::TyData::Function(Fn {
             num_binders: $n,
             parameters: vec![$(arg!($arg)),*],
-            ty: ty!($t),
         }).intern()
     };
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -165,7 +165,7 @@ AssocTyValue: AssocTyValue = {
 };
 
 pub Ty: Ty = {
-    "for" "<" <l:Comma<LifetimeId>> ">" <t:Ty> => Ty::ForAll {
+    "for" "<" <l:Comma<LifetimeId>> ">" "fn" "(" <t:Ty> ")" => Ty::ForAll {
         lifetime_names: l,
         ty: Box::new(t)
     },

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -174,6 +174,10 @@ pub Ty: Ty = {
 
 TyWithoutFor: Ty = {
     <n:Id> => Ty::Id { name: n},
+    "fn" "(" <t:Ty> ")" => Ty::ForAll {
+        lifetime_names: vec![],
+        ty: Box::new(t)
+    },
     "dyn" <b:Plus<QuantifiedInlineBound>> => Ty::Dyn {
         bounds: b,
     },

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -341,7 +341,7 @@ fn match_ty<TF: TypeFamily>(
             .db
             .associated_ty_data(projection_ty.associated_ty_id)
             .to_program_clauses(builder),
-        TyData::ForAll(quantified_ty) => quantified_ty
+        TyData::Function(quantified_ty) => quantified_ty
             .parameters
             .iter()
             .map(|p| p.assert_ty_ref())

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -341,7 +341,11 @@ fn match_ty<TF: TypeFamily>(
             .db
             .associated_ty_data(projection_ty.associated_ty_id)
             .to_program_clauses(builder),
-        TyData::ForAll(quantified_ty) => match_ty(builder, environment, &quantified_ty.ty),
+        TyData::ForAll(quantified_ty) => quantified_ty
+            .parameters
+            .iter()
+            .map(|p| p.assert_ty_ref())
+            .for_each(|ty| match_ty(builder, environment, &ty)),
         TyData::BoundVar(_) => {}
         TyData::InferenceVar(_) => panic!("should have floundered"),
         TyData::Dyn(_) => {}

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -64,7 +64,7 @@ impl<'me, TF: TypeFamily> EnvElaborator<'me, TF> {
             // bounds story around `dyn Trait` types.
             TyData::Dyn(_) => (),
 
-            TyData::ForAll(_) | TyData::BoundVar(_) | TyData::InferenceVar(_) => (),
+            TyData::Function(_) | TyData::BoundVar(_) | TyData::InferenceVar(_) => (),
         }
     }
 

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -112,7 +112,7 @@ impl<'a, T> IntoBindersAndValue for &'a Binders<T> {
     }
 }
 
-impl<'a, TF> IntoBindersAndValue for &'a QuantifiedApply<TF>
+impl<'a, TF> IntoBindersAndValue for &'a Fn<TF>
 where
     TF: TypeFamily,
 {

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -112,12 +112,12 @@ impl<'a, T> IntoBindersAndValue for &'a Binders<T> {
     }
 }
 
-impl<'a, TF> IntoBindersAndValue for &'a QuantifiedTy<TF>
+impl<'a, TF> IntoBindersAndValue for &'a QuantifiedApply<TF>
 where
     TF: TypeFamily,
 {
     type Binders = std::iter::Map<std::ops::Range<usize>, fn(usize) -> chalk_ir::ParameterKind<()>>;
-    type Value = &'a Ty<TF>;
+    type Value = &'a Vec<Parameter<TF>>;
 
     fn into_binders_and_value(self) -> (Self::Binders, Self::Value) {
         fn make_lifetime(_: usize) -> ParameterKind<()> {
@@ -125,7 +125,7 @@ where
         }
 
         let p: fn(usize) -> ParameterKind<()> = make_lifetime;
-        ((0..self.num_binders).map(p), &self.ty)
+        ((0..self.num_binders).map(p), &self.parameters)
     }
 }
 

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -46,7 +46,7 @@ fn cycle_error() {
 
     // exists(A -> A = for<'a> A)
     table
-        .unify(&environment0, &a, &ty!(for_all 1 (infer 0)))
+        .unify(&environment0, &a, &ty!(function 1 (infer 0)))
         .unwrap_err();
 }
 
@@ -215,18 +215,18 @@ fn quantify_ty_under_binder() {
         .unify(&environment0, &v0.to_ty(), &v1.to_ty())
         .unwrap();
 
-    // Here: the `for_all` introduces 3 binders, so in the result,
+    // Here: the `function` introduces 3 binders, so in the result,
     // `(bound 3)` references the first canonicalized inference
     // variable. -- note that `infer 0` and `infer 1` have been
     // unified above, as well.
     assert_eq!(
         table
             .canonicalize(
-                &ty!(for_all 3 (apply (item 0) (bound 1) (infer 0) (infer 1) (lifetime (infer 2))))
+                &ty!(function 3 (apply (item 0) (bound 1) (infer 0) (infer 1) (lifetime (infer 2))))
             )
             .quantified,
         Canonical {
-            value: ty!(for_all 3 (apply (item 0) (bound 1) (bound 3) (bound 3) (lifetime (bound 4)))),
+            value: ty!(function 3 (apply (item 0) (bound 1) (bound 3) (bound 3) (lifetime (bound 4)))),
             binders: vec![ParameterKind::Ty(U0), ParameterKind::Lifetime(U0)],
         }
     );

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -110,26 +110,26 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
             (&TyData::InferenceVar(var), &TyData::Apply(_))
             | (&TyData::InferenceVar(var), &TyData::Placeholder(_))
             | (&TyData::InferenceVar(var), &TyData::Dyn(_))
-            | (&TyData::InferenceVar(var), &TyData::ForAll(_)) => self.unify_var_ty(var, b),
+            | (&TyData::InferenceVar(var), &TyData::Function(_)) => self.unify_var_ty(var, b),
 
             (&TyData::Apply(_), &TyData::InferenceVar(var))
             | (&TyData::Placeholder(_), &TyData::InferenceVar(var))
             | (&TyData::Dyn(_), &TyData::InferenceVar(var))
-            | (&TyData::ForAll(_), &TyData::InferenceVar(var)) => self.unify_var_ty(var, a),
+            | (&TyData::Function(_), &TyData::InferenceVar(var)) => self.unify_var_ty(var, a),
 
             // Unifying `forall<X> { T }` with some other forall type `forall<X> { U }`
-            (&TyData::ForAll(ref quantified_ty1), &TyData::ForAll(ref quantified_ty2)) => {
+            (&TyData::Function(ref quantified_ty1), &TyData::Function(ref quantified_ty2)) => {
                 self.unify_binders(quantified_ty1, quantified_ty2)
             }
 
             // This would correspond to unifying a `fn` type with a non-fn
             // type in Rust; error.
-            (&TyData::ForAll(_), &TyData::Apply(_))
-            | (&TyData::ForAll(_), &TyData::Dyn(_))
-            | (&TyData::ForAll(_), &TyData::Placeholder(_))
-            | (&TyData::Apply(_), &TyData::ForAll(_))
-            | (&TyData::Placeholder(_), &TyData::ForAll(_))
-            | (&TyData::Dyn(_), &TyData::ForAll(_)) => {
+            (&TyData::Function(_), &TyData::Apply(_))
+            | (&TyData::Function(_), &TyData::Dyn(_))
+            | (&TyData::Function(_), &TyData::Placeholder(_))
+            | (&TyData::Apply(_), &TyData::Function(_))
+            | (&TyData::Placeholder(_), &TyData::Function(_))
+            | (&TyData::Dyn(_), &TyData::Function(_)) => {
                 return Err(NoSolution);
             }
 
@@ -162,14 +162,14 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
             // Trait>::Item` with some other type `U`.
             (&TyData::Apply(_), &TyData::Projection(ref proj))
             | (&TyData::Placeholder(_), &TyData::Projection(ref proj))
-            | (&TyData::ForAll(_), &TyData::Projection(ref proj))
+            | (&TyData::Function(_), &TyData::Projection(ref proj))
             | (&TyData::InferenceVar(_), &TyData::Projection(ref proj))
             | (&TyData::Dyn(_), &TyData::Projection(ref proj)) => self.unify_projection_ty(proj, a),
 
             (&TyData::Projection(ref proj), &TyData::Projection(_))
             | (&TyData::Projection(ref proj), &TyData::Apply(_))
             | (&TyData::Projection(ref proj), &TyData::Placeholder(_))
-            | (&TyData::Projection(ref proj), &TyData::ForAll(_))
+            | (&TyData::Projection(ref proj), &TyData::Function(_))
             | (&TyData::Projection(ref proj), &TyData::InferenceVar(_))
             | (&TyData::Projection(ref proj), &TyData::Dyn(_)) => self.unify_projection_ty(proj, b),
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -77,19 +77,6 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
         })
     }
 
-    /// When we encounter a "sub-unification" problem that is in a distinct
-    /// environment, we invoke this routine.
-    fn sub_unify<T>(&mut self, ty1: T, ty2: T) -> Fallible<()>
-    where
-        T: Zip<TF> + Fold<TF>,
-    {
-        let sub_unifier = Unifier::new(self.table, &self.environment);
-        let UnificationResult { goals, constraints } = sub_unifier.unify(&ty1, &ty2)?;
-        self.goals.extend(goals);
-        self.constraints.extend(constraints);
-        Ok(())
-    }
-
     fn unify_ty_ty<'a>(&mut self, a: &'a Ty<TF>, b: &'a Ty<TF>) -> Fallible<()> {
         //         ^^                 ^^         ^^ FIXME rustc bug
         if let Some(n_a) = self.table.normalize_shallow(a) {
@@ -135,17 +122,15 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
                 self.unify_binders(quantified_ty1, quantified_ty2)
             }
 
-            // Unifying `forall<X> { T }` with some other type `U`
-            (&TyData::ForAll(ref quantified_ty), &TyData::Apply(_))
-            | (&TyData::ForAll(ref quantified_ty), &TyData::Placeholder(_))
-            | (&TyData::ForAll(ref quantified_ty), &TyData::Dyn(_)) => {
-                self.unify_forall_other(quantified_ty, b)
-            }
-
-            (&TyData::Apply(_), &TyData::ForAll(ref quantified_ty))
-            | (&TyData::Placeholder(_), &TyData::ForAll(ref quantified_ty))
-            | (&TyData::Dyn(_), &TyData::ForAll(ref quantified_ty)) => {
-                self.unify_forall_other(quantified_ty, a)
+            // This would correspond to unifying a `fn` type with a non-fn
+            // type in Rust; error.
+            (&TyData::ForAll(_), &TyData::Apply(_))
+            | (&TyData::ForAll(_), &TyData::Dyn(_))
+            | (&TyData::ForAll(_), &TyData::Placeholder(_))
+            | (&TyData::Apply(_), &TyData::ForAll(_))
+            | (&TyData::Placeholder(_), &TyData::ForAll(_))
+            | (&TyData::Dyn(_), &TyData::ForAll(_)) => {
+                return Err(NoSolution);
             }
 
             (&TyData::Placeholder(ref p1), &TyData::Placeholder(ref p2)) => {
@@ -241,26 +226,6 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
             }
             .cast(),
         )))
-    }
-
-    /// Unifying `forall<X> { T }` with some other type `U` --
-    /// to do so, we create a fresh placeholder `P` for `X` and
-    /// see if `[X/Px] T` can be unified with `U`. This should
-    /// almost never be true, actually, unless `X` is unused.
-    fn unify_forall_other(&mut self, ty1: &QuantifiedApply<TF>, ty2: &Ty<TF>) -> Fallible<()> {
-        let ui = self.table.new_universe();
-        let lifetimes1: Vec<_> = (0..ty1.num_binders)
-            .map(|idx| {
-                LifetimeData::Placeholder(PlaceholderIndex { ui, idx })
-                    .intern()
-                    .cast()
-            })
-            .collect();
-
-        let ty1 = ty1.substitute(&lifetimes1);
-        let ty2 = ty2.clone();
-
-        self.sub_unify(ty1, ty2)
     }
 
     /// Unify an inference variable `var` with some non-inference

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -118,8 +118,8 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
             | (&TyData::Function(_), &TyData::InferenceVar(var)) => self.unify_var_ty(var, a),
 
             // Unifying `forall<X> { T }` with some other forall type `forall<X> { U }`
-            (&TyData::Function(ref quantified_ty1), &TyData::Function(ref quantified_ty2)) => {
-                self.unify_binders(quantified_ty1, quantified_ty2)
+            (&TyData::Function(ref fn1), &TyData::Function(ref fn2)) => {
+                self.unify_binders(fn1, fn2)
             }
 
             // This would correspond to unifying a `fn` type with a non-fn

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -247,7 +247,7 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
     /// to do so, we create a fresh placeholder `P` for `X` and
     /// see if `[X/Px] T` can be unified with `U`. This should
     /// almost never be true, actually, unless `X` is unused.
-    fn unify_forall_other(&mut self, ty1: &QuantifiedTy<TF>, ty2: &Ty<TF>) -> Fallible<()> {
+    fn unify_forall_other(&mut self, ty1: &QuantifiedApply<TF>, ty2: &Ty<TF>) -> Fallible<()> {
         let ui = self.table.new_universe();
         let lifetimes1: Vec<_> = (0..ty1.num_binders)
             .map(|idx| {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -527,7 +527,7 @@ impl MayInvalidate {
             }
 
             // For everything else, be conservative here and just say we may invalidate.
-            (TyData::ForAll(_), _)
+            (TyData::Function(_), _)
             | (TyData::Dyn(_), _)
             | (TyData::Apply(_), _)
             | (TyData::Placeholder(_), _)

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -180,7 +180,7 @@ impl<TF: TypeFamily> AntiUnifier<'_, TF> {
             // kinda hard. Don't try to be smart for now, just plop a
             // variable in there and be done with it.
             (TyData::BoundVar(_), TyData::BoundVar(_))
-            | (TyData::ForAll(_), TyData::ForAll(_))
+            | (TyData::Function(_), TyData::Function(_))
             | (TyData::Dyn(_), TyData::Dyn(_)) => self.new_variable(),
 
             (TyData::Apply(apply1), TyData::Apply(apply2)) => {
@@ -199,7 +199,7 @@ impl<TF: TypeFamily> AntiUnifier<'_, TF> {
             (TyData::InferenceVar(_), _)
             | (TyData::BoundVar(_), _)
             | (TyData::Dyn(_), _)
-            | (TyData::ForAll(_), _)
+            | (TyData::Function(_), _)
             | (TyData::Apply(_), _)
             | (TyData::Projection(_), _)
             | (TyData::Placeholder(_), _) => self.new_variable(),

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -372,7 +372,7 @@ impl<TF: TypeFamily> Zipper<TF> for AnswerSubstitutor<'_, TF> {
                 Zip::zip_with(self, answer, pending)
             }
 
-            (TyData::ForAll(answer), TyData::ForAll(pending)) => {
+            (TyData::Function(answer), TyData::Function(pending)) => {
                 self.answer_binders += answer.num_binders;
                 self.pending_binders += pending.num_binders;
                 Zip::zip_with(self, &answer.parameters, &pending.parameters)?;
@@ -391,7 +391,7 @@ impl<TF: TypeFamily> Zipper<TF> for AnswerSubstitutor<'_, TF> {
             | (TyData::Dyn(_), _)
             | (TyData::Projection(_), _)
             | (TyData::Placeholder(_), _)
-            | (TyData::ForAll(_), _) => panic!(
+            | (TyData::Function(_), _) => panic!(
                 "structural mismatch between answer `{:?}` and pending goal `{:?}`",
                 answer, pending,
             ),

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -375,7 +375,7 @@ impl<TF: TypeFamily> Zipper<TF> for AnswerSubstitutor<'_, TF> {
             (TyData::ForAll(answer), TyData::ForAll(pending)) => {
                 self.answer_binders += answer.num_binders;
                 self.pending_binders += pending.num_binders;
-                Zip::zip_with(self, &answer.ty, &pending.ty)?;
+                Zip::zip_with(self, &answer.parameters, &pending.parameters)?;
                 self.answer_binders -= answer.num_binders;
                 self.pending_binders -= pending.num_binders;
                 Ok(())

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -256,7 +256,7 @@ fn truncate_normalizes_under_binders() {
     let _v0 = table.new_variable(u0);
 
     // ty0 = for<'a> Vec<Vec<X>>
-    let ty0 = ty!(for_all 1
+    let ty0 = ty!(function 1
                   (apply (item 0)
                    (apply (item 0)
                     (infer 0))));

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -90,7 +90,7 @@ impl<TF: TypeFamily> FoldInputTypes for Ty<TF> {
             // bounds, and these bounds will be enforced upon calling such a function. In some
             // sense, well-formedness requirements for the input types of an HKT will be enforced
             // lazily, so no need to include them here.
-            TyData::ForAll(..) => (),
+            TyData::Function(..) => (),
 
             TyData::InferenceVar(..) => {
                 panic!("unexpected inference variable in wf rules: {:?}", self)

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -379,9 +379,9 @@ fn duplicate_parameters() {
 
     lowering_error! {
         program {
-            struct fn<'a> { }
+            struct fun<'a> { }
             struct Foo<'a> {
-                a: for<'a> fn<'a>
+                a: for<'a> fn(fun<'a>)
             }
         } error_msg {
             "duplicate or shadowed parameters"

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -357,7 +357,7 @@ fn forall_projection() {
         }
 
         goal {
-            for<'a> <Unit as DropLt<'a>>::Item: Eq<Unit>
+            for<'a> <Unit as DropLt<'a>>::Item: Eq<for<> Unit>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
@@ -384,7 +384,7 @@ fn forall_projection_gat() {
 
         goal {
             forall<T> {
-                for<'a> <Unit as DropOuter<'a>>::Item<T>: Eq<Unit>
+                for<'a> <Unit as DropOuter<'a>>::Item<T>: Eq<for<> Unit>
             }
         } yields {
             "No possible solution"
@@ -393,7 +393,7 @@ fn forall_projection_gat() {
         goal {
             forall<T> {
                 if (T: Sized) {
-                    for<'a> <Unit as DropOuter<'a>>::Item<T>: Eq<Unit>
+                    for<'a> <Unit as DropOuter<'a>>::Item<T>: Eq<for<> Unit>
                 }
             }
         } yields {
@@ -411,7 +411,7 @@ fn forall_projection_gat() {
         goal {
             forall<T> {
                 if (T: Sized) {
-                    WellFormed(for<'a> <Unit as DropOuter<'a>>::Item<T>: Eq<Unit>)
+                    WellFormed(for<'a> <Unit as DropOuter<'a>>::Item<T>: Eq<for<> Unit>)
                 }
             }
         } yields {

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -357,7 +357,7 @@ fn forall_projection() {
         }
 
         goal {
-            for<'a> <Unit as DropLt<'a>>::Item: Eq<for<> Unit>
+            for<'a> fn(<Unit as DropLt<'a>>::Item): Eq<for<> fn(Unit)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
@@ -384,7 +384,7 @@ fn forall_projection_gat() {
 
         goal {
             forall<T> {
-                for<'a> <Unit as DropOuter<'a>>::Item<T>: Eq<for<> Unit>
+                for<'a> fn(<Unit as DropOuter<'a>>::Item<T>): Eq<for<> fn(Unit)>
             }
         } yields {
             "No possible solution"
@@ -393,7 +393,7 @@ fn forall_projection_gat() {
         goal {
             forall<T> {
                 if (T: Sized) {
-                    for<'a> <Unit as DropOuter<'a>>::Item<T>: Eq<for<> Unit>
+                    for<'a> fn(<Unit as DropOuter<'a>>::Item<T>): Eq<for<> fn(Unit)>
                 }
             }
         } yields {
@@ -411,7 +411,7 @@ fn forall_projection_gat() {
         goal {
             forall<T> {
                 if (T: Sized) {
-                    WellFormed(for<'a> <Unit as DropOuter<'a>>::Item<T>: Eq<for<> Unit>)
+                    WellFormed(for<'a> fn(<Unit as DropOuter<'a>>::Item<T>): Eq<for<> fn(Unit)>)
                 }
             }
         } yields {

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -357,7 +357,7 @@ fn forall_projection() {
         }
 
         goal {
-            for<'a> fn(<Unit as DropLt<'a>>::Item): Eq<for<> fn(Unit)>
+            for<'a> fn(<Unit as DropLt<'a>>::Item): Eq<fn(Unit)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
@@ -384,7 +384,7 @@ fn forall_projection_gat() {
 
         goal {
             forall<T> {
-                for<'a> fn(<Unit as DropOuter<'a>>::Item<T>): Eq<for<> fn(Unit)>
+                for<'a> fn(<Unit as DropOuter<'a>>::Item<T>): Eq<fn(Unit)>
             }
         } yields {
             "No possible solution"
@@ -393,7 +393,7 @@ fn forall_projection_gat() {
         goal {
             forall<T> {
                 if (T: Sized) {
-                    for<'a> fn(<Unit as DropOuter<'a>>::Item<T>): Eq<for<> fn(Unit)>
+                    for<'a> fn(<Unit as DropOuter<'a>>::Item<T>): Eq<fn(Unit)>
                 }
             }
         } yields {
@@ -411,7 +411,7 @@ fn forall_projection_gat() {
         goal {
             forall<T> {
                 if (T: Sized) {
-                    WellFormed(for<'a> fn(<Unit as DropOuter<'a>>::Item<T>): Eq<for<> fn(Unit)>)
+                    WellFormed(for<'a> fn(<Unit as DropOuter<'a>>::Item<T>): Eq<fn(Unit)>)
                 }
             }
         } yields {

--- a/tests/test/unify.rs
+++ b/tests/test/unify.rs
@@ -57,7 +57,7 @@ fn forall_equality() {
             // region constraints, since each region variable must
             // refer to exactly one placeholder region, and they are
             // all in a valid universe to do so (universe 4).
-            for<'a, 'b> Ref<'a, Ref<'b, Unit>>: Eq<for<'c, 'd> Ref<'c, Ref<'d, Unit>>>
+            for<'a, 'b> fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> fn(Ref<'c, Ref<'d, Unit>>)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
@@ -68,8 +68,8 @@ fn forall_equality() {
             //
             // Note that `?0` (in universe 2) must be equal to both
             // `!1_0` and `!1_1`, which of course it cannot be.
-            for<'a, 'b> Ref<'a, Ref<'b, Ref<'a, Unit>>>: Eq<
-                for<'c, 'd> Ref<'c, Ref<'d, Ref<'d, Unit>>>>
+            for<'a, 'b> fn(Ref<'a, Ref<'b, Ref<'a, Unit>>>): Eq<
+                for<'c, 'd> fn(Ref<'c, Ref<'d, Ref<'d, Unit>>>)>
         } yields {
             "Unique; substitution [], lifetime constraints [InEnvironment { environment: Env([]), goal: '!1_1 == '!1_0 }, InEnvironment { environment: Env([]), goal: '!2_1 == '!2_0 }]"
         }
@@ -130,7 +130,7 @@ fn equality_binder() {
         goal {
             forall<T> {
                 exists<'a> {
-                    for<'c> Ref<'c, T> = for<> Ref<'a, T>
+                    for<'c> fn(Ref<'c, T>) = for<> fn(Ref<'a, T>)
                 }
             }
         } yields {
@@ -150,13 +150,13 @@ fn equality_binder2() {
         }
 
         goal {
-            for<'b, 'c> Ref<'b, 'c> = for<'a> Ref<'a, 'a>
+            for<'b, 'c> fn(Ref<'b, 'c>) = for<'a> fn(Ref<'a, 'a>)
         } yields {
             "Unique; substitution [], lifetime constraints [InEnvironment { environment: Env([]), goal: '!1_1 == '!1_0 }]"
         }
 
         goal {
-            for<'a> Ref<'a, 'a> = for<'b, 'c> Ref<'b, 'c>
+            for<'a> fn(Ref<'a, 'a>) = for<'b, 'c> fn(Ref<'b, 'c>)
         } yields {
             "Unique; substitution [], lifetime constraints [InEnvironment { environment: Env([]), goal: '!2_0 == '!2_1 }]"
         }
@@ -275,25 +275,25 @@ fn quantified_types() {
     test! {
         program {
             trait Foo { }
-            struct fn<'a> { }
+            struct fn1<'a> { }
             struct fn2<'a, 'b> { }
-            impl Foo for for<'a> fn<'a> { }
+            impl Foo for for<'a> fn(fn1<'a>) { }
         }
 
         goal {
-            for<'a> fn<'a>: Foo
+            for<'a> fn(fn1<'a>): Foo
         } yields {
             "Unique"
         }
 
         goal {
-            for<'a, 'b> fn2<'a, 'b> = for<'b, 'a> fn2<'a, 'b>
+            for<'a, 'b> fn(fn2<'a, 'b>) = for<'b, 'a> fn(fn2<'a, 'b>)
         } yields {
             "Unique"
         }
 
         goal {
-            forall<'a> { for<> fn<'a>: Foo }
+            forall<'a> { for<> fn(fn1<'a>): Foo }
         } yields {
             // Lifetime constraints are unsatisfiable
             "Unique; substitution [], \

--- a/tests/test/unify.rs
+++ b/tests/test/unify.rs
@@ -130,7 +130,7 @@ fn equality_binder() {
         goal {
             forall<T> {
                 exists<'a> {
-                    for<'c> Ref<'c, T> = Ref<'a, T>
+                    for<'c> Ref<'c, T> = for<> Ref<'a, T>
                 }
             }
         } yields {
@@ -293,11 +293,11 @@ fn quantified_types() {
         }
 
         goal {
-            forall<'a> { fn<'a>: Foo }
+            forall<'a> { for<> fn<'a>: Foo }
         } yields {
             // Lifetime constraints are unsatisfiable
             "Unique; substitution [], \
-            lifetime constraints [InEnvironment { environment: Env([]), goal: '!2_0 == '!1_0 }]"
+            lifetime constraints [InEnvironment { environment: Env([]), goal: '!1_0 == '!3_0 }]"
         }
     }
 }

--- a/tests/test/unify.rs
+++ b/tests/test/unify.rs
@@ -130,7 +130,7 @@ fn equality_binder() {
         goal {
             forall<T> {
                 exists<'a> {
-                    for<'c> fn(Ref<'c, T>) = for<> fn(Ref<'a, T>)
+                    for<'c> fn(Ref<'c, T>) = fn(Ref<'a, T>)
                 }
             }
         } yields {
@@ -293,7 +293,7 @@ fn quantified_types() {
         }
 
         goal {
-            forall<'a> { for<> fn(fn1<'a>): Foo }
+            forall<'a> { fn(fn1<'a>): Foo }
         } yields {
             // Lifetime constraints are unsatisfiable
             "Unique; substitution [], \

--- a/tests/test/wf_lowering.rs
+++ b/tests/test/wf_lowering.rs
@@ -526,16 +526,16 @@ fn higher_ranked_inline_bound_on_gat() {
             struct Ref<'a, T> { }
             struct i32 {}
 
-            struct fn<T> { }
+            struct fun<T> { }
 
-            impl<'a, T> Fn<Ref<'a, T>> for for<'b> fn<Ref<'b, T>> { }
+            impl<'a, T> Fn<Ref<'a, T>> for for<'b> fn(fun<Ref<'b, T>>) { }
 
             trait Bar {
                 type Item<T>: forall<'a> Fn<Ref<'a, T>>;
             }
 
             impl Bar for i32 {
-                type Item<T> = for<'a> fn<Ref<'a, T>>;
+                type Item<T> = for<'a> fn(fun<Ref<'a, T>>);
             }
         }
     }
@@ -545,16 +545,16 @@ fn higher_ranked_inline_bound_on_gat() {
             trait Fn<T, U> { }
             struct i32 {}
 
-            struct fn<T, U> { }
+            struct fun<T, U> { }
 
-            impl<T, U> Fn<T, U> for fn<T, U> { }
+            impl<T, U> Fn<T, U> for fun<T, U> { }
 
             trait Bar {
                 type Item<T>: forall<U> Fn<T, U>;
             }
 
             impl Bar for i32 {
-                type Item<T> = fn<T, i32>;
+                type Item<T> = fun<T, i32>;
             }
         } error_msg {
             "trait impl for `Bar` does not meet well-formedness requirements"


### PR DESCRIPTION
Note: the `forall_projection` test is currently triggering a stack overflow, but I haven't been able to get a trace:
```
$ RUST_BACKTRACE=1 target/debug/chalk
?- program
Enter a program; press Ctrl-D when finished
| trait Eq<T> { }
| impl<T> Eq<T> for T { }
| 
| trait DropLt<'a> { type Item; }
| impl<'a, T> DropLt<'a> for T { type Item = T; }
| 
| struct Unit { }
| struct Ref<'a, T> { }
| 
?- for<'a> <Unit as DropLt<'a>>::Item: Eq<Unit>

thread 'main' has overflowed its stack
fatal runtime error: stack overflow
Aborted (core dumped)
```