### PR TITLE
intern "substitutions"

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -904,7 +904,7 @@ impl LowerProjectionTy for ProjectionTy {
         } = *self;
         let chalk_ir::TraitRef {
             trait_id,
-            parameters: trait_parameters,
+            substitution: trait_substitution,
         } = trait_ref.lower(env)?;
         let lookup = match env.associated_ty_lookups.get(&(trait_id.into(), name.str)) {
             Some(lookup) => lookup,
@@ -933,11 +933,11 @@ impl LowerProjectionTy for ProjectionTy {
             }
         }
 
-        args.extend(trait_parameters);
+        args.extend(trait_substitution.iter().cloned());
 
         Ok(chalk_ir::ProjectionTy {
             associated_ty_id: lookup.id,
-            parameters: args,
+            substitution: chalk_ir::Substitution::from(args),
         })
     }
 }
@@ -961,7 +961,7 @@ impl LowerTy for Ty {
                     } else {
                         Ok(chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
                             name: chalk_ir::TypeName::Struct(id),
-                            parameters: vec![],
+                            substitution: chalk_ir::Substitution::empty(),
                         })
                         .intern())
                     }
@@ -1001,10 +1001,10 @@ impl LowerTy for Ty {
                     })?;
                 }
 
-                let parameters = args
+                let substitution = args
                     .iter()
                     .map(|t| Ok(t.lower(env)?))
-                    .collect::<LowerResult<Vec<_>>>()?;
+                    .collect::<LowerResult<chalk_ir::Substitution<_>>>()?;
 
                 for (param, arg) in k.binders.binders.iter().zip(args.iter()) {
                     if param.kind() != arg.kind() {
@@ -1018,7 +1018,7 @@ impl LowerTy for Ty {
 
                 Ok(chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
                     name: chalk_ir::TypeName::Struct(id),
-                    parameters: parameters,
+                    substitution: substitution,
                 })
                 .intern())
             }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1001,10 +1001,8 @@ impl LowerTy for Ty {
                     })?;
                 }
 
