### PR TITLE
Add regression test for issue 111

### DIFF
--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -1,0 +1,42 @@
+//! Tests that don't fit a single category
+
+use super::*;
+
+// Regression test for rust-lang/chalk#111
+#[test]
+fn futures_ambiguity() {
+    test! {
+        program {
+            struct Result<T, E> { }
+
+            trait Future {
+                type Output;
+            }
+
+            trait FutureResult
+                where
+                Self: Future<Output = Result<
+                    <Self as FutureResult>::Item,
+                    <Self as FutureResult>::Error
+                >>
+            {
+                type Item;
+                type Error;
+            }
+
+            impl<T, I, E> FutureResult for T
+                where
+                T: Future<Output = Result<I, E>>
+            {
+                type Item = I;
+                type Error = E;
+            }
+        }
+
+        goal {
+            forall<T> { if (T: FutureResult) { exists<I, E> { T: Future<Output = Result<I, E>> } } }
+        } yields {
+            r"Unique; substitution [?0 := (FutureResult::Item)<!1_0>, ?1 := (FutureResult::Error)<!1_0>], lifetime constraints []"
+        }
+    }
+}

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -206,6 +206,7 @@ mod cycle;
 mod existential_types;
 mod implied_bounds;
 mod impls;
+mod misc;
 mod negation;
 mod projection;
 mod unify;


### PR DESCRIPTION
Closes #111 

As noted in https://github.com/rust-lang/chalk/issues/111#issuecomment-548571024, this has been fixed. Added a test so we can close the issue.