### PR TITLE
permit inference variables to be unified with unnormalized projections

### DIFF
--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -123,11 +123,13 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
             (&TyData::InferenceVar(var), &TyData::Apply(_))
             | (&TyData::InferenceVar(var), &TyData::Opaque(_))
             | (&TyData::InferenceVar(var), &TyData::Dyn(_))
+            | (&TyData::InferenceVar(var), &TyData::Projection(_))
             | (&TyData::InferenceVar(var), &TyData::ForAll(_)) => self.unify_var_ty(var, b),
 
             (&TyData::Apply(_), &TyData::InferenceVar(var))
             | (TyData::Opaque(_), &TyData::InferenceVar(var))
             | (&TyData::Dyn(_), &TyData::InferenceVar(var))
+            | (&TyData::Projection(_), &TyData::InferenceVar(var))
             | (&TyData::ForAll(_), &TyData::InferenceVar(var)) => self.unify_var_ty(var, a),
 
             // Unifying `forall<X> { T }` with some other forall type `forall<X> { U }`
@@ -179,7 +181,6 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
             // Trait>::Item` with some other type `U`.
             (&TyData::Apply(_), &TyData::Projection(ref proj))
             | (&TyData::ForAll(_), &TyData::Projection(ref proj))
-            | (&TyData::InferenceVar(_), &TyData::Projection(ref proj))
             | (&TyData::Dyn(_), &TyData::Projection(ref proj))
             | (&TyData::Opaque(_), &TyData::Projection(ref proj)) => {
                 self.unify_projection_ty(proj, a)
@@ -188,7 +189,6 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
             (&TyData::Projection(ref proj), &TyData::Projection(_))
             | (&TyData::Projection(ref proj), &TyData::Apply(_))
             | (&TyData::Projection(ref proj), &TyData::ForAll(_))
-            | (&TyData::Projection(ref proj), &TyData::InferenceVar(_))
             | (&TyData::Projection(ref proj), &TyData::Dyn(_))
             | (&TyData::Projection(ref proj), &TyData::Opaque(_)) => {
                 self.unify_projection_ty(proj, b)

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -36,7 +36,7 @@ fn futures_ambiguity() {
         goal {
             forall<T> { if (T: FutureResult) { exists<I, E> { T: Future<Output = Result<I, E>> } } }
         } yields {
-            r"Unique; substitution [?0 := (FutureResult::Item)<!1_0>, ?1 := (FutureResult::Error)<!1_0>], lifetime constraints []"
+            r"Unique; substitution [?0 := <!1_0 as FutureResult>::Item, ?1 := <!1_0 as FutureResult>::Error], lifetime constraints []"
         }
     }
 }

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -115,7 +115,7 @@ macro_rules! test {
     ]) => {
         test!(@program[$program]
               @parsed_goals[$($parsed_goals)*
-                            $($((stringify!($goal), $C, $expected))+)+]
+                            $($((stringify!($goal), $C, TestGoal::All(vec![$expected])))+)+]
               @unparsed_goals[goal $($unparsed_goals)*])
     };
 
@@ -125,7 +125,7 @@ macro_rules! test {
     ]) => {
         test!(@program[$program]
               @parsed_goals[$($parsed_goals)*
-                            $($((stringify!($goal), $C, $expected))+)+]
+                            $($((stringify!($goal), $C, TestGoal::All(vec![$expected])))+)+]
               @unparsed_goals[])
     };
 }

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -667,3 +667,52 @@ fn gat_unify_with_implied_wc() {
         }
     }
 }
+
+#[test]
+fn rust_analyzer_regression() {
+    test! {
+        program {
+            trait FnOnce<Args> {
+                type Output;
+            }
+
+            trait Try {
+                type Ok;
+                type Error;
+            }
+
+            struct Tuple<A, B> { }
+
+            trait ParallelIterator {
+                type Item;
+            }
+        }
+
+        //fn try_reduce_with<PI, R, T>(pi: PI, reduce_op: R) -> Option<T>
+        //    where
+        //        PI: ParallelIterator<Item = T>,
+        //        R: FnOnce(T::Ok) -> T,
+        //        T: Try,
+        //    {
+        //        pi.drive_unindexed()
+        //    }
+        //
+        // where `drive_unindexed` is a method in `ParallelIterator`:
+        //
+        // fn drive_unindexed(self) -> ();
+
+        goal {
+            forall<PI, R, T> {
+                if (
+                    PI: ParallelIterator<Item = T>;
+                    R: FnOnce<Tuple< <T as Try>::Ok, <T as Try>::Ok >>;
+                    T: Try
+                ) {
+                    PI: ParallelIterator
+                }
+            }
+        } yields[SolverChoice::SLG { max_size: 4 }] {
+            "substitution [], lifetime constraints []"
+        }
+    }
+}


### PR DESCRIPTION
This fixes the rust-analyzer problems found in #280 and serves as an alternative to https://github.com/rust-lang/chalk/pull/294. I'm not really sure which approach I prefer -- there might even be a "third way" that is better still.

If nothing else, though, I think that the regression tests found on this branch is the correct form. I had to make a few small fixes to the test macro so that we could select the solver and specify the "max size" correctly.