-                let substitution = args
-                    .iter()
-                    .map(|t| Ok(t.lower(env)?))
-                    .collect::<LowerResult<chalk_ir::Substitution<_>>>()?;
+                let substitution =
+                    chalk_ir::Substitution::from_fallible(args.iter().map(|t| Ok(t.lower(env)?)))?;
 
                 for (param, arg) in k.binders.binders.iter().zip(args.iter()) {
                     if param.kind() != arg.kind() {

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -163,8 +163,11 @@ impl RustIrDatabase<ChalkIr> for Program {
             .filter(|(_, impl_datum)| {
                 let trait_ref = &impl_datum.binders.value.trait_ref;
                 trait_id == trait_ref.trait_id && {
-                    assert_eq!(trait_ref.parameters.len(), parameters.len());
-                    <[_] as CouldMatch<[_]>>::could_match(&parameters, &trait_ref.parameters)
+                    assert_eq!(trait_ref.substitution.len(), parameters.len());
+                    <[_] as CouldMatch<[_]>>::could_match(
+                        &parameters,
+                        &trait_ref.substitution.parameters(),
+                    )
                 }
             })
             .map(|(&impl_id, _)| impl_id)

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -191,7 +191,7 @@ impl RustIrDatabase<ChalkIr> for Program {
         self.impl_data.values().any(|impl_datum| {
             let impl_trait_ref = &impl_datum.binders.value.trait_ref;
             impl_trait_ref.trait_id == auto_trait_id
-                && match impl_trait_ref.parameters[0].assert_ty_ref().data() {
+                && match impl_trait_ref.self_type_parameter().data() {
                     TyData::Apply(apply) => match apply.name {
                         TypeName::Struct(id) => id == struct_id,
                         _ => false,

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -169,6 +169,12 @@ impl<TF: TypeFamily> CastTo<Parameter<TF>> for Lifetime<TF> {
     }
 }
 
+impl<TF: TypeFamily> CastTo<Parameter<TF>> for Parameter<TF> {
+    fn cast_to(self) -> Parameter<TF> {
+        self
+    }
+}
+
 impl<T, TF> CastTo<ProgramClause<TF>> for T
 where
     T: CastTo<DomainGoal<TF>>,

--- a/chalk-ir/src/could_match.rs
+++ b/chalk-ir/src/could_match.rs
@@ -24,10 +24,10 @@ where
                         let names_could_match = a.name == b.name;
 
                         names_could_match
-                            && a.parameters
+                            && a.substitution
                                 .iter()
-                                .zip(&b.parameters)
-                                .all(|(p_a, p_b)| p_a.could_match(p_b))
+                                .zip(&b.substitution)
+                                .all(|(p_a, p_b)| p_a.could_match(&p_b))
                     }
 
                     _ => true,

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -409,7 +409,7 @@ impl<TF: TypeFamily> Substitution<TF> {
     /// Displays the substitution in the form `< P0, .. Pn >`, or (if
     /// the substitution is empty) as an empty string.
     pub fn with_angle(&self) -> Angle<'_, Parameter<TF>> {
-        Angle(&self.parameters)
+        Angle(self.parameters())
     }
 }
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -425,7 +425,7 @@ impl<TF: TypeFamily> Display for Substitution<TF> {
 
         write!(f, "[")?;
 
-        for (index, value) in self.parameters.iter().enumerate() {
+        for (index, value) in self.iter().enumerate() {
             if first {
                 first = false;
             } else {

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -115,7 +115,8 @@ impl Debug for PlaceholderIndex {
 
 impl<TF: TypeFamily> Debug for ApplicationTy<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        write!(fmt, "{:?}{:?}", self.name, Angle(&self.parameters))
+        let ApplicationTy { name, substitution } = self;
+        write!(fmt, "{:?}{:?}", name, substitution.with_angle())
     }
 }
 
@@ -150,27 +151,22 @@ struct SeparatorTraitRef<'me, TF: TypeFamily> {
 
 impl<TF: TypeFamily> Debug for SeparatorTraitRef<'_, TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        let parameters = self.trait_ref.substitution.parameters();
         write!(
             fmt,
             "{:?}{}{:?}{:?}",
-            self.trait_ref.parameters[0],
+            parameters[0],
             self.separator,
             self.trait_ref.trait_id,
-            Angle(&self.trait_ref.parameters[1..])
+            Angle(&parameters[1..])
         )
     }
 }
 
 impl<TF: TypeFamily> Debug for ProjectionTy<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        TF::debug_projection(self, fmt).unwrap_or_else(|| {
-            write!(
-                fmt,
-                "({:?}){:?}",
-                self.associated_ty_id,
-                Angle(&self.parameters)
-            )
-        })
+        TF::debug_projection(self, fmt)
+            .unwrap_or_else(|| write!(fmt, "({:?}){:?}", self.associated_ty_id, &self.substitution))
     }
 }
 
@@ -242,13 +238,9 @@ impl<TF: TypeFamily> Debug for DomainGoal<TF> {
             DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),
             DomainGoal::IsUpstream(n) => write!(fmt, "IsUpstream({:?})", n),
             DomainGoal::IsFullyVisible(n) => write!(fmt, "IsFullyVisible({:?})", n),
-            DomainGoal::LocalImplAllowed(tr) => write!(
-                fmt,
-                "LocalImplAllowed({:?}: {:?}{:?})",
-                tr.parameters[0],
-                tr.trait_id,
-                Angle(&tr.parameters[1..])
-            ),
+            DomainGoal::LocalImplAllowed(tr) => {
+                write!(fmt, "LocalImplAllowed({:?})", tr.with_colon(),)
+            }
             DomainGoal::Compatible(_) => write!(fmt, "Compatible"),
             DomainGoal::DownstreamType(n) => write!(fmt, "DownstreamType({:?})", n),
         }
@@ -413,9 +405,17 @@ impl<TF: TypeFamily> Display for ConstrainedSubst<TF> {
     }
 }
 
+impl<TF: TypeFamily> Substitution<TF> {
+    /// Displays the substitution in the form `< P0, .. Pn >`, or (if
+    /// the substitution is empty) as an empty string.
+    pub fn with_angle(&self) -> Angle<'_, Parameter<TF>> {
+        Angle(&self.parameters)
+    }
+}
+
 impl<TF: TypeFamily> Debug for Substitution<TF> {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        Display::fmt(self, f)
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        Display::fmt(self, fmt)
     }
 }
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -165,8 +165,14 @@ impl<TF: TypeFamily> Debug for SeparatorTraitRef<'_, TF> {
 
 impl<TF: TypeFamily> Debug for ProjectionTy<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        TF::debug_projection(self, fmt)
-            .unwrap_or_else(|| write!(fmt, "({:?}){:?}", self.associated_ty_id, &self.substitution))
+        TF::debug_projection(self, fmt).unwrap_or_else(|| {
+            write!(
+                fmt,
+                "({:?}){:?}",
+                self.associated_ty_id,
+                self.substitution.with_angle()
+            )
+        })
     }
 }
 

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -155,8 +155,8 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
     /// method).
     fn intern_goal(data: GoalData<Self>) -> Self::InternedGoal;
 
