### PR TITLE
Use string_cache instead of lalrpop-intern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,12 +160,12 @@ dependencies = [
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "salsa 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "stacker 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -196,8 +196,8 @@ dependencies = [
  "chalk-rust-ir 0.1.0",
  "chalk-solve 0.1.0",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "salsa 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ dependencies = [
  "chalk-derive 0.1.0",
  "chalk-engine 0.9.0",
  "chalk-macros 0.1.1",
- "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -222,9 +222,9 @@ name = "chalk-parse"
 version = "0.1.0"
 dependencies = [
  "lalrpop 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -452,11 +452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop-intern"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "lalrpop-util"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +581,14 @@ version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -910,6 +913,11 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "siphasher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "smallvec"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +953,18 @@ dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1155,7 +1175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lalrpop 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)" = "64dc3698e75d452867d9bd86f4a723f452ce9d01fe1d55990b79f0c790aa67db"
-"checksum lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cc4fd87be4a815fd373e02773983940f0d75fb26fde8c098e9e45f7af03154c0"
 "checksum lalrpop-util 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c277d18683b36349ab5cd030158b54856fca6bb2d5dc5263b06288f486958b7c"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
@@ -1173,6 +1192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum phf_generator 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "03dc191feb9b08b0dc1330d6549b795b9d81aec19efe6b4a45aec8d4caee0c4b"
 "checksum phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93"
+"checksum phf_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
@@ -1210,10 +1230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stacker 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb79482f57cf598af52094ec4cc3b3c42499d3ce5bd426f2ac41515b7e57404b"
 "checksum string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25d70109977172b127fe834e5449e5ab1740b9ba49fa18a2020f509174f25423"
+"checksum string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
 "checksum string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "35293b05cf1494e8ddd042a7df6756bf18d07f42d234f32e71dce8a7aabb0191"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ bench = []
 diff = "0.1.11"
 docopt = "1.0.0"
 itertools = "0.8.0"
-lalrpop-intern = "0.15.1"
 rustyline = "1.0"
 salsa = "0.10.0"
 serde = "1.0"
 serde_derive = "1.0"
 stacker = "0.1.5"
+string_cache = "0.8.0"
 
 [dependencies.chalk-parse]
 version = "0.1.0"

--- a/chalk-integration/Cargo.toml
+++ b/chalk-integration/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 itertools = "0.7.8"
-lalrpop-intern = "0.15.1"
+string_cache = "0.8.0"
 salsa = "0.10.0"
 
 [dependencies.chalk-solve]

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -166,7 +166,7 @@ impl RustIrDatabase<ChalkIr> for Program {
 
     fn type_name(&self, id: TypeKindId) -> Identifier {
         match self.type_kinds.get(&id) {
-            Some(v) => v.name,
+            Some(v) => v.name.clone(),
             None => panic!("no type with id `{:?}`", id),
         }
     }

--- a/chalk-ir/Cargo.toml
+++ b/chalk-ir/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["compiler", "traits", "prolog"]
 edition = "2018"
 
 [dependencies]
-lalrpop-intern = "0.15.1"
+string_cache = "0.8.0"
 
 [dependencies.chalk-macros]
 version = "0.1.0"

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -596,7 +596,6 @@ macro_rules! copy_fold {
     };
 }
 
-copy_fold!(Identifier);
 copy_fold!(UniverseIndex);
 copy_fold!(ImplId);
 copy_fold!(StructId);

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -6,10 +6,10 @@ use crate::fold::{
 };
 use chalk_derive::{Fold, HasTypeFamily};
 use chalk_engine::fallible::*;
-use lalrpop_intern::InternedString;
 use std::collections::BTreeSet;
 use std::iter;
 use std::marker::PhantomData;
+use string_cache::DefaultAtom;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Void {}
@@ -39,7 +39,6 @@ macro_rules! impl_debugs {
 }
 
 extern crate chalk_engine;
-extern crate lalrpop_intern;
 
 #[macro_use]
 mod macros;
@@ -59,7 +58,7 @@ pub mod could_match;
 pub mod debug;
 pub mod tls;
 
-pub type Identifier = InternedString;
+pub type Identifier = DefaultAtom;
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasTypeFamily)]
 /// The set of assumptions we've made so far, and the current number of

--- a/chalk-parse/Cargo.toml
+++ b/chalk-parse/Cargo.toml
@@ -18,5 +18,5 @@ version = "0.17"
 version = "0.17"
 
 [dependencies]
-lalrpop-intern = "0.15.1"
 regex = "1.0.5"
+string_cache = "0.8.0"

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -1,5 +1,5 @@
-use lalrpop_intern::InternedString;
 use std::fmt;
+use string_cache::DefaultAtom;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Span {
@@ -68,7 +68,7 @@ pub struct AssocTyDefn {
     pub where_clauses: Vec<QuantifiedWhereClause>,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ParameterKind {
     Ty(Identifier),
     Lifetime(Identifier),
@@ -174,7 +174,7 @@ pub enum Ty {
     },
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Lifetime {
     Id { name: Identifier },
 }
@@ -211,9 +211,9 @@ impl Polarity {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Identifier {
-    pub str: InternedString,
+    pub str: DefaultAtom,
     pub span: Span,
 }
 

--- a/chalk-parse/src/lib.rs
+++ b/chalk-parse/src/lib.rs
@@ -2,7 +2,6 @@
 
 #[macro_use]
 extern crate lalrpop_util;
-extern crate lalrpop_intern;
 
 pub mod ast;
 #[rustfmt::skip]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -1,5 +1,5 @@
 use crate::ast::*;
-use lalrpop_intern::intern;
+use string_cache::DefaultAtom;
 
 grammar;
 
@@ -359,14 +359,14 @@ Angle<T>: Vec<T> = {
 
 Id: Identifier = {
     <l:@L> <s:r"([A-Za-z]|_)([A-Za-z0-9]|_)*"> <r:@R> => Identifier {
-        str: intern(s),
+        str: DefaultAtom::from(s),
         span: Span::new(l, r),
     }
 };
 
 LifetimeId: Identifier = {
     <l:@L> <s:r"'([A-Za-z]|_)([A-Za-z0-9]|_)*"> <r:@R> => Identifier {
-        str: intern(s),
+        str: DefaultAtom::from(s),
         span: Span::new(l, r),
     }
 };

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -249,7 +249,7 @@ pub trait Anonymize {
 
 impl Anonymize for [ParameterKind<Identifier>] {
     fn anonymize(&self) -> Vec<ParameterKind<()>> {
-        self.iter().map(|pk| pk.map(|_| ())).collect()
+        self.iter().cloned().map(|pk| pk.map(|_| ())).collect()
     }
 }
 

--- a/chalk-solve/src/coherence.rs
+++ b/chalk-solve/src/coherence.rs
@@ -27,10 +27,10 @@ impl fmt::Display for CoherenceError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CoherenceError::OverlappingImpls(id) => {
-                write!(f, "overlapping impls of trait {:?}", id)
+                write!(f, "overlapping impls of trait \"{}\"", id)
             }
             CoherenceError::FailedOrphanCheck(id) => {
-                write!(f, "impl for trait {:?} violates the orphan rules", id)
+                write!(f, "impl for trait \"{}\" violates the orphan rules", id)
             }
         }
     }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -21,12 +21,12 @@ impl fmt::Display for WfError {
         match self {
             WfError::IllFormedTypeDecl(id) => write!(
                 f,
-                "type declaration {:?} does not meet well-formedness requirements",
+                "type declaration \"{}\" does not meet well-formedness requirements",
                 id
             ),
             WfError::IllFormedTraitImpl(id) => write!(
                 f,
-                "trait impl for {:?} does not meet well-formedness requirements",
+                "trait impl for \"{}\" does not meet well-formedness requirements",
                 id
             ),
         }


### PR DESCRIPTION
Fixes #287 

Unfortunately, `DefaultAtom` from `string_cache` is not `Copy`, so have to add `.clone()` in many places.