### PR TITLE
Move ids to type family

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -76,7 +76,7 @@ pub fn derive_fold(item: TokenStream) -> TokenStream {
         let mut impl_generics = input.generics.clone();
         impl_generics.params.extend(vec![
             GenericParam::Type(syn::parse(quote! { _TF: TypeFamily }.into()).unwrap()),
-            GenericParam::Type(syn::parse(quote! { _TTF: TypeFamily }.into()).unwrap()),
+            GenericParam::Type(syn::parse(quote! { _TTF: TargetTypeFamily<_TF> }.into()).unwrap()),
             GenericParam::Type(
                 syn::parse(quote! { _U: HasTypeFamily<TypeFamily = _TTF> }.into()).unwrap(),
             ),
@@ -124,7 +124,7 @@ pub fn derive_fold(item: TokenStream) -> TokenStream {
     if let Some(tf) = is_type_family(&generic_param0) {
         let mut impl_generics = input.generics.clone();
         impl_generics.params.extend(vec![GenericParam::Type(
-            syn::parse(quote! { _TTF: TypeFamily }.into()).unwrap(),
+            syn::parse(quote! { _TTF: TargetTypeFamily<#tf> }.into()).unwrap(),
         )]);
 
         return TokenStream::from(quote! {

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -16,6 +16,7 @@ use chalk_ir::StructId;
 use chalk_ir::TraitId;
 use chalk_ir::TypeId;
 use chalk_ir::TypeKindId;
+use chalk_ir::TypeName;
 use chalk_ir::UCanonical;
 use chalk_rust_ir::AssociatedTyDatum;
 use chalk_rust_ir::AssociatedTyValue;
@@ -102,6 +103,10 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
 
     fn struct_datum(&self, id: StructId) -> Arc<StructDatum<ChalkIr>> {
         self.program_ir().unwrap().struct_datum(id)
+    }
+
+    fn as_struct_id(&self, type_name: &TypeName) -> Option<StructId> {
+        self.program_ir().unwrap().as_struct_id(type_name)
     }
 
     fn impls_for_trait(&self, trait_id: TraitId, parameters: &[Parameter<ChalkIr>]) -> Vec<ImplId> {

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -85,15 +85,15 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         self.program_ir().unwrap().custom_clauses()
     }
 
-    fn associated_ty_data(&self, ty: TypeId) -> Arc<AssociatedTyDatum<ChalkIr>> {
+    fn associated_ty_data(&self, ty: TypeId<ChalkIr>) -> Arc<AssociatedTyDatum<ChalkIr>> {
         self.program_ir().unwrap().associated_ty_data(ty)
     }
 
-    fn trait_datum(&self, id: TraitId) -> Arc<TraitDatum<ChalkIr>> {
+    fn trait_datum(&self, id: TraitId<ChalkIr>) -> Arc<TraitDatum<ChalkIr>> {
         self.program_ir().unwrap().trait_datum(id)
     }
 
-    fn impl_datum(&self, id: ImplId) -> Arc<ImplDatum<ChalkIr>> {
+    fn impl_datum(&self, id: ImplId<ChalkIr>) -> Arc<ImplDatum<ChalkIr>> {
         self.program_ir().unwrap().impl_datum(id)
     }
 
@@ -101,33 +101,41 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         self.program_ir().unwrap().associated_ty_values[&id].clone()
     }
 
-    fn struct_datum(&self, id: StructId) -> Arc<StructDatum<ChalkIr>> {
+    fn struct_datum(&self, id: StructId<ChalkIr>) -> Arc<StructDatum<ChalkIr>> {
         self.program_ir().unwrap().struct_datum(id)
     }
 
-    fn as_struct_id(&self, type_name: &TypeName) -> Option<StructId> {
+    fn as_struct_id(&self, type_name: &TypeName<ChalkIr>) -> Option<StructId<ChalkIr>> {
         self.program_ir().unwrap().as_struct_id(type_name)
     }
 
-    fn impls_for_trait(&self, trait_id: TraitId, parameters: &[Parameter<ChalkIr>]) -> Vec<ImplId> {
+    fn impls_for_trait(
+        &self,
+        trait_id: TraitId<ChalkIr>,
+        parameters: &[Parameter<ChalkIr>],
+    ) -> Vec<ImplId<ChalkIr>> {
         self.program_ir()
             .unwrap()
             .impls_for_trait(trait_id, parameters)
     }
 
-    fn local_impls_to_coherence_check(&self, trait_id: TraitId) -> Vec<ImplId> {
+    fn local_impls_to_coherence_check(&self, trait_id: TraitId<ChalkIr>) -> Vec<ImplId<ChalkIr>> {
         self.program_ir()
             .unwrap()
             .local_impls_to_coherence_check(trait_id)
     }
 
-    fn impl_provided_for(&self, auto_trait_id: TraitId, struct_id: StructId) -> bool {
+    fn impl_provided_for(
+        &self,
+        auto_trait_id: TraitId<ChalkIr>,
+        struct_id: StructId<ChalkIr>,
+    ) -> bool {
         self.program_ir()
             .unwrap()
             .impl_provided_for(auto_trait_id, struct_id)
     }
 
-    fn type_name(&self, id: TypeKindId) -> Identifier {
+    fn type_name(&self, id: TypeKindId<ChalkIr>) -> Identifier {
         self.program_ir().unwrap().type_name(id)
     }
 }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -12,10 +12,12 @@ use std::sync::Arc;
 use crate::error::RustIrError;
 use crate::program::Program as LoweredProgram;
 
-type TypeIds = BTreeMap<chalk_ir::Identifier, chalk_ir::TypeKindId>;
-type TypeKinds = BTreeMap<chalk_ir::TypeKindId, rust_ir::TypeKind>;
-type AssociatedTyLookups = BTreeMap<(chalk_ir::TraitId, chalk_ir::Identifier), AssociatedTyLookup>;
-type AssociatedTyValueIds = BTreeMap<(chalk_ir::ImplId, chalk_ir::Identifier), AssociatedTyValueId>;
+type TypeIds = BTreeMap<chalk_ir::Identifier, chalk_ir::TypeKindId<ChalkIr>>;
+type TypeKinds = BTreeMap<chalk_ir::TypeKindId<ChalkIr>, rust_ir::TypeKind>;
+type AssociatedTyLookups =
+    BTreeMap<(chalk_ir::TraitId<ChalkIr>, chalk_ir::Identifier), AssociatedTyLookup>;
+type AssociatedTyValueIds =
+    BTreeMap<(chalk_ir::ImplId<ChalkIr>, chalk_ir::Identifier), AssociatedTyValueId>;
 type ParameterMap = BTreeMap<chalk_ir::ParameterKind<chalk_ir::Identifier>, usize>;
 
 pub type LowerResult<T> = Result<T, RustIrError>;
@@ -45,12 +47,12 @@ struct Env<'k> {
 /// ```
 #[derive(Debug, PartialEq, Eq)]
 struct AssociatedTyLookup {
-    id: chalk_ir::TypeId,
+    id: chalk_ir::TypeId<ChalkIr>,
     addl_parameter_kinds: Vec<chalk_ir::ParameterKind<()>>,
 }
 
 enum NameLookup {
-    Type(chalk_ir::TypeKindId),
+    Type(chalk_ir::TypeKindId<ChalkIr>),
     Parameter(usize),
 }
 
@@ -88,7 +90,7 @@ impl<'k> Env<'k> {
         Err(RustIrError::InvalidLifetimeName(name))
     }
 
-    fn type_kind(&self, id: chalk_ir::TypeKindId) -> &rust_ir::TypeKind {
+    fn type_kind(&self, id: chalk_ir::TypeKindId<ChalkIr>) -> &rust_ir::TypeKind {
         &self.type_kinds[&id]
     }
 
@@ -623,7 +625,7 @@ impl LowerLeafGoal for LeafGoal {
 trait LowerStructDefn {
     fn lower_struct(
         &self,
-        struct_id: chalk_ir::StructId,
+        struct_id: chalk_ir::StructId<ChalkIr>,
         env: &Env,
     ) -> LowerResult<rust_ir::StructDatum<ChalkIr>>;
 }
@@ -631,7 +633,7 @@ trait LowerStructDefn {
 impl LowerStructDefn for StructDefn {
     fn lower_struct(
         &self,
-        struct_id: chalk_ir::StructId,
+        struct_id: chalk_ir::StructId<ChalkIr>,
         env: &Env,
     ) -> LowerResult<rust_ir::StructDatum<ChalkIr>> {
         if self.flags.fundamental && self.all_parameters().len() != 1 {
@@ -1056,7 +1058,7 @@ trait LowerImpl {
     fn lower_impl(
         &self,
         empty_env: &Env,
-        impl_id: ImplId,
+        impl_id: ImplId<ChalkIr>,
         associated_ty_value_ids: &AssociatedTyValueIds,
     ) -> LowerResult<rust_ir::ImplDatum<ChalkIr>>;
 }
@@ -1065,7 +1067,7 @@ impl LowerImpl for Impl {
     fn lower_impl(
         &self,
         empty_env: &Env,
-        impl_id: ImplId,
+        impl_id: ImplId<ChalkIr>,
         associated_ty_value_ids: &AssociatedTyValueIds,
     ) -> LowerResult<rust_ir::ImplDatum<ChalkIr>> {
         debug_heading!("LowerImpl::lower_impl(impl_id={:?})", impl_id);
@@ -1158,7 +1160,7 @@ impl LowerClause for Clause {
 trait LowerTrait {
     fn lower_trait(
         &self,
-        trait_id: chalk_ir::TraitId,
+        trait_id: chalk_ir::TraitId<ChalkIr>,
         env: &Env,
     ) -> LowerResult<rust_ir::TraitDatum<ChalkIr>>;
 }
@@ -1166,7 +1168,7 @@ trait LowerTrait {
 impl LowerTrait for TraitDefn {
     fn lower_trait(
         &self,
-        trait_id: chalk_ir::TraitId,
+        trait_id: chalk_ir::TraitId<ChalkIr>,
         env: &Env,
     ) -> LowerResult<rust_ir::TraitDatum<ChalkIr>> {
         let all_parameters = self.all_parameters();

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -122,6 +122,13 @@ impl RustIrDatabase<ChalkIr> for Program {
         self.struct_data[&id].clone()
     }
 
+    fn as_struct_id(&self, type_name: &TypeName) -> Option<StructId> {
+        match type_name {
+            TypeName::TypeKindId(TypeKindId::StructId(struct_id)) => Some(*struct_id),
+            _ => None,
+        }
+    }
+
     fn impls_for_trait(&self, trait_id: TraitId, parameters: &[Parameter<ChalkIr>]) -> Vec<ImplId> {
         self.impl_data
             .iter()

--- a/chalk-integration/src/query.rs
+++ b/chalk-integration/src/query.rs
@@ -32,7 +32,9 @@ pub trait LoweringDatabase: RustIrDatabase<ChalkIr> {
 
     /// Performs coherence check and computes which impls specialize
     /// one another (the "specialization priorities").
-    fn coherence(&self) -> Result<BTreeMap<TraitId, Arc<SpecializationPriorities>>, ChalkError>;
+    fn coherence(
+        &self,
+    ) -> Result<BTreeMap<TraitId<ChalkIr>, Arc<SpecializationPriorities<ChalkIr>>>, ChalkError>;
 
     fn orphan_check(&self) -> Result<(), ChalkError>;
 
@@ -71,7 +73,7 @@ fn orphan_check(db: &impl LoweringDatabase) -> Result<(), ChalkError> {
 
 fn coherence(
     db: &impl LoweringDatabase,
-) -> Result<BTreeMap<TraitId, Arc<SpecializationPriorities>>, ChalkError> {
+) -> Result<BTreeMap<TraitId<ChalkIr>, Arc<SpecializationPriorities<ChalkIr>>>, ChalkError> {
     let program = db.program_ir()?;
 
     let priorities_map: Result<BTreeMap<_, _>, ChalkError> = program

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -267,17 +267,18 @@ where
     }
 }
 
-impl CastTo<TypeKindId> for StructId {
-    fn cast_to(self) -> TypeKindId {
+impl<TF: TypeFamily> CastTo<TypeKindId<TF>> for StructId<TF> {
+    fn cast_to(self) -> TypeKindId<TF> {
         TypeKindId::StructId(self)
     }
 }
 
-impl<T> CastTo<TypeName> for T
+impl<TF, T> CastTo<TypeName<TF>> for T
 where
-    T: CastTo<TypeKindId>,
+    TF: TypeFamily,
+    T: CastTo<TypeKindId<TF>>,
 {
-    fn cast_to(self) -> TypeName {
+    fn cast_to(self) -> TypeName<TF> {
         TypeName::TypeKindId(self.cast())
     }
 }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -4,46 +4,31 @@ use super::*;
 
 impl Debug for RawId {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        fmt.debug_struct("RawId")
-            .field("index", &self.index)
-            .finish()
+        write!(fmt, "#{}", self.index)
     }
 }
 
-impl Debug for TypeKindId {
+impl<TF: TypeFamily> Debug for TypeKindId<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        match self {
-            TypeKindId::TypeId(id) => write!(fmt, "{:?}", id),
-            TypeKindId::TraitId(id) => write!(fmt, "{:?}", id),
-            TypeKindId::StructId(id) => write!(fmt, "{:?}", id),
-        }
+        TF::debug_type_kind_id(*self, fmt)
     }
 }
 
-impl Debug for TypeId {
+impl<TF: TypeFamily> Debug for TypeId<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        tls::with_current_program(|p| match p {
-            Some(prog) => prog.debug_type_kind_id(TypeKindId::TypeId(*self), fmt),
-            None => write!(fmt, "TypeId({:?})", self.0.index),
-        })
+        TF::debug_type_kind_id(TypeKindId::TypeId(*self), fmt)
     }
 }
 
-impl Debug for TraitId {
+impl<TF: TypeFamily> Debug for TraitId<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        tls::with_current_program(|p| match p {
-            Some(prog) => prog.debug_type_kind_id(TypeKindId::TraitId(*self), fmt),
-            None => write!(fmt, "TraitId({:?})", self.0.index),
-        })
+        TF::debug_type_kind_id(TypeKindId::TraitId(*self), fmt)
     }
 }
 
-impl Debug for StructId {
+impl<TF: TypeFamily> Debug for StructId<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        tls::with_current_program(|p| match p {
-            Some(prog) => prog.debug_type_kind_id(TypeKindId::StructId(*self), fmt),
-            None => write!(fmt, "StructId({:?})", self.0.index),
-        })
+        TF::debug_type_kind_id(TypeKindId::StructId(*self), fmt)
     }
 }
 
@@ -59,7 +44,7 @@ impl Debug for UniverseIndex {
     }
 }
 
-impl Debug for TypeName {
+impl<TF: TypeFamily> Debug for TypeName<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             TypeName::TypeKindId(id) => write!(fmt, "{:?}", id),

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -59,6 +59,10 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
     fn lifetime_data(lifetime: &Self::InternedLifetime) -> &LifetimeData<Self>;
 }
 
+pub trait TargetTypeFamily<TF: TypeFamily>: TypeFamily {}
+
+impl<TF: TypeFamily> TargetTypeFamily<TF> for TF {}
+
 /// Implemented by types that have an associated type family (which
 /// are virtually all of the types in chalk-ir, for example).
 /// This lets us map from a type like `Ty<TF>` to the parameter `TF`.

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -2,7 +2,9 @@ use crate::debug::Angle;
 use crate::tls;
 use crate::LifetimeData;
 use crate::ProjectionTy;
+use crate::RawId;
 use crate::TyData;
+use crate::TypeKindId;
 use chalk_engine::context::Context;
 use chalk_engine::ExClause;
 use std::fmt::{self, Debug};
@@ -33,6 +35,18 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
     /// `Lookup` trait to convert this to a `Lifetime<Self>`.
     type InternedLifetime: Debug + Clone + Eq + Ord + Hash;
 
+    /// The core "id" type used for struct-ids and the like.
+    type DefId: Debug + Copy + Eq + Ord + Hash;
+
+    /// Prints the debug representation of a type-kind-id. To get good
+    /// results, this requires inspecting TLS, and is difficult to
+    /// code without reference to a specific type-family (and hence
+    /// fully known types).
+    fn debug_type_kind_id(
+        type_kind_id: TypeKindId<Self>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result;
+
     /// Prints the debug representation of a projection. To get good
     /// results, this requires inspecting TLS, and is difficult to
     /// code without reference to a specific type-family (and hence
@@ -59,9 +73,15 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
     fn lifetime_data(lifetime: &Self::InternedLifetime) -> &LifetimeData<Self>;
 }
 
-pub trait TargetTypeFamily<TF: TypeFamily>: TypeFamily {}
+pub trait TargetTypeFamily<TF: TypeFamily>: TypeFamily {
+    fn transfer_def_id(def_id: TF::DefId) -> Self::DefId;
+}
 
-impl<TF: TypeFamily> TargetTypeFamily<TF> for TF {}
+impl<TF: TypeFamily> TargetTypeFamily<TF> for TF {
+    fn transfer_def_id(def_id: TF::DefId) -> Self::DefId {
+        def_id
+    }
+}
 
 /// Implemented by types that have an associated type family (which
 /// are virtually all of the types in chalk-ir, for example).
@@ -82,6 +102,21 @@ pub struct ChalkIr {}
 impl TypeFamily for ChalkIr {
     type InternedType = TyData<ChalkIr>;
     type InternedLifetime = LifetimeData<ChalkIr>;
+    type DefId = RawId;
+
+    fn debug_type_kind_id(
+        type_kind_id: TypeKindId<ChalkIr>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        tls::with_current_program(|p| match p {
+            Some(prog) => prog.debug_type_kind_id(type_kind_id, fmt),
+            None => match type_kind_id {
+                TypeKindId::TypeId(id) => write!(fmt, "TypeId({:?})", id),
+                TypeKindId::TraitId(id) => write!(fmt, "TraitId({:?})", id),
+                TypeKindId::StructId(id) => write!(fmt, "StructId({:?})", id),
+            },
+        })
+    }
 
     fn debug_projection(
         projection: &ProjectionTy<ChalkIr>,

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -53,7 +53,7 @@ pub mod fold;
 pub mod cast;
 
 pub mod family;
-use family::{HasTypeFamily, TypeFamily};
+use family::{HasTypeFamily, TargetTypeFamily, TypeFamily};
 
 pub mod could_match;
 pub mod debug;

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -17,8 +17,8 @@ pub enum Void {}
 macro_rules! impl_froms {
     ($e:ident: $($v:ident), *) => {
         $(
-            impl From<$v> for $e {
-                fn from(it: $v) -> $e {
+            impl<TF: TypeFamily> From<$v<TF>> for $e<TF> {
+                fn from(it: $v<TF>) -> $e<TF> {
                     $e::$v(it)
                 }
             }
@@ -29,9 +29,9 @@ macro_rules! impl_froms {
 macro_rules! impl_debugs {
     ($($id:ident), *) => {
         $(
-            impl std::fmt::Debug for $id {
+            impl<TF: TypeFamily> std::fmt::Debug for $id<TF> {
                 fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-                    write!(fmt, "{}({:?})", stringify!($id), self.0.index)
+                    write!(fmt, "{}({:?})", stringify!($id), self.0)
                 }
             }
         )*
@@ -114,10 +114,10 @@ impl<G: HasTypeFamily> HasTypeFamily for InEnvironment<G> {
     type TypeFamily = G::TypeFamily;
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum TypeName {
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Fold)]
+pub enum TypeName<TF: TypeFamily> {
     /// a type like `Vec<T>`
-    TypeKindId(TypeKindId),
+    TypeKindId(TypeKindId<TF>),
 
     /// instantiated form a universally quantified type, e.g., from
     /// `forall<T> { .. }`. Stands in as a representative of "some
@@ -125,7 +125,7 @@ pub enum TypeName {
     Placeholder(PlaceholderIndex),
 
     /// an associated type like `Iterator::Item`; see `AssociatedType` for details
-    AssociatedType(TypeId),
+    AssociatedType(TypeId<TF>),
 
     /// This can be used to represent an error, e.g. during name resolution of a type.
     /// Chalk itself will not produce this, just pass it through when given.
@@ -163,31 +163,31 @@ impl UniverseIndex {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct StructId(pub RawId);
+pub struct StructId<TF: TypeFamily>(pub TF::DefId);
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TraitId(pub RawId);
+pub struct TraitId<TF: TypeFamily>(pub TF::DefId);
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ImplId(pub RawId);
+pub struct ImplId<TF: TypeFamily>(pub TF::DefId);
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ClauseId(pub RawId);
+pub struct ClauseId<TF: TypeFamily>(pub TF::DefId);
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TypeId(pub RawId);
+pub struct TypeId<TF: TypeFamily>(pub TF::DefId);
 
 impl_debugs!(ImplId, ClauseId);
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum TypeKindId {
-    TypeId(TypeId),
-    TraitId(TraitId),
-    StructId(StructId),
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Fold)]
+pub enum TypeKindId<TF: TypeFamily> {
+    TypeId(TypeId<TF>),
+    TraitId(TraitId<TF>),
+    StructId(StructId<TF>),
 }
 
-impl TypeKindId {
-    pub fn raw_id(&self) -> RawId {
+impl<TF: TypeFamily> TypeKindId<TF> {
+    pub fn raw_id(&self) -> TF::DefId {
         match self {
             TypeKindId::TypeId(id) => id.0,
             TypeKindId::TraitId(id) => id.0,
@@ -459,7 +459,7 @@ impl PlaceholderIndex {
 // Fold derive intentionally omitted, folded through Ty
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasTypeFamily)]
 pub struct ApplicationTy<TF: TypeFamily> {
-    pub name: TypeName,
+    pub name: TypeName<TF>,
     pub parameters: Vec<Parameter<TF>>,
 }
 
@@ -587,7 +587,7 @@ impl<TF: TypeFamily> Parameter<TF> {
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasTypeFamily)]
 pub struct ProjectionTy<TF: TypeFamily> {
-    pub associated_ty_id: TypeId,
+    pub associated_ty_id: TypeId<TF>,
     pub parameters: Vec<Parameter<TF>>,
 }
 
@@ -599,7 +599,7 @@ impl<TF: TypeFamily> ProjectionTy<TF> {
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasTypeFamily)]
 pub struct TraitRef<TF: TypeFamily> {
-    pub trait_id: TraitId,
+    pub trait_id: TraitId<TF>,
     pub parameters: Vec<Parameter<TF>>,
 }
 

--- a/chalk-ir/src/tls.rs
+++ b/chalk-ir/src/tls.rs
@@ -11,7 +11,7 @@ thread_local! {
 pub trait DebugContext {
     fn debug_type_kind_id(
         &self,
-        id: TypeKindId,
+        id: TypeKindId<ChalkIr>,
         fmt: &mut fmt::Formatter,
     ) -> Result<(), fmt::Error>;
 

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -154,11 +154,11 @@ macro_rules! eq_zip {
     };
 }
 
-eq_zip!(TF => StructId);
-eq_zip!(TF => TraitId);
-eq_zip!(TF => TypeId);
-eq_zip!(TF => TypeKindId);
-eq_zip!(TF => TypeName);
+eq_zip!(TF => StructId<TF>);
+eq_zip!(TF => TraitId<TF>);
+eq_zip!(TF => TypeId<TF>);
+eq_zip!(TF => TypeKindId<TF>);
+eq_zip!(TF => TypeName<TF>);
 eq_zip!(TF => Identifier);
 eq_zip!(TF => QuantifierKind);
 eq_zip!(TF => PhantomData<TF>);

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -4,7 +4,7 @@
 
 use chalk_derive::{Fold, HasTypeFamily};
 use chalk_ir::cast::Cast;
-use chalk_ir::family::{HasTypeFamily, TypeFamily};
+use chalk_ir::family::{HasTypeFamily, TargetTypeFamily, TypeFamily};
 use chalk_ir::fold::{shift::Shift, Fold, Folder};
 use chalk_ir::{
     Binders, Identifier, ImplId, LifetimeData, Parameter, ParameterKind, ProjectionEq,

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -33,7 +33,7 @@ impl<TF: TypeFamily> ImplDatum<TF> {
         self.polarity.is_positive()
     }
 
-    pub fn trait_id(&self) -> TraitId {
+    pub fn trait_id(&self) -> TraitId<TF> {
         self.binders.value.trait_ref.trait_id
     }
 }
@@ -64,12 +64,12 @@ pub struct DefaultImplDatumBound<TF: TypeFamily> {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct StructDatum<TF: TypeFamily> {
     pub binders: Binders<StructDatumBound<TF>>,
-    pub id: StructId,
+    pub id: StructId<TF>,
     pub flags: StructFlags,
 }
 
 impl<TF: TypeFamily> StructDatum<TF> {
-    pub fn name(&self) -> TypeName {
+    pub fn name(&self) -> TypeName<TF> {
         self.id.cast()
     }
 }
@@ -88,7 +88,7 @@ pub struct StructFlags {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TraitDatum<TF: TypeFamily> {
-    pub id: TraitId,
+    pub id: TraitId<TF>,
 
     pub binders: Binders<TraitDatumBound<TF>>,
 
@@ -98,7 +98,7 @@ pub struct TraitDatum<TF: TypeFamily> {
     pub flags: TraitFlags,
 
     /// The id of each associated type defined in the trait.
-    pub associated_ty_ids: Vec<TypeId>,
+    pub associated_ty_ids: Vec<TypeId<TF>>,
 }
 
 impl<TF: TypeFamily> TraitDatum<TF> {
@@ -188,7 +188,7 @@ impl<TF: TypeFamily> IntoWhereClauses<TF> for QuantifiedInlineBound<TF> {
 /// Does not know anything about what it's binding.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Fold)]
 pub struct TraitBound<TF: TypeFamily> {
-    pub trait_id: TraitId,
+    pub trait_id: TraitId<TF>,
     pub args_no_self: Vec<Parameter<TF>>,
 }
 
@@ -213,7 +213,7 @@ impl<TF: TypeFamily> TraitBound<TF> {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Fold)]
 pub struct ProjectionEqBound<TF: TypeFamily> {
     pub trait_bound: TraitBound<TF>,
-    pub associated_ty_id: TypeId,
+    pub associated_ty_id: TypeId<TF>,
     /// Does not include trait parameters.
     pub parameters: Vec<Parameter<TF>>,
     pub value: Ty<TF>,
@@ -291,10 +291,10 @@ impl<'a> ToParameter for (&'a ParameterKind<()>, usize) {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct AssociatedTyDatum<TF: TypeFamily> {
     /// The trait this associated type is defined in.
-    pub trait_id: TraitId,
+    pub trait_id: TraitId<TF>,
 
     /// The ID of this associated type
-    pub id: TypeId,
+    pub id: TypeId<TF>,
 
     /// Name of this associated type.
     pub name: Identifier,
@@ -377,7 +377,7 @@ pub struct AssociatedTyValue<TF: TypeFamily> {
     ///     type Item = XXX; // <-- (where this is self)
     /// }
     /// ```
-    pub impl_id: ImplId,
+    pub impl_id: ImplId<TF>,
 
     /// Associated type being defined.
     ///
@@ -390,7 +390,7 @@ pub struct AssociatedTyValue<TF: TypeFamily> {
     ///     type Item; // <-- refers to this declaration here!
     /// }
     /// ```
-    pub associated_ty_id: TypeId,
+    pub associated_ty_id: TypeId<TF>,
 
     /// Additional binders declared on the associated type itself,
     /// beyond those from the impl. This would be empty for normal

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -45,8 +45,8 @@ pub mod program_clauses;
 /// ```
 pub fn push_auto_trait_impls<TF: TypeFamily>(
     builder: &mut ClauseBuilder<'_, TF>,
-    auto_trait_id: TraitId,
-    struct_id: StructId,
+    auto_trait_id: TraitId<TF>,
+    struct_id: StructId<TF>,
 ) {
     debug_heading!(
         "push_auto_trait_impls({:?}, {:?})",
@@ -294,7 +294,7 @@ fn program_clauses_that_could_match<TF: TypeFamily>(
 /// ```
 fn push_program_clauses_for_associated_type_values_in_impls_of<TF: TypeFamily>(
     builder: &mut ClauseBuilder<'_, TF>,
-    trait_id: TraitId,
+    trait_id: TraitId<TF>,
     trait_parameters: &[Parameter<TF>],
 ) {
     debug_heading!(
@@ -357,7 +357,10 @@ fn match_ty<TF: TypeFamily>(
     }
 }
 
-fn match_type_kind<TF: TypeFamily>(builder: &mut ClauseBuilder<'_, TF>, type_kind_id: TypeKindId) {
+fn match_type_kind<TF: TypeFamily>(
+    builder: &mut ClauseBuilder<'_, TF>,
+    type_kind_id: TypeKindId<TF>,
+) {
     match type_kind_id {
         TypeKindId::TypeId(type_id) => builder
             .db

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -157,7 +157,7 @@ fn program_clauses_that_could_match<TF: TypeFamily>(
             if trait_datum.is_auto_trait() {
                 match trait_ref.parameters[0].assert_ty_ref().data() {
                     TyData::Apply(apply) => {
-                        if let TypeName::TypeKindId(TypeKindId::StructId(struct_id)) = apply.name {
+                        if let Some(struct_id) = db.as_struct_id(&apply.name) {
                             push_auto_trait_impls(builder, trait_id, struct_id);
                         }
                     }

--- a/chalk-solve/src/coherence/orphan.rs
+++ b/chalk-solve/src/coherence/orphan.rs
@@ -16,7 +16,7 @@ use chalk_ir::*;
 pub fn perform_orphan_check<TF: TypeFamily>(
     db: &dyn RustIrDatabase<TF>,
     solver_choice: SolverChoice,
-    impl_id: ImplId,
+    impl_id: ImplId<TF>,
 ) -> Result<(), CoherenceError> {
     debug_heading!("orphan_check(impl={:#?})", impl_id);
 

--- a/chalk-solve/src/coherence/solve.rs
+++ b/chalk-solve/src/coherence/solve.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 impl<TF: TypeFamily> CoherenceSolver<'_, TF> {
     pub(super) fn visit_specializations_of_trait(
         &self,
-        mut record_specialization: impl FnMut(ImplId, ImplId),
+        mut record_specialization: impl FnMut(ImplId<TF>, ImplId<TF>),
     ) -> Result<(), CoherenceError> {
         // Ignore impls for marker traits as they are allowed to overlap.
         let trait_datum = self.db.trait_datum(self.trait_id);

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -36,6 +36,9 @@ pub trait RustIrDatabase<TF: TypeFamily>: Debug {
     /// Returns the `AssociatedTyValue` with the given id.
     fn associated_ty_value(&self, id: AssociatedTyValueId) -> Arc<AssociatedTyValue<TF>>;
 
+    /// If `id` is a struct id, returns `Some(id)` (but cast to `StructId`).
+    fn as_struct_id(&self, id: &TypeName) -> Option<StructId>;
+
     /// Returns a list of potentially relevant impls for a given
     /// trait-id; we also supply the type parameters that we are
     /// trying to match (if known: these parameters may contain

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -22,22 +22,22 @@ pub trait RustIrDatabase<TF: TypeFamily>: Debug {
     fn custom_clauses(&self) -> Vec<ProgramClause<TF>>;
 
     /// Returns the datum for the associated type with the given id.
-    fn associated_ty_data(&self, ty: TypeId) -> Arc<AssociatedTyDatum<TF>>;
+    fn associated_ty_data(&self, ty: TypeId<TF>) -> Arc<AssociatedTyDatum<TF>>;
 
     /// Returns the datum for the impl with the given id.
-    fn trait_datum(&self, trait_id: TraitId) -> Arc<TraitDatum<TF>>;
+    fn trait_datum(&self, trait_id: TraitId<TF>) -> Arc<TraitDatum<TF>>;
 
     /// Returns the datum for the impl with the given id.
-    fn struct_datum(&self, struct_id: StructId) -> Arc<StructDatum<TF>>;
+    fn struct_datum(&self, struct_id: StructId<TF>) -> Arc<StructDatum<TF>>;
 
     /// Returns the datum for the impl with the given id.
-    fn impl_datum(&self, impl_id: ImplId) -> Arc<ImplDatum<TF>>;
+    fn impl_datum(&self, impl_id: ImplId<TF>) -> Arc<ImplDatum<TF>>;
 
     /// Returns the `AssociatedTyValue` with the given id.
     fn associated_ty_value(&self, id: AssociatedTyValueId) -> Arc<AssociatedTyValue<TF>>;
 
     /// If `id` is a struct id, returns `Some(id)` (but cast to `StructId`).
-    fn as_struct_id(&self, id: &TypeName) -> Option<StructId>;
+    fn as_struct_id(&self, id: &TypeName<TF>) -> Option<StructId<TF>>;
 
     /// Returns a list of potentially relevant impls for a given
     /// trait-id; we also supply the type parameters that we are
@@ -48,7 +48,11 @@ pub trait RustIrDatabase<TF: TypeFamily>: Debug {
     /// apply. The parameters are provided as a "hint" to help the
     /// implementor do less work, but can be completely ignored if
     /// desired.
-    fn impls_for_trait(&self, trait_id: TraitId, parameters: &[Parameter<TF>]) -> Vec<ImplId>;
+    fn impls_for_trait(
+        &self,
+        trait_id: TraitId<TF>,
+        parameters: &[Parameter<TF>],
+    ) -> Vec<ImplId<TF>>;
 
     /// Returns the impls that require coherence checking. This is not the
     /// full set of impls that exist:
@@ -56,7 +60,7 @@ pub trait RustIrDatabase<TF: TypeFamily>: Debug {
     /// - It can exclude impls not defined in the current crate.
     /// - It can exclude "built-in" impls, like those for closures; only the
     ///   impls actually written by users need to be checked.
-    fn local_impls_to_coherence_check(&self, trait_id: TraitId) -> Vec<ImplId>;
+    fn local_impls_to_coherence_check(&self, trait_id: TraitId<TF>) -> Vec<ImplId<TF>>;
 
     /// Returns true if there is an explicit impl of the auto trait
     /// `auto_trait_id` for the struct `struct_id`. This is part of
@@ -64,10 +68,10 @@ pub trait RustIrDatabase<TF: TypeFamily>: Debug {
     /// by the user for the struct, then we provide default impls
     /// based on the field types (otherwise, we rely on the impls the
     /// user gave).
-    fn impl_provided_for(&self, auto_trait_id: TraitId, struct_id: StructId) -> bool;
+    fn impl_provided_for(&self, auto_trait_id: TraitId<TF>, struct_id: StructId<TF>) -> bool;
 
     /// Returns the name for the type with the given id.
-    fn type_name(&self, id: TypeKindId) -> Identifier;
+    fn type_name(&self, id: TypeKindId<TF>) -> Identifier;
 }
 
 pub use solve::Guidance;

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -133,7 +133,7 @@ where
         Self { db, solver_choice }
     }
 
-    pub fn verify_struct_decl(&self, struct_id: StructId) -> Result<(), WfError> {
+    pub fn verify_struct_decl(&self, struct_id: StructId<TF>) -> Result<(), WfError> {
         let struct_datum = self.db.struct_datum(struct_id);
 
         // We retrieve all the input types of the struct fields.
@@ -189,7 +189,7 @@ where
         }
     }
 
-    pub fn verify_trait_impl(&self, impl_id: ImplId) -> Result<(), WfError> {
+    pub fn verify_trait_impl(&self, impl_id: ImplId<TF>) -> Result<(), WfError> {
         let impl_datum = self.db.impl_datum(impl_id);
 
         if !impl_datum.is_positive() {

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -194,7 +194,7 @@ fn atc_accounting() {
         assert_eq!(
             &atv_text[..].replace(",\n", "\n"),
             &r#"AssociatedTyValue {
-    impl_id: ImplId(2),
+    impl_id: ImplId(#2),
     associated_ty_id: (Iterable::Iter),
     value: for<lifetime, type> AssociatedTyValueBound {
         ty: Iter<'^0, ^1>


### PR DESCRIPTION
This PR moves the `RawId` type into the type family. It is presented as `TF::DefId`, mirroring the name that rustc uses. The goal here is to allow rustc to map this to `DefId`.

For now, I kept the various newtypes (e.g., `StructId` and so forth) exactly as they are. At some point we are going to move to move things like `TypeName` so that we have an "interned" `TypeName`, but I'm not 100% sure about the various newtypes, they may want to stay like this, or else move into the `TypeFamily`, or maybe we just get rid of them (but I think it's nice to have the distinctions between various kinds of ids).

I think a good rule though would be that `TypeName` should be opaque to most of the chalk logic (apart perhaps from the clause generation logic, which would interact with it through methods on `RustIrDatabase`), which implies that we may want to extract some of its variants out into `TypeName`.