-    /// Lookup the `LifetimeData` that was interned to create a `InternedLifetime`.
-    fn goal_data(lifetime: &Self::InternedGoal) -> &GoalData<Self>;
+    /// Lookup the `GoalData` that was interned to create a `InternedGoal`.
+    fn goal_data(goal: &Self::InternedGoal) -> &GoalData<Self>;
 
     /// Create an "interned" substitution from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -167,7 +167,7 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
     ) -> Result<Self::InternedSubstitution, E>;
 
     /// Lookup the `SubstitutionData` that was interned to create a `InternedSubstitution`.
-    fn substitution_data(lifetime: &Self::InternedSubstitution) -> &[Parameter<Self>];
+    fn substitution_data(substitution: &Self::InternedSubstitution) -> &[Parameter<Self>];
 }
 
 pub trait TargetTypeFamily<TF: TypeFamily>: TypeFamily {

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -2,6 +2,7 @@ use crate::tls;
 use crate::AssocTypeId;
 use crate::GoalData;
 use crate::LifetimeData;
+use crate::Parameter;
 use crate::ParameterData;
 use crate::ProjectionTy;
 use crate::RawId;
@@ -67,6 +68,14 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
     /// An `InternedGoal` is created by `intern_goal` and can be
     /// converted back to its underlying data via `goal_data`.
     type InternedGoal: Debug + Clone + Eq + Ord + Hash;
+
+    /// "Interned" representation of a "substitution".  In normal user code,
+    /// `Self::InternedSubstitution` is not referenced. Instead, we refer to
+    /// `Substitution<Self>`, which wraps this type.
+    ///
+    /// An `InternedSubstitution` is created by `intern_substitution` and can be
+    /// converted back to its underlying data via `substitution_data`.
+    type InternedSubstitution: Debug + Clone + Eq + Ord + Hash;
 
     /// The core "id" type used for struct-ids and the like.
     type DefId: Debug + Copy + Eq + Ord + Hash;
@@ -146,8 +155,19 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
     /// method).
     fn intern_goal(data: GoalData<Self>) -> Self::InternedGoal;
 
-    /// Lookup the `GoalData` that was interned to create a `InternedGoal`.
+    /// Lookup the `LifetimeData` that was interned to create a `InternedLifetime`.
     fn goal_data(lifetime: &Self::InternedGoal) -> &GoalData<Self>;
+
+    /// Create an "interned" substitution from `data`. This is not
+    /// normally invoked directly; instead, you invoke
+    /// `SubstitutionData::intern` (which will ultimately call this
+    /// method).
+    fn intern_substitution<E>(
+        data: impl IntoIterator<Item = Result<Parameter<Self>, E>>,
+    ) -> Result<Self::InternedSubstitution, E>;
+
+    /// Lookup the `SubstitutionData` that was interned to create a `InternedSubstitution`.
+    fn substitution_data(lifetime: &Self::InternedSubstitution) -> &[Parameter<Self>];
 }
 
 pub trait TargetTypeFamily<TF: TypeFamily>: TypeFamily {
@@ -181,6 +201,7 @@ impl TypeFamily for ChalkIr {
     type InternedLifetime = LifetimeData<ChalkIr>;
     type InternedParameter = ParameterData<ChalkIr>;
     type InternedGoal = Arc<GoalData<ChalkIr>>;
+    type InternedSubstitution = Vec<Parameter<ChalkIr>>;
     type DefId = RawId;
 
     fn debug_struct_id(
@@ -241,6 +262,16 @@ impl TypeFamily for ChalkIr {
 
     fn goal_data(goal: &Arc<GoalData<ChalkIr>>) -> &GoalData<ChalkIr> {
         goal
+    }
+
+    fn intern_substitution<E>(
+        data: impl IntoIterator<Item = Result<Parameter<ChalkIr>, E>>,
+    ) -> Result<Vec<Parameter<ChalkIr>>, E> {
+        data.into_iter().collect()
+    }
+
+    fn substitution_data(substitution: &Vec<Parameter<ChalkIr>>) -> &[Parameter<ChalkIr>] {
+        substitution
     }
 }
 

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -86,6 +86,7 @@ impl<T: Fold<TF, TTF>, TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> 
         }
     }
 }
