### PR TITLE
When truncating a goal, don't truncate the environment

### DIFF
--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -240,10 +240,16 @@ impl<TF: TypeFamily> context::TruncateOps<SlgContext<TF>> for TruncatingInferenc
         &mut self,
         subgoal: &InEnvironment<Goal<TF>>,
     ) -> Option<InEnvironment<Goal<TF>>> {
+        // We only want to truncate the goal itself. We keep the environment intact.
+        // See rust-lang/chalk#280
+        let InEnvironment { environment, goal } = subgoal;
         let Truncated { overflow, value } =
-            truncate::truncate(&mut self.infer, self.max_size, subgoal);
+            truncate::truncate(&mut self.infer, self.max_size, goal);
         if overflow {
-            Some(value)
+            Some(InEnvironment {
+                environment: environment.clone(),
+                goal: value,
+            })
         } else {
             None
         }

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -115,7 +115,7 @@ macro_rules! test {
     ]) => {
         test!(@program[$program]
               @parsed_goals[$($parsed_goals)*
-                            $($((stringify!($goal), $C, $expected))+)+]
+                            $($((stringify!($goal), $C, TestGoal::All(vec![$expected])))+)+]
               @unparsed_goals[goal $($unparsed_goals)*])
     };
 
@@ -125,7 +125,7 @@ macro_rules! test {
     ]) => {
         test!(@program[$program]
               @parsed_goals[$($parsed_goals)*
-                            $($((stringify!($goal), $C, $expected))+)+]
+                            $($((stringify!($goal), $C, TestGoal::All(vec![$expected])))+)+]
               @unparsed_goals[])
     };
 }

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -667,3 +667,52 @@ fn gat_unify_with_implied_wc() {
         }
     }
 }
+
+#[test]
+fn rust_analyzer_regression() {
+    test! {
+        program {
+            trait FnOnce<Args> {
+                type Output;
+            }
+
+            trait Try {
+                type Ok;
+                type Error;
+            }
+
+            struct Tuple<A, B> { }
+
+            trait ParallelIterator {
+                type Item;
+            }
+        }
+
+        //fn try_reduce_with<PI, R, T>(pi: PI, reduce_op: R) -> Option<T>
+        //    where
+        //        PI: ParallelIterator<Item = T>,
+        //        R: FnOnce(T::Ok) -> T,
+        //        T: Try,
+        //    {
+        //        pi.drive_unindexed()
+        //    }
+        //
+        // where `drive_unindexed` is a method in `ParallelIterator`:
+        //
+        // fn drive_unindexed(self) -> ();
+
+        goal {
+            forall<PI, R, T> {
+                if (
+                    PI: ParallelIterator<Item = T>;
+                    R: FnOnce<Tuple< <T as Try>::Ok, <T as Try>::Ok >>;
+                    T: Try
+                ) {
+                    PI: ParallelIterator
+                }
+            }
+        } yields[SolverChoice::SLG { max_size: 4 }] {
+            "substitution [], lifetime constraints []"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #280 
Fixes #289

Not sure if this is the *correct* fix. It does solve the issue and, conceptually, I don't see a particular reason why we need to truncate the `environment` of a goal. However, there may be other cases we could theoretically still enter an infinite loop and this doesn't necessarily protect against that.