### PR TITLE
Remove depth getting passed around

### DIFF
--- a/chalk-engine/src/stack.rs
+++ b/chalk-engine/src/stack.rs
@@ -94,29 +94,20 @@ impl<C: Context> Stack<C> {
         StackIndex::from(old_len)
     }
 
-    /// Pops the top-most entry from the stack, which should have the depth `*depth`:
+    /// Pops the top-most entry from the stack:
     /// * If the stack is now empty, returns false.
-    /// * Otherwise, adjusts depth to reflect the new top of the stack and returns true.
-    fn pop_and_adjust_depth(&mut self, depth: &mut StackIndex) -> bool {
-        assert_eq!(self.stack.len(), depth.value + 1);
+    /// * Otherwise, returns true.
+    fn pop_and_adjust_depth(&mut self) -> bool {
         self.stack.pop();
-        if depth.value == 0 {
-            false
-        } else {
-            depth.value -= 1;
-            true
-        }
+        !self.stack.is_empty()
     }
 
     /// Pops the top-most entry from the stack, which should have the depth `*depth`:
     /// * If the stack is now empty, returns None.
     /// * Otherwise, `take`s the active strand from the new top and returns it.
-    pub(super) fn pop_and_take_caller_strand(
-        &mut self,
-        depth: &mut StackIndex,
-    ) -> Option<Strand<C>> {
-        if self.pop_and_adjust_depth(depth) {
-            Some(self[*depth].active_strand.take().unwrap())
+    pub(super) fn pop_and_take_caller_strand(&mut self) -> Option<Strand<C>> {
+        if self.pop_and_adjust_depth() {
+            Some(self.top().active_strand.take().unwrap())
         } else {
             None
         }
@@ -125,15 +116,16 @@ impl<C: Context> Stack<C> {
     /// Pops the top-most entry from the stack, which should have the depth `*depth`:
     /// * If the stack is now empty, returns None.
     /// * Otherwise, borrows the active strand (mutably) from the new top and returns it.
-    pub(super) fn pop_and_borrow_caller_strand(
-        &mut self,
-        depth: &mut StackIndex,
-    ) -> Option<&mut Strand<C>> {
-        if self.pop_and_adjust_depth(depth) {
-            Some(self[*depth].active_strand.as_mut().unwrap())
+    pub(super) fn pop_and_borrow_caller_strand(&mut self) -> Option<&mut Strand<C>> {
+        if self.pop_and_adjust_depth() {
+            Some(self.top().active_strand.as_mut().unwrap())
         } else {
             None
         }
+    }
+
+    pub(super) fn top(&mut self) -> &mut StackEntry<C> {
+        self.stack.last_mut().unwrap()
     }
 }
 


### PR DESCRIPTION
Followup work from recursive removal

This simplifies logic a bit because we actually don't need to pass around depth at all.

There's a few other things I want to do with `chalk-engine` as followup to the recursive removal. Don't want to block this PR on them, but if this doesn't get merged before I finish them, I'll just change this PR for them.