+
 impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for Parameter<TF> {
     type Result = Parameter<TTF>;
     fn fold_with(
@@ -107,6 +108,19 @@ impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for Goal<TF> {
     ) -> Fallible<Self::Result> {
         let data = self.data().fold_with(folder, binders)?;
         Ok(Goal::new(data))
+    }
+}
+
+impl<TF: TypeFamily, TTF: TargetTypeFamily<TF>> Fold<TF, TTF> for Substitution<TF> {
+    type Result = Substitution<TTF>;
+    fn fold_with(
+        &self,
+        folder: &mut dyn Folder<TF, TTF>,
+        binders: usize,
+    ) -> Fallible<Self::Result> {
+        Ok(Substitution::from_fallible(
+            self.iter().map(|p| p.fold_with(folder, binders)),
+        )?)
     }
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -594,8 +594,8 @@ impl<TF: TypeFamily> TraitRef<TF> {
         self.parameters.iter().filter_map(|p| p.ty()).cloned()
     }
 
-    pub fn self_type_parameter(&self) -> Option<Ty<TF>> {
-        self.type_parameters().next()
+    pub fn self_type_parameter(&self) -> Ty<TF> {
+        self.type_parameters().next().unwrap()
     }
 
     pub fn from_env(self) -> FromEnv<TF> {

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -5,7 +5,7 @@ macro_rules! ty {
     (apply $n:tt $($arg:tt)*) => {
         $crate::TyData::Apply(ApplicationTy {
             name: ty_name!($n),
-            parameters: vec![$(arg!($arg)),*],
+            substitution: $crate::Substitution::from(vec![$(arg!($arg)),*] as Vec<$crate::Parameter<_>>),
         }).intern()
     };
 
@@ -26,7 +26,7 @@ macro_rules! ty {
     (projection (item $n:tt) $($arg:tt)*) => {
         $crate::TyData::Projection(ProjectionTy {
             associated_ty_id: AssocTypeId(RawId { index: $n }),
-            parameters: vec![$(arg!($arg)),*],
+            substitution: $crate::Substitution::from(vec![$(arg!($arg)),*] as Vec<$crate::Parameter<_>>),
         }).intern()
     };
 

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -179,9 +179,12 @@ macro_rules! struct_zip {
     }
 }
 
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for Substitution<TF> {
+    parameters,
+});
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for TraitRef<TF> {
     trait_id,
-    parameters,
+    substitution,
 });
 struct_zip!(impl[
     T: HasTypeFamily<TypeFamily = TF> + Zip<TF>,
@@ -190,11 +193,11 @@ struct_zip!(impl[
     environment,
     goal,
 });
-struct_zip!(impl[TF: TypeFamily] Zip<TF> for ApplicationTy<TF> { name, parameters });
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for ApplicationTy<TF> { name, substitution });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for DynTy<TF> { bounds });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for ProjectionTy<TF> {
     associated_ty_id,
-    parameters,
+    substitution,
 });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for Normalize<TF> { projection, ty });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for ProjectionEq<TF> { projection, ty });

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -179,9 +179,6 @@ macro_rules! struct_zip {
     }
 }
 
