### PR TITLE
more refactorings to chalk-ir

### DIFF
--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -53,7 +53,7 @@ impl ChalkDatabase {
         tls::set_current_program(&program, || op(&program))
     }
 
-    pub fn parse_and_lower_goal(&self, text: &str) -> Result<Box<Goal<ChalkIr>>, ChalkError> {
+    pub fn parse_and_lower_goal(&self, text: &str) -> Result<Goal<ChalkIr>, ChalkError> {
         let program = self.checked_program()?;
         Ok(chalk_parse::parse_goal(text)?.lower(&*program)?)
     }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -974,24 +974,7 @@ impl LowerTy for Ty {
                 TypeLookup::Parameter(d) => Ok(chalk_ir::TyData::BoundVar(d).intern()),
             },
 
-            Ty::Dyn { ref bounds } => Ok(chalk_ir::TyData::Dyn(chalk_ir::BoundedTy {
-                bounds: env.in_binders(
-                    // FIXME: Figure out a proper name for this type parameter
-                    Some(chalk_ir::ParameterKind::Ty(intern(FIXME_SELF))),
-                    |env| {
-                        Ok(bounds
-                            .lower(env)?
-                            .iter()
-                            .flat_map(|qil| {
-                                qil.into_where_clauses(chalk_ir::TyData::BoundVar(0).intern())
-                            })
-                            .collect())
-                    },
-                )?,
-            })
-            .intern()),
-
-            Ty::Opaque { ref bounds } => Ok(chalk_ir::TyData::Opaque(chalk_ir::BoundedTy {
+            Ty::Dyn { ref bounds } => Ok(chalk_ir::TyData::Dyn(chalk_ir::DynTy {
                 bounds: env.in_binders(
                     // FIXME: Figure out a proper name for this type parameter
                     Some(chalk_ir::ParameterKind::Ty(intern(FIXME_SELF))),

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -117,7 +117,7 @@ where
     T: CastTo<LeafGoal<TF>>,
 {
     fn cast_to(self) -> Goal<TF> {
-        Goal::Leaf(self.cast())
+        GoalData::Leaf(self.cast()).intern()
     }
 }
 
@@ -150,10 +150,11 @@ impl<T: CastTo<Goal<TF>>, TF: TypeFamily> CastTo<Goal<TF>> for Binders<T> {
         if self.binders.is_empty() {
             self.value.cast()
         } else {
-            Goal::Quantified(
+            GoalData::Quantified(
                 QuantifierKind::ForAll,
                 self.map(|bound| Box::new(bound.cast())),
             )
+            .intern()
         }
     }
 }

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -150,11 +150,7 @@ impl<T: CastTo<Goal<TF>>, TF: TypeFamily> CastTo<Goal<TF>> for Binders<T> {
         if self.binders.is_empty() {
             self.value.cast()
         } else {
-            GoalData::Quantified(
-                QuantifierKind::ForAll,
-                self.map(|bound| Box::new(bound.cast())),
-            )
-            .intern()
+            GoalData::Quantified(QuantifierKind::ForAll, self.map(|bound| bound.cast())).intern()
         }
     }
 }

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -76,7 +76,6 @@ macro_rules! reflexive_impl {
 reflexive_impl!(for(TF: TypeFamily) TyData<TF>);
 reflexive_impl!(for(TF: TypeFamily) LifetimeData<TF>);
 reflexive_impl!(for(TF: TypeFamily) TraitRef<TF>);
-reflexive_impl!(for(TF: TypeFamily) LeafGoal<TF>);
 reflexive_impl!(for(TF: TypeFamily) DomainGoal<TF>);
 reflexive_impl!(for(TF: TypeFamily) Goal<TF>);
 reflexive_impl!(for(TF: TypeFamily) WhereClause<TF>);
@@ -103,21 +102,12 @@ where
     }
 }
 
-impl<T, TF: TypeFamily> CastTo<LeafGoal<TF>> for T
+impl<T, TF: TypeFamily> CastTo<Goal<TF>> for T
 where
     T: CastTo<DomainGoal<TF>>,
 {
-    fn cast_to(self) -> LeafGoal<TF> {
-        LeafGoal::DomainGoal(self.cast())
-    }
-}
-
-impl<T, TF: TypeFamily> CastTo<Goal<TF>> for T
-where
-    T: CastTo<LeafGoal<TF>>,
-{
     fn cast_to(self) -> Goal<TF> {
-        GoalData::Leaf(self.cast()).intern()
+        GoalData::DomainGoal(self.cast()).intern()
     }
 }
 
@@ -139,9 +129,9 @@ impl<TF: TypeFamily> CastTo<DomainGoal<TF>> for FromEnv<TF> {
     }
 }
 
-impl<TF: TypeFamily> CastTo<LeafGoal<TF>> for EqGoal<TF> {
-    fn cast_to(self) -> LeafGoal<TF> {
-        LeafGoal::EqGoal(self)
+impl<TF: TypeFamily> CastTo<Goal<TF>> for EqGoal<TF> {
+    fn cast_to(self) -> Goal<TF> {
+        GoalData::EqGoal(self).intern()
     }
 }
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -272,8 +272,8 @@ impl<TF: TypeFamily> Debug for EqGoal<TF> {
 
 impl<TF: TypeFamily> Debug for Goal<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        match *self {
-            Goal::Quantified(qkind, ref subgoal) => {
+        match self.data() {
+            GoalData::Quantified(qkind, ref subgoal) => {
                 write!(fmt, "{:?}<", qkind)?;
                 for (index, binder) in subgoal.binders.iter().enumerate() {
                     if index > 0 {
@@ -286,8 +286,8 @@ impl<TF: TypeFamily> Debug for Goal<TF> {
                 }
                 write!(fmt, "> {{ {:?} }}", subgoal.value)
             }
-            Goal::Implies(ref wc, ref g) => write!(fmt, "if ({:?}) {{ {:?} }}", wc, g),
-            Goal::All(ref goals) => {
+            GoalData::Implies(ref wc, ref g) => write!(fmt, "if ({:?}) {{ {:?} }}", wc, g),
+            GoalData::All(ref goals) => {
                 write!(fmt, "all(")?;
                 for (goal, index) in goals.iter().zip(0..) {
                     if index > 0 {
@@ -298,9 +298,9 @@ impl<TF: TypeFamily> Debug for Goal<TF> {
                 write!(fmt, ")")?;
                 Ok(())
             }
-            Goal::Not(ref g) => write!(fmt, "not {{ {:?} }}", g),
-            Goal::Leaf(ref wc) => write!(fmt, "{:?}", wc),
-            Goal::CannotProve(()) => write!(fmt, r"¯\_(ツ)_/¯"),
+            GoalData::Not(ref g) => write!(fmt, "not {{ {:?} }}", g),
+            GoalData::Leaf(ref wc) => write!(fmt, "{:?}", wc),
+            GoalData::CannotProve(()) => write!(fmt, r"¯\_(ツ)_/¯"),
         }
     }
 }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -58,8 +58,7 @@ impl<TF: TypeFamily> Debug for TyData<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             TyData::BoundVar(depth) => write!(fmt, "^{}", depth),
-            TyData::Dyn(clauses) => write!(fmt, "dyn {:?}", clauses),
-            TyData::Opaque(clauses) => write!(fmt, "impl {:?}", clauses),
+            TyData::Dyn(clauses) => write!(fmt, "{:?}", clauses),
             TyData::InferenceVar(var) => write!(fmt, "{:?}", var),
             TyData::Apply(apply) => write!(fmt, "{:?}", apply),
             TyData::Projection(proj) => write!(fmt, "{:?}", proj),
@@ -69,10 +68,10 @@ impl<TF: TypeFamily> Debug for TyData<TF> {
     }
 }
 
-impl<TF: TypeFamily> Debug for BoundedTy<TF> {
+impl<TF: TypeFamily> Debug for DynTy<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        let BoundedTy { bounds } = self;
-        write!(fmt, "{:?}", bounds)
+        let DynTy { bounds } = self;
+        write!(fmt, "dyn {:?}", bounds)
     }
 }
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -255,15 +255,6 @@ impl<TF: TypeFamily> Debug for DomainGoal<TF> {
     }
 }
 
-impl<TF: TypeFamily> Debug for LeafGoal<TF> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        match *self {
-            LeafGoal::EqGoal(ref eq) => write!(fmt, "{:?}", eq),
-            LeafGoal::DomainGoal(ref dom) => write!(fmt, "{:?}", dom),
-        }
-    }
-}
-
 impl<TF: TypeFamily> Debug for EqGoal<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         write!(fmt, "({:?} = {:?})", self.a, self.b)
@@ -299,7 +290,8 @@ impl<TF: TypeFamily> Debug for Goal<TF> {
                 Ok(())
             }
             GoalData::Not(ref g) => write!(fmt, "not {{ {:?} }}", g),
-            GoalData::Leaf(ref wc) => write!(fmt, "{:?}", wc),
+            GoalData::EqGoal(ref wc) => write!(fmt, "{:?}", wc),
+            GoalData::DomainGoal(ref wc) => write!(fmt, "{:?}", wc),
             GoalData::CannotProve(()) => write!(fmt, r"¯\_(ツ)_/¯"),
         }
     }

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -179,7 +179,7 @@ impl TypeFamily for ChalkIr {
     type InternedType = Box<TyData<ChalkIr>>;
     type InternedLifetime = LifetimeData<ChalkIr>;
     type InternedParameter = ParameterData<ChalkIr>;
-    type InternedGoal = GoalData<ChalkIr>;
+    type InternedGoal = Box<GoalData<ChalkIr>>;
     type DefId = RawId;
 
     fn debug_struct_id(
@@ -234,11 +234,11 @@ impl TypeFamily for ChalkIr {
         parameter
     }
 
-    fn intern_goal(goal: GoalData<ChalkIr>) -> GoalData<ChalkIr> {
-        goal
+    fn intern_goal(goal: GoalData<ChalkIr>) -> Box<GoalData<ChalkIr>> {
+        Box::new(goal)
     }
 
-    fn goal_data(goal: &GoalData<ChalkIr>) -> &GoalData<ChalkIr> {
+    fn goal_data(goal: &Box<GoalData<ChalkIr>>) -> &GoalData<ChalkIr> {
         goal
     }
 }

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -1,5 +1,6 @@
 use crate::tls;
 use crate::AssocTypeId;
+use crate::GoalData;
 use crate::LifetimeData;
 use crate::ParameterData;
 use crate::ProjectionTy;
@@ -57,6 +58,14 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
     /// An `InternedType` is created by `intern_parameter` and can be
     /// converted back to its underlying data via `parameter_data`.
     type InternedParameter: Debug + Clone + Eq + Ord + Hash;
+
+    /// "Interned" representation of a "goal".  In normal user code,
+    /// `Self::InternedGoal` is not referenced. Instead, we refer to
+    /// `Goal<Self>`, which wraps this type.
+    ///
+    /// An `InternedGoal` is created by `intern_goal` and can be
+    /// converted back to its underlying data via `goal_data`.
+    type InternedGoal: Debug + Clone + Eq + Ord + Hash;
 
     /// The core "id" type used for struct-ids and the like.
     type DefId: Debug + Copy + Eq + Ord + Hash;
@@ -129,6 +138,15 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
 
     /// Lookup the `LifetimeData` that was interned to create a `InternedLifetime`.
     fn parameter_data(lifetime: &Self::InternedParameter) -> &ParameterData<Self>;
+
+    /// Create an "interned" goal from `data`. This is not
+    /// normally invoked directly; instead, you invoke
+    /// `GoalData::intern` (which will ultimately call this
+    /// method).
+    fn intern_goal(data: GoalData<Self>) -> Self::InternedGoal;
+
+    /// Lookup the `GoalData` that was interned to create a `InternedGoal`.
+    fn goal_data(lifetime: &Self::InternedGoal) -> &GoalData<Self>;
 }
 
 pub trait TargetTypeFamily<TF: TypeFamily>: TypeFamily {
@@ -161,6 +179,7 @@ impl TypeFamily for ChalkIr {
     type InternedType = Box<TyData<ChalkIr>>;
     type InternedLifetime = LifetimeData<ChalkIr>;
     type InternedParameter = ParameterData<ChalkIr>;
+    type InternedGoal = GoalData<ChalkIr>;
     type DefId = RawId;
 
     fn debug_struct_id(
@@ -213,6 +232,14 @@ impl TypeFamily for ChalkIr {
 
     fn parameter_data(parameter: &ParameterData<ChalkIr>) -> &ParameterData<ChalkIr> {
         parameter
+    }
+
+    fn intern_goal(goal: GoalData<ChalkIr>) -> GoalData<ChalkIr> {
+        goal
+    }
+
+    fn goal_data(goal: &GoalData<ChalkIr>) -> &GoalData<ChalkIr> {
+        goal
     }
 }
 

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -13,6 +13,7 @@ use chalk_engine::ExClause;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 /// A "type family" encapsulates the concrete representation of
 /// certain "core types" from chalk-ir. All the types in chalk-ir are
@@ -176,10 +177,10 @@ pub trait HasTypeFamily {
 pub struct ChalkIr {}
 
 impl TypeFamily for ChalkIr {
-    type InternedType = Box<TyData<ChalkIr>>;
+    type InternedType = Arc<TyData<ChalkIr>>;
     type InternedLifetime = LifetimeData<ChalkIr>;
     type InternedParameter = ParameterData<ChalkIr>;
-    type InternedGoal = Box<GoalData<ChalkIr>>;
+    type InternedGoal = Arc<GoalData<ChalkIr>>;
     type DefId = RawId;
 
     fn debug_struct_id(
@@ -210,11 +211,11 @@ impl TypeFamily for ChalkIr {
         tls::with_current_program(|prog| Some(prog?.debug_projection(projection, fmt)))
     }
 
-    fn intern_ty(ty: TyData<ChalkIr>) -> Box<TyData<ChalkIr>> {
-        Box::new(ty)
+    fn intern_ty(ty: TyData<ChalkIr>) -> Arc<TyData<ChalkIr>> {
+        Arc::new(ty)
     }
 
-    fn ty_data(ty: &Box<TyData<ChalkIr>>) -> &TyData<Self> {
+    fn ty_data(ty: &Arc<TyData<ChalkIr>>) -> &TyData<Self> {
         ty
     }
 
@@ -234,11 +235,11 @@ impl TypeFamily for ChalkIr {
         parameter
     }
 
-    fn intern_goal(goal: GoalData<ChalkIr>) -> Box<GoalData<ChalkIr>> {
-        Box::new(goal)
+    fn intern_goal(goal: GoalData<ChalkIr>) -> Arc<GoalData<ChalkIr>> {
+        Arc::new(goal)
     }
 
-    fn goal_data(goal: &Box<GoalData<ChalkIr>>) -> &GoalData<ChalkIr> {
+    fn goal_data(goal: &Arc<GoalData<ChalkIr>>) -> &GoalData<ChalkIr> {
         goal
     }
 }
@@ -256,6 +257,10 @@ impl<T: HasTypeFamily> HasTypeFamily for Vec<T> {
 }
 
 impl<T: HasTypeFamily> HasTypeFamily for Box<T> {
+    type TypeFamily = T::TypeFamily;
+}
+
+impl<T: HasTypeFamily> HasTypeFamily for Arc<T> {
     type TypeFamily = T::TypeFamily;
 }
 

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -318,7 +318,6 @@ where
             }
         }
         TyData::Dyn(clauses) => Ok(TyData::Dyn(clauses.fold_with(folder, binders)?).intern()),
-        TyData::Opaque(clauses) => Ok(TyData::Opaque(clauses.fold_with(folder, binders)?).intern()),
         TyData::InferenceVar(var) => folder.fold_inference_ty(*var, binders),
         TyData::Apply(apply) => Ok(TyData::Apply(apply.fold_with(folder, binders)?).intern()),
         TyData::Placeholder(ui) => Ok(folder.fold_free_placeholder_ty(*ui, binders)?),

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -98,6 +98,18 @@ impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for Parameter<TF> 
     }
 }
 
+impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for Goal<TF> {
+    type Result = Goal<TTF>;
+    fn fold_with(
+        &self,
+        folder: &mut dyn Folder<TF, TTF>,
+        binders: usize,
+    ) -> Fallible<Self::Result> {
+        let data = self.data().fold_with(folder, binders)?;
+        Ok(Goal::new(data))
+    }
+}
+
 #[macro_export]
 macro_rules! copy_fold {
     ($t:ty) => {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1023,19 +1023,20 @@ impl<T> UCanonical<T> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasTypeFamily)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasTypeFamily)]
 /// A general goal; this is the full range of questions you can pose to Chalk.
 pub struct Goal<TF: TypeFamily> {
-    interned: GoalData<TF>,
+    interned: TF::InternedGoal,
 }
 
 impl<TF: TypeFamily> Goal<TF> {
     pub fn new(interned: GoalData<TF>) -> Self {
+        let interned = TF::intern_goal(interned);
         Self { interned }
     }
 
     pub fn data(&self) -> &GoalData<TF> {
-        &self.interned
+        TF::goal_data(&self.interned)
     }
 
     pub fn quantify(self, kind: QuantifierKind, binders: Vec<ParameterKind<()>>) -> Goal<TF> {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1043,7 +1043,7 @@ impl<TF: TypeFamily> Goal<TF> {
         GoalData::Quantified(
             kind,
             Binders {
-                value: Box::new(self),
+                value: self,
                 binders,
             },
         )
@@ -1052,7 +1052,7 @@ impl<TF: TypeFamily> Goal<TF> {
 
     /// Takes a goal `G` and turns it into `not { G }`
     pub fn negate(self) -> Self {
-        GoalData::Not(Box::new(self)).intern()
+        GoalData::Not(self).intern()
     }
 
     /// Takes a goal `G` and turns it into `compatible { G }`
@@ -1062,27 +1062,25 @@ impl<TF: TypeFamily> Goal<TF> {
         GoalData::Quantified(
             QuantifierKind::ForAll,
             Binders {
-                value: Box::new(self),
+                value: self,
                 binders: Vec::new(),
             }
             .with_fresh_type_var(|goal, ty| {
-                Box::new(
-                    GoalData::Implies(
-                        vec![
-                            DomainGoal::Compatible(()).cast(),
-                            DomainGoal::DownstreamType(ty).cast(),
-                        ],
-                        goal,
-                    )
-                    .intern(),
+                GoalData::Implies(
+                    vec![
+                        DomainGoal::Compatible(()).cast(),
+                        DomainGoal::DownstreamType(ty).cast(),
+                    ],
+                    goal,
                 )
+                .intern()
             }),
         )
         .intern()
     }
 
     pub fn implied_by(self, predicates: Vec<ProgramClause<TF>>) -> Goal<TF> {
-        GoalData::Implies(predicates, Box::new(self)).intern()
+        GoalData::Implies(predicates, self).intern()
     }
 
     /// True if this goal is "trivially true" -- i.e., no work is
@@ -1138,10 +1136,10 @@ where
 pub enum GoalData<TF: TypeFamily> {
     /// Introduces a binding at depth 0, shifting other bindings up
     /// (deBruijn index).
-    Quantified(QuantifierKind, Binders<Box<Goal<TF>>>),
-    Implies(Vec<ProgramClause<TF>>, Box<Goal<TF>>),
+    Quantified(QuantifierKind, Binders<Goal<TF>>),
+    Implies(Vec<ProgramClause<TF>>, Goal<TF>),
     All(Vec<Goal<TF>>),
-    Not(Box<Goal<TF>>),
+    Not(Goal<TF>),
     Leaf(LeafGoal<TF>),
 
     /// Indicates something that cannot be proven to be true or false

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -792,15 +792,6 @@ impl<TF: TypeFamily> DomainGoal<TF> {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
-/// A goal that does not involve any logical connectives. Equality is treated
-/// specially by the logic (as with most first-order logics), since it interacts
-/// with unification etc.
-pub enum LeafGoal<TF: TypeFamily> {
-    EqGoal(EqGoal<TF>),
-    DomainGoal(DomainGoal<TF>),
-}
-
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
 pub struct EqGoal<TF: TypeFamily> {
     pub a: Parameter<TF>,
     pub b: Parameter<TF>,
@@ -1140,7 +1131,13 @@ pub enum GoalData<TF: TypeFamily> {
     Implies(Vec<ProgramClause<TF>>, Goal<TF>),
     All(Vec<Goal<TF>>),
     Not(Goal<TF>),
-    Leaf(LeafGoal<TF>),
+
+    /// Make two things equal; the rules for doing so are well known to the logic
+    EqGoal(EqGoal<TF>),
+
+    /// A "domain goal" indicates some base sort of goal that can be
+    /// proven via program clauses
+    DomainGoal(DomainGoal<TF>),
 
     /// Indicates something that cannot be proven to be true or false
     /// definitively. This can occur with overflow but also with

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -253,14 +253,7 @@ pub enum TyData<TF: TypeFamily> {
     ///
     /// See the `Opaque` variant for a discussion about the use of
     /// binders here.
-    Dyn(BoundedTy<TF>),
-
-    /// An "opaque" type is one that is created via the "impl Trait" syntax.
-    /// They are named so because the concrete type implementing the trait
-    /// is unknown, and hence the type is opaque to us. The only information
-    /// that we know of is that this type implements the traits listed by the
-    /// user.
-    Opaque(BoundedTy<TF>),
+    Dyn(DynTy<TF>),
 
     /// A "projection" type corresponds to an (unnormalized)
     /// projection like `<P0 as Trait<P1..Pn>>::Foo`. Note that the
@@ -296,10 +289,10 @@ impl<TF: TypeFamily> TyData<TF> {
     }
 }
 
-/// A "BoundedTy" could be either a `dyn Trait` or an (opaque) `impl
+/// A "DynTy" could be either a `dyn Trait` or an (opaque) `impl
 /// Trait`. Both of them are conceptually very related to a
 /// "existential type" of the form `exists<T> { T: Trait }`. The
-/// `BoundedTy` type represents those bounds.
+/// `DynTy` type represents those bounds.
 ///
 /// The "binder" here represents the unknown self type. So, a type like
 /// `impl for<'a> Fn(&'a u32)` would be represented with two-levels of
@@ -320,7 +313,7 @@ impl<TF: TypeFamily> TyData<TF> {
 /// a bound type with debruijn index 1 (i.e., skipping through one
 /// level of binder).
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
-pub struct BoundedTy<TF: TypeFamily> {
+pub struct DynTy<TF: TypeFamily> {
     pub bounds: Binders<Vec<QuantifiedWhereClause<TF>>>,
 }
 

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -251,7 +251,6 @@ enum_zip!(impl<TF> for DomainGoal<TF> {
     Compatible,
     DownstreamType
 });
-enum_zip!(impl<TF> for LeafGoal<TF> { DomainGoal, EqGoal });
 enum_zip!(impl<TF> for ProgramClause<TF> { Implies, ForAll });
 
 // Annoyingly, Goal cannot use `enum_zip` because some variants have
@@ -276,13 +275,19 @@ impl<TF: TypeFamily> Zip<TF> for GoalData<TF> {
             }
             (&GoalData::All(ref g_a), &GoalData::All(ref g_b)) => Zip::zip_with(zipper, g_a, g_b),
             (&GoalData::Not(ref f_a), &GoalData::Not(ref f_b)) => Zip::zip_with(zipper, f_a, f_b),
-            (&GoalData::Leaf(ref f_a), &GoalData::Leaf(ref f_b)) => Zip::zip_with(zipper, f_a, f_b),
+            (&GoalData::EqGoal(ref f_a), &GoalData::EqGoal(ref f_b)) => {
+                Zip::zip_with(zipper, f_a, f_b)
+            }
+            (&GoalData::DomainGoal(ref f_a), &GoalData::DomainGoal(ref f_b)) => {
+                Zip::zip_with(zipper, f_a, f_b)
+            }
             (&GoalData::CannotProve(()), &GoalData::CannotProve(())) => Ok(()),
             (&GoalData::Quantified(..), _)
             | (&GoalData::Implies(..), _)
             | (&GoalData::All(..), _)
             | (&GoalData::Not(..), _)
-            | (&GoalData::Leaf(..), _)
+            | (&GoalData::EqGoal(..), _)
+            | (&GoalData::DomainGoal(..), _)
             | (&GoalData::CannotProve(..), _) => {
                 return Err(NoSolution);
             }

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -191,7 +191,7 @@ struct_zip!(impl[
     goal,
 });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for ApplicationTy<TF> { name, parameters });
-struct_zip!(impl[TF: TypeFamily] Zip<TF> for BoundedTy<TF> { bounds });
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for DynTy<TF> { bounds });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for ProjectionTy<TF> {
     associated_ty_id,
     parameters,

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -259,25 +259,31 @@ enum_zip!(impl<TF> for ProgramClause<TF> { Implies, ForAll });
 // relevant name mangling.
 impl<TF: TypeFamily> Zip<TF> for Goal<TF> {
     fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+        Zip::zip_with(zipper, a.data(), b.data())
+    }
+}
+
+impl<TF: TypeFamily> Zip<TF> for GoalData<TF> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
         match (a, b) {
-            (&Goal::Quantified(ref f_a, ref g_a), &Goal::Quantified(ref f_b, ref g_b)) => {
+            (&GoalData::Quantified(ref f_a, ref g_a), &GoalData::Quantified(ref f_b, ref g_b)) => {
                 Zip::zip_with(zipper, f_a, f_b)?;
                 Zip::zip_with(zipper, g_a, g_b)
             }
-            (&Goal::Implies(ref f_a, ref g_a), &Goal::Implies(ref f_b, ref g_b)) => {
+            (&GoalData::Implies(ref f_a, ref g_a), &GoalData::Implies(ref f_b, ref g_b)) => {
                 Zip::zip_with(zipper, f_a, f_b)?;
                 Zip::zip_with(zipper, g_a, g_b)
             }
-            (&Goal::All(ref g_a), &Goal::All(ref g_b)) => Zip::zip_with(zipper, g_a, g_b),
-            (&Goal::Not(ref f_a), &Goal::Not(ref f_b)) => Zip::zip_with(zipper, f_a, f_b),
-            (&Goal::Leaf(ref f_a), &Goal::Leaf(ref f_b)) => Zip::zip_with(zipper, f_a, f_b),
-            (&Goal::CannotProve(()), &Goal::CannotProve(())) => Ok(()),
-            (&Goal::Quantified(..), _)
-            | (&Goal::Implies(..), _)
-            | (&Goal::All(..), _)
-            | (&Goal::Not(..), _)
-            | (&Goal::Leaf(..), _)
-            | (&Goal::CannotProve(..), _) => {
+            (&GoalData::All(ref g_a), &GoalData::All(ref g_b)) => Zip::zip_with(zipper, g_a, g_b),
+            (&GoalData::Not(ref f_a), &GoalData::Not(ref f_b)) => Zip::zip_with(zipper, f_a, f_b),
+            (&GoalData::Leaf(ref f_a), &GoalData::Leaf(ref f_b)) => Zip::zip_with(zipper, f_a, f_b),
+            (&GoalData::CannotProve(()), &GoalData::CannotProve(())) => Ok(()),
+            (&GoalData::Quantified(..), _)
+            | (&GoalData::Implies(..), _)
+            | (&GoalData::All(..), _)
+            | (&GoalData::Not(..), _)
+            | (&GoalData::Leaf(..), _)
+            | (&GoalData::CannotProve(..), _) => {
                 return Err(NoSolution);
             }
         }

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -158,9 +158,6 @@ pub enum Ty {
     Dyn {
         bounds: Vec<QuantifiedInlineBound>,
     },
-    Opaque {
-        bounds: Vec<QuantifiedInlineBound>,
-    },
     Apply {
         name: Identifier,
         args: Vec<Parameter>,

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -177,9 +177,6 @@ TyWithoutFor: Ty = {
     "dyn" <b:Plus<QuantifiedInlineBound>> => Ty::Dyn {
         bounds: b,
     },
-    "impl" <b:Plus<QuantifiedInlineBound>> => Ty::Opaque {
-        bounds: b,
-    },
     <n:Id> "<" <a:Comma<Parameter>> ">" => Ty::Apply { name: n, args: a },
     <p:ProjectionTy> => Ty::Projection { proj: p },
     "(" <Ty> ")",

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -61,8 +61,8 @@ impl<'me, TF: TypeFamily> EnvElaborator<'me, TF> {
             }
 
             // FIXME(#203) -- We haven't fully figured out the implied
-            // bounds story around object and impl trait types.
-            TyData::Dyn(_) | TyData::Opaque(_) => (),
+            // bounds story around `dyn Trait` types.
+            TyData::Dyn(_) => (),
 
             TyData::ForAll(_) | TyData::BoundVar(_) | TyData::InferenceVar(_) => (),
         }

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -221,6 +221,7 @@ impl<TF: TypeFamily> ToProgramClauses<TF> for StructDatum<TF> {
                     builder.push_clause(
                         DomainGoal::$goal(self_ty.clone()),
                         Some(DomainGoal::$goal(
+                            //
                             // This unwrap is safe because we asserted
                             // above for the presence of a type
                             // parameter
@@ -428,7 +429,7 @@ impl<TF: TypeFamily> ToProgramClauses<TF> for TraitDatum<TF> {
                         .chain(iter::once(
                             DomainGoal::DownstreamType(type_parameters[i].clone()).cast(),
                         ))
-                        .chain(iter::once(Goal::CannotProve(()))),
+                        .chain(iter::once(GoalData::CannotProve(()).intern())),
                 );
             }
 
@@ -463,7 +464,7 @@ impl<TF: TypeFamily> ToProgramClauses<TF> for TraitDatum<TF> {
                                 .type_parameters()
                                 .map(|ty| DomainGoal::IsUpstream(ty).cast()),
                         )
-                        .chain(iter::once(Goal::CannotProve(()))),
+                        .chain(iter::once(GoalData::CannotProve(()).intern())),
                 );
             }
 

--- a/chalk-solve/src/coherence/solve.rs
+++ b/chalk-solve/src/coherence/solve.rs
@@ -97,7 +97,7 @@ impl<TF: TypeFamily> CoherenceSolver<'_, TF> {
         // to unify the inputs to both impls with one another
         let params_goals = lhs_params
             .zip(rhs_params)
-            .map(|(a, b)| Goal::Leaf(LeafGoal::EqGoal(EqGoal { a, b })));
+            .map(|(a, b)| GoalData::Leaf(LeafGoal::EqGoal(EqGoal { a, b })).intern());
 
         // Upshift the rhs variables in where clauses
         let lhs_where_clauses = lhs.binders.value.where_clauses.iter().cloned();
@@ -175,7 +175,7 @@ impl<TF: TypeFamily> CoherenceSolver<'_, TF> {
         let less_special_params = params(less_special).iter().map(|p| p.shifted_in(more_len));
         let params_goals = more_special_params
             .zip(less_special_params)
-            .map(|(a, b)| Goal::Leaf(LeafGoal::EqGoal(EqGoal { a, b })));
+            .map(|(a, b)| GoalData::Leaf(LeafGoal::EqGoal(EqGoal { a, b })).intern());
 
         // Create the where clause goals.
         let more_special_wc = more_special

--- a/chalk-solve/src/coherence/solve.rs
+++ b/chalk-solve/src/coherence/solve.rs
@@ -97,7 +97,7 @@ impl<TF: TypeFamily> CoherenceSolver<'_, TF> {
         // to unify the inputs to both impls with one another
         let params_goals = lhs_params
             .zip(rhs_params)
-            .map(|(a, b)| GoalData::Leaf(LeafGoal::EqGoal(EqGoal { a, b })).intern());
+            .map(|(a, b)| GoalData::EqGoal(EqGoal { a, b }).intern());
 
         // Upshift the rhs variables in where clauses
         let lhs_where_clauses = lhs.binders.value.where_clauses.iter().cloned();
@@ -175,7 +175,7 @@ impl<TF: TypeFamily> CoherenceSolver<'_, TF> {
         let less_special_params = params(less_special).iter().map(|p| p.shifted_in(more_len));
         let params_goals = more_special_params
             .zip(less_special_params)
-            .map(|(a, b)| GoalData::Leaf(LeafGoal::EqGoal(EqGoal { a, b })).intern());
+            .map(|(a, b)| GoalData::EqGoal(EqGoal { a, b }).intern());
 
         // Create the where clause goals.
         let more_special_wc = more_special

--- a/chalk-solve/src/coinductive_goal.rs
+++ b/chalk-solve/src/coinductive_goal.rs
@@ -17,16 +17,14 @@ pub trait IsCoinductive<TF: TypeFamily> {
 impl<TF: TypeFamily> IsCoinductive<TF> for Goal<TF> {
     fn is_coinductive(&self, db: &dyn RustIrDatabase<TF>) -> bool {
         match self.data() {
-            GoalData::Leaf(LeafGoal::DomainGoal(DomainGoal::Holds(wca))) => match wca {
+            GoalData::DomainGoal(DomainGoal::Holds(wca)) => match wca {
                 WhereClause::Implemented(tr) => {
                     db.trait_datum(tr.trait_id).is_auto_trait()
                         || db.trait_datum(tr.trait_id).is_coinductive_trait()
                 }
                 WhereClause::ProjectionEq(..) => false,
             },
-            GoalData::Leaf(LeafGoal::DomainGoal(DomainGoal::WellFormed(WellFormed::Trait(..)))) => {
-                true
-            }
+            GoalData::DomainGoal(DomainGoal::WellFormed(WellFormed::Trait(..))) => true,
             GoalData::Quantified(QuantifierKind::ForAll, goal) => goal.value.is_coinductive(db),
             _ => false,
         }

--- a/chalk-solve/src/coinductive_goal.rs
+++ b/chalk-solve/src/coinductive_goal.rs
@@ -16,16 +16,18 @@ pub trait IsCoinductive<TF: TypeFamily> {
 
 impl<TF: TypeFamily> IsCoinductive<TF> for Goal<TF> {
     fn is_coinductive(&self, db: &dyn RustIrDatabase<TF>) -> bool {
-        match self {
-            Goal::Leaf(LeafGoal::DomainGoal(DomainGoal::Holds(wca))) => match wca {
+        match self.data() {
+            GoalData::Leaf(LeafGoal::DomainGoal(DomainGoal::Holds(wca))) => match wca {
                 WhereClause::Implemented(tr) => {
                     db.trait_datum(tr.trait_id).is_auto_trait()
                         || db.trait_datum(tr.trait_id).is_coinductive_trait()
                 }
                 WhereClause::ProjectionEq(..) => false,
             },
-            Goal::Leaf(LeafGoal::DomainGoal(DomainGoal::WellFormed(WellFormed::Trait(..)))) => true,
-            Goal::Quantified(QuantifierKind::ForAll, goal) => goal.value.is_coinductive(db),
+            GoalData::Leaf(LeafGoal::DomainGoal(DomainGoal::WellFormed(WellFormed::Trait(..)))) => {
+                true
+            }
+            GoalData::Quantified(QuantifierKind::ForAll, goal) => goal.value.is_coinductive(db),
             _ => false,
         }
     }

--- a/chalk-solve/src/ext.rs
+++ b/chalk-solve/src/ext.rs
@@ -68,20 +68,20 @@ impl<TF: TypeFamily> GoalExt<TF> for Goal<TF> {
             let mut env_goal = InEnvironment::new(&Environment::new(), self);
             loop {
                 let InEnvironment { environment, goal } = env_goal;
-                match goal {
-                    Goal::Quantified(QuantifierKind::ForAll, subgoal) => {
-                        let subgoal = infer.instantiate_binders_universally(&subgoal);
+                match goal.data() {
+                    GoalData::Quantified(QuantifierKind::ForAll, subgoal) => {
+                        let subgoal = infer.instantiate_binders_universally(subgoal);
                         env_goal = InEnvironment::new(&environment, *subgoal);
                     }
 
-                    Goal::Quantified(QuantifierKind::Exists, subgoal) => {
-                        let subgoal = infer.instantiate_binders_existentially(&subgoal);
+                    GoalData::Quantified(QuantifierKind::Exists, subgoal) => {
+                        let subgoal = infer.instantiate_binders_existentially(subgoal);
                         env_goal = InEnvironment::new(&environment, *subgoal);
                     }
 
-                    Goal::Implies(wc, subgoal) => {
-                        let new_environment = &environment.add_clauses(wc);
-                        env_goal = InEnvironment::new(&new_environment, *subgoal);
+                    GoalData::Implies(wc, subgoal) => {
+                        let new_environment = environment.add_clauses(wc.iter().cloned());
+                        env_goal = InEnvironment::new(&new_environment, Goal::clone(subgoal));
                     }
 
                     _ => break InEnvironment::new(&environment, goal),

--- a/chalk-solve/src/ext.rs
+++ b/chalk-solve/src/ext.rs
@@ -71,12 +71,12 @@ impl<TF: TypeFamily> GoalExt<TF> for Goal<TF> {
                 match goal.data() {
                     GoalData::Quantified(QuantifierKind::ForAll, subgoal) => {
                         let subgoal = infer.instantiate_binders_universally(subgoal);
-                        env_goal = InEnvironment::new(&environment, *subgoal);
+                        env_goal = InEnvironment::new(&environment, subgoal);
                     }
 
                     GoalData::Quantified(QuantifierKind::Exists, subgoal) => {
                         let subgoal = infer.instantiate_binders_existentially(subgoal);
-                        env_goal = InEnvironment::new(&environment, *subgoal);
+                        env_goal = InEnvironment::new(&environment, subgoal);
                     }
 
                     GoalData::Implies(wc, subgoal) => {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -70,7 +70,7 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
     type Environment = Environment<TF>;
     type DomainGoal = DomainGoal<TF>;
     type Goal = Goal<TF>;
-    type BindersGoal = Binders<Box<Goal<TF>>>;
+    type BindersGoal = Binders<Goal<TF>>;
     type Parameter = Parameter<TF>;
     type ProgramClause = ProgramClause<TF>;
     type ProgramClauses = Vec<ProgramClause<TF>>;
@@ -324,9 +324,9 @@ impl<TF: TypeFamily> context::InferenceTable<SlgContext<TF>> for TruncatingInfer
             GoalData::Quantified(QuantifierKind::Exists, binders_goal) => {
                 HhGoal::Exists(binders_goal)
             }
-            GoalData::Implies(dg, subgoal) => HhGoal::Implies(dg, *subgoal),
+            GoalData::Implies(dg, subgoal) => HhGoal::Implies(dg, subgoal),
             GoalData::All(goals) => HhGoal::All(goals),
-            GoalData::Not(g1) => HhGoal::Not(*g1),
+            GoalData::Not(g1) => HhGoal::Not(g1),
             GoalData::Leaf(LeafGoal::EqGoal(EqGoal { a, b })) => HhGoal::Unify((), a, b),
             GoalData::Leaf(LeafGoal::DomainGoal(domain_goal)) => HhGoal::DomainGoal(domain_goal),
             GoalData::CannotProve(()) => HhGoal::CannotProve,
@@ -360,12 +360,12 @@ impl<TF: TypeFamily> context::InferenceTable<SlgContext<TF>> for TruncatingInfer
 }
 
 impl<TF: TypeFamily> context::UnificationOps<SlgContext<TF>> for TruncatingInferenceTable<TF> {
-    fn instantiate_binders_universally(&mut self, arg: &Binders<Box<Goal<TF>>>) -> Goal<TF> {
-        *self.infer.instantiate_binders_universally(arg)
+    fn instantiate_binders_universally(&mut self, arg: &Binders<Goal<TF>>) -> Goal<TF> {
+        self.infer.instantiate_binders_universally(arg)
     }
 
-    fn instantiate_binders_existentially(&mut self, arg: &Binders<Box<Goal<TF>>>) -> Goal<TF> {
-        *self.infer.instantiate_binders_existentially(arg)
+    fn instantiate_binders_existentially(&mut self, arg: &Binders<Goal<TF>>) -> Goal<TF> {
+        self.infer.instantiate_binders_existentially(arg)
     }
 
     fn debug_ex_clause<'v>(&mut self, value: &'v ExClause<SlgContext<TF>>) -> Box<dyn Debug + 'v> {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -327,8 +327,8 @@ impl<TF: TypeFamily> context::InferenceTable<SlgContext<TF>> for TruncatingInfer
             GoalData::Implies(dg, subgoal) => HhGoal::Implies(dg, subgoal),
             GoalData::All(goals) => HhGoal::All(goals),
             GoalData::Not(g1) => HhGoal::Not(g1),
-            GoalData::Leaf(LeafGoal::EqGoal(EqGoal { a, b })) => HhGoal::Unify((), a, b),
-            GoalData::Leaf(LeafGoal::DomainGoal(domain_goal)) => HhGoal::DomainGoal(domain_goal),
+            GoalData::EqGoal(EqGoal { a, b }) => HhGoal::Unify((), a, b),
+            GoalData::DomainGoal(domain_goal) => HhGoal::DomainGoal(domain_goal),
             GoalData::CannotProve(()) => HhGoal::CannotProve,
         }
     }

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -525,7 +525,6 @@ impl MayInvalidate {
             // For everything else, be conservative here and just say we may invalidate.
             (TyData::ForAll(_), _)
             | (TyData::Dyn(_), _)
-            | (TyData::Opaque(_), _)
             | (TyData::Apply(_), _)
             | (TyData::Placeholder(_), _)
             | (TyData::Projection(_), _) => true,

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -317,15 +317,19 @@ impl<TF: TypeFamily> context::TruncateOps<SlgContext<TF>> for TruncatingInferenc
 
 impl<TF: TypeFamily> context::InferenceTable<SlgContext<TF>> for TruncatingInferenceTable<TF> {
     fn into_hh_goal(&mut self, goal: Goal<TF>) -> HhGoal<SlgContext<TF>> {
-        match goal {
-            Goal::Quantified(QuantifierKind::ForAll, binders_goal) => HhGoal::ForAll(binders_goal),
-            Goal::Quantified(QuantifierKind::Exists, binders_goal) => HhGoal::Exists(binders_goal),
-            Goal::Implies(dg, subgoal) => HhGoal::Implies(dg, *subgoal),
-            Goal::All(goals) => HhGoal::All(goals),
-            Goal::Not(g1) => HhGoal::Not(*g1),
-            Goal::Leaf(LeafGoal::EqGoal(EqGoal { a, b })) => HhGoal::Unify((), a, b),
-            Goal::Leaf(LeafGoal::DomainGoal(domain_goal)) => HhGoal::DomainGoal(domain_goal),
-            Goal::CannotProve(()) => HhGoal::CannotProve,
+        match goal.data().clone() {
+            GoalData::Quantified(QuantifierKind::ForAll, binders_goal) => {
+                HhGoal::ForAll(binders_goal)
+            }
+            GoalData::Quantified(QuantifierKind::Exists, binders_goal) => {
+                HhGoal::Exists(binders_goal)
+            }
+            GoalData::Implies(dg, subgoal) => HhGoal::Implies(dg, *subgoal),
+            GoalData::All(goals) => HhGoal::All(goals),
+            GoalData::Not(g1) => HhGoal::Not(*g1),
+            GoalData::Leaf(LeafGoal::EqGoal(EqGoal { a, b })) => HhGoal::Unify((), a, b),
+            GoalData::Leaf(LeafGoal::DomainGoal(domain_goal)) => HhGoal::DomainGoal(domain_goal),
+            GoalData::CannotProve(()) => HhGoal::CannotProve,
         }
     }
 

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -181,8 +181,7 @@ impl<TF: TypeFamily> AntiUnifier<'_, TF> {
             // variable in there and be done with it.
             (TyData::BoundVar(_), TyData::BoundVar(_))
             | (TyData::ForAll(_), TyData::ForAll(_))
-            | (TyData::Dyn(_), TyData::Dyn(_))
-            | (TyData::Opaque(_), TyData::Opaque(_)) => self.new_variable(),
+            | (TyData::Dyn(_), TyData::Dyn(_)) => self.new_variable(),
 
             (TyData::Apply(apply1), TyData::Apply(apply2)) => {
                 self.aggregate_application_tys(apply1, apply2)
@@ -200,7 +199,6 @@ impl<TF: TypeFamily> AntiUnifier<'_, TF> {
             (TyData::InferenceVar(_), _)
             | (TyData::BoundVar(_), _)
             | (TyData::Dyn(_), _)
-            | (TyData::Opaque(_), _)
             | (TyData::ForAll(_), _)
             | (TyData::Apply(_), _)
             | (TyData::Projection(_), _)

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -360,10 +360,7 @@ impl<TF: TypeFamily> Zipper<TF> for AnswerSubstitutor<'_, TF> {
 
             (TyData::Apply(answer), TyData::Apply(pending)) => Zip::zip_with(self, answer, pending),
 
-            (TyData::Dyn(answer), TyData::Dyn(pending))
-            | (TyData::Opaque(answer), TyData::Opaque(pending)) => {
-                Zip::zip_with(self, answer, pending)
-            }
+            (TyData::Dyn(answer), TyData::Dyn(pending)) => Zip::zip_with(self, answer, pending),
 
             (TyData::Projection(answer), TyData::Projection(pending)) => {
                 Zip::zip_with(self, answer, pending)
@@ -390,7 +387,6 @@ impl<TF: TypeFamily> Zipper<TF> for AnswerSubstitutor<'_, TF> {
             (TyData::BoundVar(_), _)
             | (TyData::Apply(_), _)
             | (TyData::Dyn(_), _)
-            | (TyData::Opaque(_), _)
             | (TyData::Projection(_), _)
             | (TyData::Placeholder(_), _)
             | (TyData::ForAll(_), _) => panic!(

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -111,9 +111,11 @@ impl<TF: TypeFamily> context::ResolventOps<SlgContext<TF>> for TruncatingInferen
         // Add the `conditions` from the program clause into the result too.
         ex_clause
             .subgoals
-            .extend(conditions.into_iter().map(|c| match c {
-                Goal::Not(c) => Literal::Negative(InEnvironment::new(environment, *c)),
-                c => Literal::Positive(InEnvironment::new(environment, c)),
+            .extend(conditions.into_iter().map(|c| match c.data() {
+                GoalData::Not(c) => {
+                    Literal::Negative(InEnvironment::new(environment, Goal::clone(c)))
+                }
+                _ => Literal::Positive(InEnvironment::new(environment, c)),
             }));
 
         Ok(ex_clause)

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -68,7 +68,7 @@ impl<TF: TypeFamily> FoldInputTypes for Ty<TF> {
                 app.parameters.fold(accumulator);
             }
 
-            TyData::Dyn(qwc) | TyData::Opaque(qwc) => {
+            TyData::Dyn(qwc) => {
                 accumulator.push(self.clone());
                 qwc.bounds.fold(accumulator);
             }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -172,7 +172,8 @@ where
 
         // We ask that the above input types are well-formed provided that all the where-clauses
         // on the struct definition hold.
-        let goal = Goal::Implies(hypotheses, goal)
+        let goal = GoalData::Implies(hypotheses, goal)
+            .intern()
             .quantify(QuantifierKind::ForAll, struct_datum.binders.binders.clone());
 
         let is_legal = match self
@@ -264,7 +265,8 @@ where
             )
             .collect();
 
-        let goal = Goal::Implies(hypotheses, goal)
+        let goal = GoalData::Implies(hypotheses, goal)
+            .intern()
             .quantify(QuantifierKind::ForAll, impl_datum.binders.binders.clone());
 
         debug!("WF trait goal: {:?}", goal);
@@ -399,7 +401,7 @@ where
             .casted()
             .collect();
 
-        let goal = Goal::Implies(hypotheses, Box::new(goal));
+        let goal = GoalData::Implies(hypotheses, Box::new(goal)).intern();
 
         // Create a composed goal that is universally quantified over
         // the parameters from the associated type value (e.g.,

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -158,7 +158,7 @@ where
             .into_iter()
             .map(|ty| DomainGoal::WellFormed(WellFormed::Ty(ty)))
             .casted();
-        let goal = goals.collect::<Box<Goal<TF>>>();
+        let goal = goals.collect::<Goal<TF>>();
 
         let hypotheses = struct_datum
             .binders
@@ -244,7 +244,7 @@ where
             .chain(assoc_ty_goals)
             .chain(Some(trait_ref_wf).cast());
 
-        let goal = goals.collect::<Box<Goal<TF>>>();
+        let goal = goals.collect::<Goal<TF>>();
 
         // Assumptions: types appearing in the header which are not projection types are
         // assumed to be well-formed, and where clauses declared on the impl are assumed
@@ -401,7 +401,7 @@ where
             .casted()
             .collect();
 
-        let goal = GoalData::Implies(hypotheses, Box::new(goal)).intern();
+        let goal = GoalData::Implies(hypotheses, goal).intern();
 
         // Create a composed goal that is universally quantified over
         // the parameters from the associated type value (e.g.,

--- a/tests/test/existential_types.rs
+++ b/tests/test/existential_types.rs
@@ -14,12 +14,6 @@ fn dyn_Clone_is_Clone() {
         } yields {
             "Unique; substitution []"
         }
-
-        goal {
-            impl Clone: Clone
-        } yields {
-            "Unique; substitution []"
-        }
     }
 }
 
@@ -101,23 +95,7 @@ fn dyn_higher_ranked_type_arguments() {
 
         goal {
             forall<'static> {
-                impl forall<'a> Foo<Ref<'a>>: Foo<Ref<'static>>
-            }
-        } yields {
-            "Unique; substitution [], lifetime constraints []"
-        }
-
-        goal {
-            forall<'static> {
                 dyn forall<'a> Foo<Ref<'a>> + Bar: Foo<Ref<'static>>
-            }
-        } yields {
-            "Unique; substitution [], lifetime constraints []"
-        }
-
-        goal {
-            forall<'static> {
-                impl forall<'a> Foo<Ref<'a>> + Bar: Foo<Ref<'static>>
             }
         } yields {
             "Unique; substitution [], lifetime constraints []"
@@ -133,17 +111,6 @@ fn dyn_higher_ranked_type_arguments() {
             forall<'static> {
                 forall<'a> {
                     dyn Foo<Ref<'static>>: Foo<Ref<'a>>
-                }
-            }
-        } yields {
-            // Note that this requires 'a == 'static, so it would be resolveable later on.
-            "Unique; substitution [], lifetime constraints [InEnvironment { environment: Env([]), goal: '!2_0 == '!1_0 }]"
-        }
-
-        goal {
-            forall<'static> {
-                forall<'a> {
-                    impl Foo<Ref<'static>>: Foo<Ref<'a>>
                 }
             }
         } yields {


### PR DESCRIPTION
Moving closer to the proposal in #312 

* Remove `TyData::Opaque` -- this was meant to be impl Trait, but I realized later that this would be modeled quite differently, as a form of "alias type" (not yet added)
* Rename `BoundTy` to `DynTy`, since that is more obvious what it means
* Make the representation of `Goal` part of `TypeFamily`
* Remove explicit uses of `Box` from `GoalData`
* Move to `Arc` for the chalk-ir
* Simplify `GoalData` by removing `LeafGoal`