-struct_zip!(impl[TF: TypeFamily] Zip<TF> for Substitution<TF> {
-    parameters,
-});
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for TraitRef<TF> {
     trait_id,
     substitution,
@@ -255,6 +252,12 @@ enum_zip!(impl<TF> for DomainGoal<TF> {
     DownstreamType
 });
 enum_zip!(impl<TF> for ProgramClause<TF> { Implies, ForAll });
+
+impl<TF: TypeFamily> Zip<TF> for Substitution<TF> {
+    fn zip_with<Z: Zipper<TF>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()> {
+        Zip::zip_with(zipper, a.parameters(), b.parameters())
+    }
+}
 
 // Annoyingly, Goal cannot use `enum_zip` because some variants have
 // two parameters, and I'm too lazy to make the macro account for the

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -201,9 +201,9 @@ impl<TF: TypeFamily> TraitBound<TF> {
     pub fn as_trait_ref(&self, self_ty: Ty<TF>) -> TraitRef<TF> {
         TraitRef {
             trait_id: self.trait_id,
-            substitution: iter::once(self_ty.cast())
-                .chain(self.args_no_self.iter().cloned())
-                .collect(),
+            substitution: Substitution::from(
+                iter::once(self_ty.cast()).chain(self.args_no_self.iter().cloned()),
+            ),
         }
     }
 }
@@ -223,12 +223,12 @@ impl<TF: TypeFamily> ProjectionEqBound<TF> {
     fn into_where_clauses(&self, self_ty: Ty<TF>) -> Vec<WhereClause<TF>> {
         let trait_ref = self.trait_bound.as_trait_ref(self_ty);
 
-        let substitution: Substitution<TF> = self
-            .parameters
-            .iter()
-            .cloned()
-            .chain(trait_ref.substitution.iter().cloned())
-            .collect();
+        let substitution = Substitution::from(
+            self.parameters
+                .iter()
+                .cloned()
+                .chain(trait_ref.substitution.iter().cloned()),
+        );
 
         vec![
             WhereClause::Implemented(trait_ref),
@@ -339,7 +339,7 @@ impl<TF: TypeFamily> AssociatedTyDatum<TF> {
 
         // Create a list `P0...Pn` of references to the binders in
         // scope for this associated type:
-        let substitution = binders.iter().zip(0..).map(|p| p.to_parameter()).collect();
+        let substitution = Substitution::from(binders.iter().zip(0..).map(|p| p.to_parameter()));
 
         // The self type will be `<P0 as Foo<P1..Pn>>::Item<Pn..Pm>` etc
         let self_ty = TyData::Projection(ProjectionTy {

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -155,7 +155,7 @@ fn program_clauses_that_could_match<TF: TypeFamily>(
             // the automatic impls for `Foo`.
             let trait_datum = db.trait_datum(trait_id);
             if trait_datum.is_auto_trait() {
-                match trait_ref.parameters[0].assert_ty_ref().data() {
+                match trait_ref.self_type_parameter().data() {
                     TyData::Apply(apply) => {
                         if let Some(struct_id) = db.as_struct_id(&apply.name) {
                             push_auto_trait_impls(builder, trait_id, struct_id);
@@ -209,7 +209,7 @@ fn program_clauses_that_could_match<TF: TypeFamily>(
             // generated two clauses that are totally irrelevant to
             // that goal, because they let us prove other things but
             // not `Clone`.
-            let self_ty = trait_ref.self_type_parameter().unwrap(); // This cannot be None
+            let self_ty = trait_ref.self_type_parameter();
             if let TyData::Dyn(dyn_ty) = self_ty.data() {
                 // In this arm, `self_ty` is the `dyn Fn(&u8)`,
                 // and `bounded_ty` is the `exists<T> { .. }`

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -66,6 +66,12 @@ impl<'me, TF: TypeFamily> ClauseBuilder<'me, TF> {
         &self.parameters
     }
 
+    /// Accesses the placeholders for the current list of parameters in scope,
+    /// in the form of a `Substitution`.
+    pub fn substitution_in_scope(&self) -> Substitution<TF> {
+        self.placeholders_in_scope().iter().cloned().collect()
+    }
+
     /// Executes `op` with the `binders` in-scope; `op` is invoked
     /// with the bound value `v` as a parameter. After `op` finishes,
     /// the binders are popped from scope.

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -69,7 +69,7 @@ impl<'me, TF: TypeFamily> ClauseBuilder<'me, TF> {
     /// Accesses the placeholders for the current list of parameters in scope,
     /// in the form of a `Substitution`.
     pub fn substitution_in_scope(&self) -> Substitution<TF> {
-        self.placeholders_in_scope().iter().cloned().collect()
+        Substitution::from(self.placeholders_in_scope().iter().cloned())
     }
 
     /// Executes `op` with the `binders` in-scope; `op` is invoked

--- a/chalk-solve/src/coherence/solve.rs
+++ b/chalk-solve/src/coherence/solve.rs
@@ -218,5 +218,5 @@ impl<TF: TypeFamily> CoherenceSolver<'_, TF> {
 }
 
 fn params<TF: TypeFamily>(impl_datum: &ImplDatum<TF>) -> &[Parameter<TF>] {
-    &impl_datum.binders.value.trait_ref.parameters
+    impl_datum.binders.value.trait_ref.substitution.parameters()
 }

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -13,15 +13,10 @@ impl<TF: TypeFamily> InferenceTable<TF> {
         &mut self,
         binders: &[ParameterKind<UniverseIndex>],
     ) -> Substitution<TF> {
-        Substitution {
-            parameters: binders
-                .iter()
-                .map(|kind| {
-                    let param_infer_var = kind.map(|ui| self.new_variable(ui));
-                    param_infer_var.to_parameter()
-                })
-                .collect(),
-        }
+        Substitution::from(binders.iter().map(|kind| {
+            let param_infer_var = kind.map(|ui| self.new_variable(ui));
+            param_infer_var.to_parameter()
+        }))
     }
 
     /// Variant on `instantiate` that takes a `Canonical<T>`.

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -450,9 +450,8 @@ trait SubstitutionExt<TF: TypeFamily> {
 
 impl<TF: TypeFamily> SubstitutionExt<TF> for Substitution<TF> {
     fn may_invalidate(&self, subst: &Canonical<Substitution<TF>>) -> bool {
-        self.parameters
-            .iter()
-            .zip(&subst.value.parameters)
+        self.iter()
+            .zip(subst.value.iter())
             .any(|(new, current)| MayInvalidate.aggregate_parameters(new, current))
     }
 }

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -546,14 +546,19 @@ impl MayInvalidate {
     ) -> bool {
         let ApplicationTy {
             name: new_name,
-            parameters: new_parameters,
+            substitution: new_substitution,
         } = new;
         let ApplicationTy {
             name: current_name,
-            parameters: current_parameters,
+            substitution: current_substitution,
         } = current;
 
-        self.aggregate_name_and_substs(new_name, new_parameters, current_name, current_parameters)
+        self.aggregate_name_and_substs(
+            new_name,
+            new_substitution,
+            current_name,
+            current_substitution,
+        )
     }
 
     fn aggregate_placeholder_tys(
@@ -571,22 +576,27 @@ impl MayInvalidate {
     ) -> bool {
         let ProjectionTy {
             associated_ty_id: new_name,
-            parameters: new_parameters,
+            substitution: new_substitution,
         } = new;
         let ProjectionTy {
             associated_ty_id: current_name,
-            parameters: current_parameters,
+            substitution: current_substitution,
         } = current;
 
-        self.aggregate_name_and_substs(new_name, new_parameters, current_name, current_parameters)
+        self.aggregate_name_and_substs(
+            new_name,
+            new_substitution,
+            current_name,
+            current_substitution,
+        )
     }
 
     fn aggregate_name_and_substs<N, TF>(
         &mut self,
         new_name: N,
-        new_parameters: &[Parameter<TF>],
+        new_substitution: &Substitution<TF>,
         current_name: N,
-        current_parameters: &[Parameter<TF>],
+        current_substitution: &Substitution<TF>,
     ) -> bool
     where
         N: Copy + Eq + Debug,
@@ -599,17 +609,17 @@ impl MayInvalidate {
         let name = new_name;
 
         assert_eq!(
-            new_parameters.len(),
-            current_parameters.len(),
-            "does {:?} take {} parameters or {}? can't both be right",
+            new_substitution.len(),
+            current_substitution.len(),
+            "does {:?} take {} substitution or {}? can't both be right",
             name,
-            new_parameters.len(),
-            current_parameters.len()
+            new_substitution.len(),
+            current_substitution.len()
         );
 
-        new_parameters
+        new_substitution
             .iter()
-            .zip(current_parameters)
+            .zip(current_substitution)
             .any(|(new, current)| self.aggregate_parameters(new, current))
     }
 }

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -186,7 +186,7 @@ impl<'me, TF: TypeFamily> context::ContextOps<SlgContext<TF>> for SlgContextOps<
             DomainGoal::Holds(WhereClause::Implemented(trait_ref)) => {
                 let trait_datum = self.program.trait_datum(trait_ref.trait_id);
                 if trait_datum.is_non_enumerable_trait() || trait_datum.is_auto_trait() {
-                    let self_ty = trait_ref.self_type_parameter().unwrap();
+                    let self_ty = trait_ref.self_type_parameter();
                     if let Some(v) = self_ty.inference_var() {
                         if !infer.infer.var_is_bound(v) {
                             return Err(Floundered);

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -95,9 +95,8 @@ fn merge_into_guidance<TF: TypeFamily>(
     // common.
     let aggr_parameters: Vec<_> = guidance
         .value
-        .parameters
         .iter()
-        .zip(&subst1.parameters)
+        .zip(subst1.iter())
         .enumerate()
         .map(|(index, (value, value1))| {
             // We have two values for some variable X that
@@ -125,9 +124,7 @@ fn merge_into_guidance<TF: TypeFamily>(
         })
         .collect();
 
-    let aggr_subst = Substitution {
-        parameters: aggr_parameters,
-    };
+    let aggr_subst = Substitution::from(aggr_parameters);
 
     infer.canonicalize(&aggr_subst).quantified
 }
@@ -136,7 +133,6 @@ fn is_trivial<TF: TypeFamily>(subst: &Canonical<Substitution<TF>>) -> bool {
     // A subst is trivial if..
     subst
         .value
-        .parameters
         .iter()
         .enumerate()
         .all(|(index, parameter)| match parameter.data() {
@@ -289,11 +285,12 @@ impl<TF: TypeFamily> AntiUnifier<'_, TF> {
             substitution2.len()
         );
 
-        let substitution: Substitution<_> = substitution1
-            .iter()
-            .zip(substitution2)
-            .map(|(p1, p2)| self.aggregate_parameters(p1, p2))
-            .collect();
+        let substitution = Substitution::from(
+            substitution1
+                .iter()
+                .zip(substitution2)
+                .map(|(p1, p2)| self.aggregate_parameters(p1, p2)),
+        );
 
         Some((name, substitution))
     }

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -297,7 +297,7 @@ impl<TF: TypeFamily> AnswerSubstitutor<'_, TF> {
             return Ok(false);
         }
 
-        let answer_param = &self.answer_subst.parameters[answer_depth - self.answer_binders];
+        let answer_param = self.answer_subst.at(answer_depth - self.answer_binders);
 
         let pending_shifted = pending
             .shifted_out(self.pending_binders)

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -23,8 +23,9 @@ pub trait Split<TF: TypeFamily>: RustIrDatabase<TF> {
     ) {
         let ProjectionTy {
             associated_ty_id,
-            ref parameters,
+            ref substitution,
         } = *projection;
+        let parameters = substitution.parameters();
         let associated_ty_data = &self.associated_ty_data(associated_ty_id);
         let trait_datum = &self.trait_datum(associated_ty_data.trait_id);
         let trait_num_params = trait_datum.binders.len();
@@ -51,7 +52,7 @@ pub trait Split<TF: TypeFamily>: RustIrDatabase<TF> {
         let (associated_ty_data, trait_params, _) = self.split_projection(&projection);
         TraitRef {
             trait_id: associated_ty_data.trait_id,
-            parameters: trait_params.to_owned(),
+            substitution: Substitution::from(trait_params),
         }
     }
 
@@ -135,21 +136,21 @@ pub trait Split<TF: TypeFamily>: RustIrDatabase<TF> {
         let trait_ref = {
             let impl_trait_ref = impl_datum.binders.map_ref(|b| &b.trait_ref);
             debug!("impl_trait_ref: {:?}", impl_trait_ref);
-            impl_trait_ref.substitute(&impl_parameters)
+            impl_trait_ref.substitute(impl_parameters)
         };
 
         // Create the parameters for the projection -- in our example
         // above, this would be `['!a, Box<!T>]`, corresponding to
         // `<Box<!T> as Foo>::Item<'!a>`
-        let projection_parameters: Vec<_> = atv_parameters
+        let projection_substitution: Substitution<_> = atv_parameters
             .iter()
-            .chain(&trait_ref.parameters)
+            .chain(&trait_ref.substitution)
             .cloned()
             .collect();
 
         let projection = ProjectionTy {
             associated_ty_id: associated_ty_value.associated_ty_id,
-            parameters: projection_parameters,
+            substitution: projection_substitution,
         };
 
         debug!("impl_parameters: {:?}", impl_parameters);

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -142,11 +142,12 @@ pub trait Split<TF: TypeFamily>: RustIrDatabase<TF> {
         // Create the parameters for the projection -- in our example
         // above, this would be `['!a, Box<!T>]`, corresponding to
         // `<Box<!T> as Foo>::Item<'!a>`
-        let projection_substitution: Substitution<_> = atv_parameters
-            .iter()
-            .chain(&trait_ref.substitution)
-            .cloned()
-            .collect();
+        let projection_substitution = Substitution::from(
+            atv_parameters
+                .iter()
+                .chain(&trait_ref.substitution)
+                .cloned(),
+        );
 
         let projection = ProjectionTy {
             associated_ty_id: associated_ty_value.associated_ty_id,


### PR DESCRIPTION
We used to directly embed `Vec<Parameter<TF>>`. This branch changes those references to `Substitution<TF>` which (internally) relies on an `TF::InternedSubstitution`. This should enable rustc to use interned slices.