### PR TITLE
Rename projection to alias

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1021,9 +1021,7 @@ impl LowerTy for Ty {
                 .intern())
             }
 
-            Ty::Projection { ref proj } => {
-                Ok(chalk_ir::TyData::Projection(proj.lower(env)?).intern())
-            }
+            Ty::Projection { ref proj } => Ok(chalk_ir::TyData::Alias(proj.lower(env)?).intern()),
 
             Ty::ForAll {
                 ref lifetime_names,

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -3,8 +3,8 @@ use chalk_ir::debug::Angle;
 use chalk_ir::family::ChalkIr;
 use chalk_ir::tls;
 use chalk_ir::{
-    AssocTypeId, Identifier, ImplId, Parameter, ProgramClause, ProjectionTy, StructId, TraitId,
-    TyData, TypeName,
+    AliasTy, AssocTypeId, Identifier, ImplId, Parameter, ProgramClause, StructId, TraitId, TyData,
+    TypeName,
 };
 use chalk_rust_ir::{
     AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ImplDatum, ImplType, StructDatum,
@@ -103,12 +103,12 @@ impl tls::DebugContext for Program {
         }
     }
 
-    fn debug_projection(
+    fn debug_alias(
         &self,
-        projection_ty: &ProjectionTy<ChalkIr>,
+        alias_ty: &AliasTy<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error> {
-        let (associated_ty_data, trait_params, other_params) = self.split_projection(projection_ty);
+        let (associated_ty_data, trait_params, other_params) = self.split_projection(alias_ty);
         write!(
             fmt,
             "<{:?} as {:?}{:?}>::{}{:?}",

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -153,7 +153,7 @@ impl<TF: TypeFamily> CastTo<TyData<TF>> for ApplicationTy<TF> {
 
 impl<TF: TypeFamily> CastTo<TyData<TF>> for ProjectionTy<TF> {
     fn cast_to(self) -> TyData<TF> {
-        TyData::Projection(self)
+        TyData::Alias(self)
     }
 }
 

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -86,9 +86,9 @@ impl<TF: TypeFamily> CastTo<WhereClause<TF>> for TraitRef<TF> {
     }
 }
 
-impl<TF: TypeFamily> CastTo<WhereClause<TF>> for ProjectionEq<TF> {
+impl<TF: TypeFamily> CastTo<WhereClause<TF>> for AliasEq<TF> {
     fn cast_to(self) -> WhereClause<TF> {
-        WhereClause::ProjectionEq(self)
+        WhereClause::AliasEq(self)
     }
 }
 
@@ -151,7 +151,7 @@ impl<TF: TypeFamily> CastTo<TyData<TF>> for ApplicationTy<TF> {
     }
 }
 
-impl<TF: TypeFamily> CastTo<TyData<TF>> for ProjectionTy<TF> {
+impl<TF: TypeFamily> CastTo<TyData<TF>> for AliasTy<TF> {
     fn cast_to(self) -> TyData<TF> {
         TyData::Alias(self)
     }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -166,9 +166,9 @@ impl<TF: TypeFamily> Debug for SeparatorTraitRef<'_, TF> {
     }
 }
 
-impl<TF: TypeFamily> Debug for ProjectionTy<TF> {
+impl<TF: TypeFamily> Debug for AliasTy<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        TF::debug_projection(self, fmt).unwrap_or_else(|| {
+        TF::debug_alias(self, fmt).unwrap_or_else(|| {
             write!(
                 fmt,
                 "({:?}){:?}",
@@ -200,13 +200,13 @@ impl<'a, T: Debug> Debug for Angle<'a, T> {
 
 impl<TF: TypeFamily> Debug for Normalize<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        write!(fmt, "Normalize({:?} -> {:?})", self.projection, self.ty)
+        write!(fmt, "Normalize({:?} -> {:?})", self.alias, self.ty)
     }
 }
 
-impl<TF: TypeFamily> Debug for ProjectionEq<TF> {
+impl<TF: TypeFamily> Debug for AliasEq<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        write!(fmt, "ProjectionEq({:?} = {:?})", self.projection, self.ty)
+        write!(fmt, "AliasEq({:?} = {:?})", self.alias, self.ty)
     }
 }
 
@@ -214,7 +214,7 @@ impl<TF: TypeFamily> Debug for WhereClause<TF> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         match self {
             WhereClause::Implemented(tr) => write!(fmt, "Implemented({:?})", tr.with_colon()),
-            WhereClause::ProjectionEq(p) => write!(fmt, "{:?}", p),
+            WhereClause::AliasEq(a) => write!(fmt, "{:?}", a),
         }
     }
 }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -61,7 +61,7 @@ impl<TF: TypeFamily> Debug for TyData<TF> {
             TyData::Dyn(clauses) => write!(fmt, "{:?}", clauses),
             TyData::InferenceVar(var) => write!(fmt, "{:?}", var),
             TyData::Apply(apply) => write!(fmt, "{:?}", apply),
-            TyData::Projection(proj) => write!(fmt, "{:?}", proj),
+            TyData::Alias(alias) => write!(fmt, "{:?}", alias),
             TyData::Placeholder(index) => write!(fmt, "{:?}", index),
             TyData::Function(function) => write!(fmt, "{:?}", function),
         }

--- a/chalk-ir/src/family.rs
+++ b/chalk-ir/src/family.rs
@@ -1,10 +1,10 @@
 use crate::tls;
+use crate::AliasTy;
 use crate::AssocTypeId;
 use crate::GoalData;
 use crate::LifetimeData;
 use crate::Parameter;
 use crate::ParameterData;
-use crate::ProjectionTy;
 use crate::RawId;
 use crate::StructId;
 use crate::TraitId;
@@ -111,17 +111,14 @@ pub trait TypeFamily: Debug + Copy + Eq + Ord + Hash {
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result>;
 
-    /// Prints the debug representation of a projection. To get good
+    /// Prints the debug representation of an alias. To get good
     /// results, this requires inspecting TLS, and is difficult to
     /// code without reference to a specific type-family (and hence
     /// fully known types).
     ///
     /// Returns `None` to fallback to the default debug output (e.g.,
     /// if no info about current program is available from TLS).
-    fn debug_projection(
-        projection: &ProjectionTy<Self>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Option<fmt::Result>;
+    fn debug_alias(alias: &AliasTy<Self>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result>;
 
     /// Create an "interned" type from `ty`. This is not normally
     /// invoked directly; instead, you invoke `TyData::intern` (which
@@ -225,11 +222,8 @@ impl TypeFamily for ChalkIr {
         tls::with_current_program(|prog| Some(prog?.debug_assoc_type_id(id, fmt)))
     }
 
-    fn debug_projection(
-        projection: &ProjectionTy<ChalkIr>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_projection(projection, fmt)))
+    fn debug_alias(alias: &AliasTy<ChalkIr>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
+        tls::with_current_program(|prog| Some(prog?.debug_alias(alias, fmt)))
     }
 
     fn intern_ty(ty: TyData<ChalkIr>) -> Arc<TyData<ChalkIr>> {

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -321,9 +321,7 @@ where
         TyData::InferenceVar(var) => folder.fold_inference_ty(*var, binders),
         TyData::Apply(apply) => Ok(TyData::Apply(apply.fold_with(folder, binders)?).intern()),
         TyData::Placeholder(ui) => Ok(folder.fold_free_placeholder_ty(*ui, binders)?),
-        TyData::Projection(proj) => {
-            Ok(TyData::Projection(proj.fold_with(folder, binders)?).intern())
-        }
+        TyData::Alias(alias) => Ok(TyData::Alias(alias.fold_with(folder, binders)?).intern()),
         TyData::Function(fun) => Ok(TyData::Function(fun.fold_with(folder, binders)?).intern()),
     }
 }

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -218,7 +218,7 @@ impl<TF: TypeFamily> Ty<TF> {
 
     pub fn is_projection(&self) -> bool {
         match self.data() {
-            TyData::Projection(..) => true,
+            TyData::Alias(..) => true,
             _ => false,
         }
     }
@@ -255,10 +255,11 @@ pub enum TyData<TF: TypeFamily> {
     /// binders here.
     Dyn(DynTy<TF>),
 
-    /// A "projection" type corresponds to an (unnormalized)
-    /// projection like `<P0 as Trait<P1..Pn>>::Foo`. Note that the
-    /// trait and all its parameters are fully known.
-    Projection(ProjectionTy<TF>),
+    /// An "alias" type represents some form of type alias, such as:
+    /// - An associated type projection like `<T as Iterator>::Item`
+    /// - `impl Trait` types
+    /// - Named type aliases like `type Foo<X> = Vec<X>`
+    Alias(ProjectionTy<TF>),
 
     /// A function type such as `for<'a> fn(&'a u32)`.
     /// Note that "higher-ranked" types (starting with `for<>`) are either

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -216,7 +216,7 @@ impl<TF: TypeFamily> Ty<TF> {
         }
     }
 
-    pub fn is_projection(&self) -> bool {
+    pub fn is_alias(&self) -> bool {
         match self.data() {
             TyData::Alias(..) => true,
             _ => false,
@@ -742,7 +742,7 @@ pub type QuantifiedWhereClause<TF> = Binders<WhereClause<TF>>;
 impl<TF: TypeFamily> WhereClause<TF> {
     /// Turn a where clause into the WF version of it i.e.:
     /// * `Implemented(T: Trait)` maps to `WellFormed(T: Trait)`
-    /// * `ProjectionEq(<T as Trait>::Item = Foo)` maps to `WellFormed(<T as Trait>::Item = Foo)`
+    /// * `AliasEq(<T as Trait>::Item = Foo)` maps to `WellFormed(<T as Trait>::Item = Foo)`
     /// * any other clause maps to itself
     pub fn into_well_formed_goal(self) -> DomainGoal<TF> {
         match self {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -259,7 +259,7 @@ pub enum TyData<TF: TypeFamily> {
     /// - An associated type projection like `<T as Iterator>::Item`
     /// - `impl Trait` types
     /// - Named type aliases like `type Foo<X> = Vec<X>`
-    Alias(ProjectionTy<TF>),
+    Alias(AliasTy<TF>),
 
     /// A function type such as `for<'a> fn(&'a u32)`.
     /// Note that "higher-ranked" types (starting with `for<>`) are either
@@ -570,12 +570,12 @@ impl<TF: TypeFamily> ParameterData<TF> {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasTypeFamily)]
-pub struct ProjectionTy<TF: TypeFamily> {
+pub struct AliasTy<TF: TypeFamily> {
     pub associated_ty_id: AssocTypeId<TF>,
     pub substitution: Substitution<TF>,
 }
 
-impl<TF: TypeFamily> ProjectionTy<TF> {
+impl<TF: TypeFamily> AliasTy<TF> {
     pub fn intern(self) -> Ty<TF> {
         Ty::new(self)
     }
@@ -609,7 +609,7 @@ impl<TF: TypeFamily> TraitRef<TF> {
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasTypeFamily)]
 pub enum WhereClause<TF: TypeFamily> {
     Implemented(TraitRef<TF>),
-    ProjectionEq(ProjectionEq<TF>),
+    AliasEq(AliasEq<TF>),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasTypeFamily)]
@@ -795,13 +795,13 @@ pub struct EqGoal<TF: TypeFamily> {
     pub b: Parameter<TF>,
 }
 
-/// Proves that the given projection **normalizes** to the given
+/// Proves that the given type alias **normalizes** to the given
 /// type. A projection `T::Foo` normalizes to the type `U` if we can
 /// **match it to an impl** and that impl has a `type Foo = V` where
 /// `U = V`.
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
 pub struct Normalize<TF: TypeFamily> {
-    pub projection: ProjectionTy<TF>,
+    pub alias: AliasTy<TF>,
     pub ty: Ty<TF>,
 }
 
@@ -809,12 +809,12 @@ pub struct Normalize<TF: TypeFamily> {
 /// `U`. Equality can be proven via normalization, but we can also
 /// prove that `T::Foo = V::Foo` if `T = V` without normalizing.
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
-pub struct ProjectionEq<TF: TypeFamily> {
-    pub projection: ProjectionTy<TF>,
+pub struct AliasEq<TF: TypeFamily> {
+    pub alias: AliasTy<TF>,
     pub ty: Ty<TF>,
 }
 
-impl<TF: TypeFamily> HasTypeFamily for ProjectionEq<TF> {
+impl<TF: TypeFamily> HasTypeFamily for AliasEq<TF> {
     type TypeFamily = TF;
 }
 

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -23,8 +23,8 @@ macro_rules! ty {
         }).intern()
     };
 
-    (projection (item $n:tt) $($arg:tt)*) => {
-        $crate::TyData::Projection(AliasTy {
+    (alias (item $n:tt) $($arg:tt)*) => {
+        $crate::TyData::Alias(AliasTy {
             associated_ty_id: AssocTypeId(RawId { index: $n }),
             substitution: $crate::Substitution::from(vec![$(arg!($arg)),*] as Vec<$crate::Parameter<_>>),
         }).intern()

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! ty {
     };
 
     (projection (item $n:tt) $($arg:tt)*) => {
-        $crate::TyData::Projection(ProjectionTy {
+        $crate::TyData::Projection(AliasTy {
             associated_ty_id: AssocTypeId(RawId { index: $n }),
             substitution: $crate::Substitution::from(vec![$(arg!($arg)),*] as Vec<$crate::Parameter<_>>),
         }).intern()

--- a/chalk-ir/src/tls.rs
+++ b/chalk-ir/src/tls.rs
@@ -1,5 +1,5 @@
 use crate::family::ChalkIr;
-use crate::{AssocTypeId, ProjectionTy, StructId, TraitId};
+use crate::{AliasTy, AssocTypeId, StructId, TraitId};
 use std::cell::RefCell;
 use std::fmt;
 use std::sync::Arc;
@@ -27,9 +27,9 @@ pub trait DebugContext {
         fmt: &mut fmt::Formatter,
     ) -> Result<(), fmt::Error>;
 
-    fn debug_projection(
+    fn debug_alias(
         &self,
-        projection: &ProjectionTy<ChalkIr>,
+        alias: &AliasTy<ChalkIr>,
         fmt: &mut fmt::Formatter,
     ) -> Result<(), fmt::Error>;
 }

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -192,12 +192,12 @@ struct_zip!(impl[
 });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for ApplicationTy<TF> { name, substitution });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for DynTy<TF> { bounds });
-struct_zip!(impl[TF: TypeFamily] Zip<TF> for ProjectionTy<TF> {
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for AliasTy<TF> {
     associated_ty_id,
     substitution,
 });
-struct_zip!(impl[TF: TypeFamily] Zip<TF> for Normalize<TF> { projection, ty });
-struct_zip!(impl[TF: TypeFamily] Zip<TF> for ProjectionEq<TF> { projection, ty });
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for Normalize<TF> { alias, ty });
+struct_zip!(impl[TF: TypeFamily] Zip<TF> for AliasEq<TF> { alias, ty });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for EqGoal<TF> { a, b });
 struct_zip!(impl[TF: TypeFamily] Zip<TF> for ProgramClauseImplication<TF> {
     consequence,
@@ -238,7 +238,7 @@ macro_rules! enum_zip {
 
 enum_zip!(impl<TF> for WellFormed<TF> { Trait, Ty });
 enum_zip!(impl<TF> for FromEnv<TF> { Trait, Ty });
-enum_zip!(impl<TF> for WhereClause<TF> { Implemented, ProjectionEq });
+enum_zip!(impl<TF> for WhereClause<TF> { Implemented, AliasEq });
 enum_zip!(impl<TF> for DomainGoal<TF> {
     Holds,
     WellFormed,

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -84,7 +84,7 @@ pub enum Parameter {
 /// An inline bound, e.g. `: Foo<K>` in `impl<K, T: Foo<K>> SomeType<T>`.
 pub enum InlineBound {
     TraitBound(TraitBound),
-    ProjectionEqBound(ProjectionEqBound),
+    AliasEqBound(AliasEqBound),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -102,9 +102,9 @@ pub struct TraitBound {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-/// Represents a projection equality bound on e.g. a type or type parameter.
+/// Represents an alias equality bound on e.g. a type or type parameter.
 /// Does not know anything about what it's binding.
-pub struct ProjectionEqBound {
+pub struct AliasEqBound {
     pub trait_bound: TraitBound,
     pub name: Identifier,
     pub args: Vec<Parameter>,
@@ -162,8 +162,8 @@ pub enum Ty {
         name: Identifier,
         args: Vec<Parameter>,
     },
-    Projection {
-        proj: ProjectionTy,
+    Alias {
+        alias: AliasTy,
     },
     ForAll {
         lifetime_names: Vec<Identifier>,
@@ -177,7 +177,7 @@ pub enum Lifetime {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct ProjectionTy {
+pub struct AliasTy {
     pub trait_ref: TraitRef,
     pub name: Identifier,
     pub args: Vec<Parameter>,
@@ -223,13 +223,13 @@ impl fmt::Display for Identifier {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum WhereClause {
     Implemented { trait_ref: TraitRef },
-    ProjectionEq { projection: ProjectionTy, ty: Ty },
+    AliasEq { alias: AliasTy, ty: Ty },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum DomainGoal {
     Holds { where_clause: WhereClause },
-    Normalize { projection: ProjectionTy, ty: Ty },
+    Normalize { alias: AliasTy, ty: Ty },
     TraitRefWellFormed { trait_ref: TraitRef },
     TyWellFormed { ty: Ty },
     TyFromEnv { ty: Ty },

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -253,7 +253,7 @@ InlineClause: Clause = {
 WhereClause: WhereClause = {
     <t:TraitRef<":">> => WhereClause::Implemented { trait_ref: t },
 
-    // `T: Foo<U = Bar>` -- projection equality
+    // `T: Foo<U = Bar>` -- alias equality
     <s:Ty> ":" <t:Id> "<" <a:(<Comma<Parameter>> ",")?> <name:Id> <a2:Angle<Parameter>>
         "=" <ty:Ty> ">" =>
     {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -92,7 +92,7 @@ AssocTyDefn: AssocTyDefn = {
 
 InlineBound: InlineBound = {
     TraitBound => InlineBound::TraitBound(<>),
-    ProjectionEqBound => InlineBound::ProjectionEqBound(<>),
+    AliasEqBound => InlineBound::AliasEqBound(<>),
 };
 
 TraitBound: TraitBound = {
@@ -104,9 +104,9 @@ TraitBound: TraitBound = {
     }
 };
 
-ProjectionEqBound: ProjectionEqBound = {
+AliasEqBound: AliasEqBound = {
     <t:Id> "<" <a:(<Comma<Parameter>> ",")?> <name:Id> <a2:Angle<Parameter>>
-        "=" <ty:Ty> ">" => ProjectionEqBound
+        "=" <ty:Ty> ">" => AliasEqBound
     {
         trait_bound: TraitBound {
             trait_name: t,
@@ -182,7 +182,7 @@ TyWithoutFor: Ty = {
         bounds: b,
     },
     <n:Id> "<" <a:Comma<Parameter>> ">" => Ty::Apply { name: n, args: a },
-    <p:ProjectionTy> => Ty::Projection { proj: p },
+    <a:AliasTy> => Ty::Alias { alias: a },
     "(" <Ty> ")",
 };
 
@@ -195,8 +195,8 @@ Parameter: Parameter = {
     Lifetime => Parameter::Lifetime(<>),
 };
 
-ProjectionTy: ProjectionTy = {
-    "<" <t:TraitRef<"as">> ">" "::" <n:Id> <a:Angle<Parameter>> => ProjectionTy {
+AliasTy: AliasTy = {
+    "<" <t:TraitRef<"as">> ">" "::" <n:Id> <a:Angle<Parameter>> => AliasTy {
         trait_ref: t, name: n, args: a
     },
 };
@@ -260,8 +260,8 @@ WhereClause: WhereClause = {
         let mut args = vec![Parameter::Ty(s)];
         if let Some(a) = a { args.extend(a); }
         let trait_ref = TraitRef { trait_name: t, args: args };
-        let projection = ProjectionTy { trait_ref, name, args: a2 };
-        WhereClause::ProjectionEq { projection, ty }
+        let alias = AliasTy { trait_ref, name, args: a2 };
+        WhereClause::AliasEq { alias, ty }
     },
 };
 
@@ -294,7 +294,7 @@ DomainGoal: DomainGoal = {
     "FromEnv" "(" <t:TraitRef<":">> ")" => DomainGoal::TraitRefFromEnv { trait_ref: t },
 
     // `<T as Foo>::U -> Bar` -- a normalization
-    "Normalize" "(" <s:ProjectionTy> "->" <t:Ty> ")" => DomainGoal::Normalize { projection: s, ty: t },
+    "Normalize" "(" <a:AliasTy> "->" <t:Ty> ")" => DomainGoal::Normalize { alias: a, ty: t },
 
     "IsLocal" "(" <ty:Ty> ")" => DomainGoal::IsLocal { ty },
     "IsUpstream" "(" <ty:Ty> ")" => DomainGoal::IsUpstream { ty },

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -342,7 +342,7 @@ impl<TF: TypeFamily> AssociatedTyDatum<TF> {
         let substitution = Substitution::from(binders.iter().zip(0..).map(|p| p.to_parameter()));
 
         // The self type will be `<P0 as Foo<P1..Pn>>::Item<Pn..Pm>` etc
-        let self_ty = TyData::Projection(ProjectionTy {
+        let self_ty = TyData::Alias(ProjectionTy {
             associated_ty_id: self.id,
             substitution,
         })

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -7,8 +7,8 @@ use chalk_ir::cast::Cast;
 use chalk_ir::family::{HasTypeFamily, TargetTypeFamily, TypeFamily};
 use chalk_ir::fold::{shift::Shift, Fold, Folder};
 use chalk_ir::{
-    AssocTypeId, Binders, Identifier, ImplId, LifetimeData, Parameter, ParameterKind, ProjectionEq,
-    ProjectionTy, QuantifiedWhereClause, RawId, StructId, Substitution, TraitId, TraitRef, Ty,
+    AliasEq, AliasTy, AssocTypeId, Binders, Identifier, ImplId, LifetimeData, Parameter,
+    ParameterKind, QuantifiedWhereClause, RawId, StructId, Substitution, TraitId, TraitRef, Ty,
     TyData, TypeName, WhereClause,
 };
 use std::iter;
@@ -140,7 +140,7 @@ pub struct TraitFlags {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasTypeFamily)]
 pub enum InlineBound<TF: TypeFamily> {
     TraitBound(TraitBound<TF>),
-    ProjectionEqBound(ProjectionEqBound<TF>),
+    AliasEqBound(AliasEqBound<TF>),
 }
 
 #[allow(type_alias_bounds)]
@@ -163,7 +163,7 @@ impl<TF: TypeFamily> IntoWhereClauses<TF> for InlineBound<TF> {
     fn into_where_clauses(&self, self_ty: Ty<TF>) -> Vec<WhereClause<TF>> {
         match self {
             InlineBound::TraitBound(b) => b.into_where_clauses(self_ty),
-            InlineBound::ProjectionEqBound(b) => b.into_where_clauses(self_ty),
+            InlineBound::AliasEqBound(b) => b.into_where_clauses(self_ty),
         }
     }
 }
@@ -208,10 +208,10 @@ impl<TF: TypeFamily> TraitBound<TF> {
     }
 }
 
-/// Represents a projection equality bound on e.g. a type or type parameter.
+/// Represents an alias equality bound on e.g. a type or type parameter.
 /// Does not know anything about what it's binding.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Fold)]
-pub struct ProjectionEqBound<TF: TypeFamily> {
+pub struct AliasEqBound<TF: TypeFamily> {
     pub trait_bound: TraitBound<TF>,
     pub associated_ty_id: AssocTypeId<TF>,
     /// Does not include trait parameters.
@@ -219,7 +219,7 @@ pub struct ProjectionEqBound<TF: TypeFamily> {
     pub value: Ty<TF>,
 }
 
-impl<TF: TypeFamily> ProjectionEqBound<TF> {
+impl<TF: TypeFamily> AliasEqBound<TF> {
     fn into_where_clauses(&self, self_ty: Ty<TF>) -> Vec<WhereClause<TF>> {
         let trait_ref = self.trait_bound.as_trait_ref(self_ty);
 
@@ -232,8 +232,8 @@ impl<TF: TypeFamily> ProjectionEqBound<TF> {
 
         vec![
             WhereClause::Implemented(trait_ref),
-            WhereClause::ProjectionEq(ProjectionEq {
-                projection: ProjectionTy {
+            WhereClause::AliasEq(AliasEq {
+                alias: AliasTy {
                     associated_ty_id: self.associated_ty_id,
                     substitution,
                 },
@@ -342,7 +342,7 @@ impl<TF: TypeFamily> AssociatedTyDatum<TF> {
         let substitution = Substitution::from(binders.iter().zip(0..).map(|p| p.to_parameter()));
 
         // The self type will be `<P0 as Foo<P1..Pn>>::Item<Pn..Pm>` etc
-        let self_ty = TyData::Alias(ProjectionTy {
+        let self_ty = TyData::Alias(AliasTy {
             associated_ty_id: self.id,
             substitution,
         })

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -234,8 +234,8 @@ fn program_clauses_that_could_match<TF: TypeFamily>(
 
             // TODO sized, unsize_trait, builtin impls?
         }
-        DomainGoal::Holds(WhereClause::ProjectionEq(projection_predicate)) => {
-            db.associated_ty_data(projection_predicate.projection.associated_ty_id)
+        DomainGoal::Holds(WhereClause::AliasEq(alias_predicate)) => {
+            db.associated_ty_data(alias_predicate.alias.associated_ty_id)
                 .to_program_clauses(builder);
         }
         DomainGoal::WellFormed(WellFormed::Trait(trait_predicate)) => {
@@ -249,7 +249,7 @@ fn program_clauses_that_could_match<TF: TypeFamily>(
             match_ty(builder, environment, ty)
         }
         DomainGoal::FromEnv(_) => (), // Computed in the environment
-        DomainGoal::Normalize(Normalize { projection, ty: _ }) => {
+        DomainGoal::Normalize(Normalize { alias, ty: _ }) => {
             // Normalize goals derive from `AssociatedTyValue` datums,
             // which are found in impls. That is, if we are
             // normalizing (e.g.) `<T as Iterator>::Item>`, then
@@ -261,9 +261,9 @@ fn program_clauses_that_could_match<TF: TypeFamily>(
             //     type Item = Bar; // <-- associated type value
             // }
             // ```
-            let associated_ty_datum = db.associated_ty_data(projection.associated_ty_id);
+            let associated_ty_datum = db.associated_ty_data(alias.associated_ty_id);
             let trait_id = associated_ty_datum.trait_id;
-            let trait_parameters = db.trait_parameters_from_projection(projection);
+            let trait_parameters = db.trait_parameters_from_projection(alias);
             push_program_clauses_for_associated_type_values_in_impls_of(
                 builder,
                 trait_id,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -181,7 +181,7 @@ fn program_clauses_that_could_match<TF: TypeFamily>(
             // ```
             // dyn(exists<T> {
             //     forall<'a> { Implemented(T: Fn<'a>) },
-            //     forall<'a> { ProjectionEq(<T as Fn<'a>>::Output, ()) },
+            //     forall<'a> { AliasEq(<T as Fn<'a>>::Output, ()) },
             // })
             // ```
             //
@@ -196,7 +196,7 @@ fn program_clauses_that_could_match<TF: TypeFamily>(
             // and
             //
             // ```
-            // forall<'a> { ProjectionEq(<dyn Fn(&u8) as Fn<'a>>::Output, ()) },
+            // forall<'a> { AliasEq(<dyn Fn(&u8) as Fn<'a>>::Output, ()) },
             // ```
             //
             // FIXME. This is presently rather wasteful, in that we

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -339,9 +339,9 @@ fn match_ty<TF: TypeFamily>(
     match ty.data() {
         TyData::Apply(application_ty) => match_type_name(builder, application_ty.name),
         TyData::Placeholder(_) => {}
-        TyData::Projection(projection_ty) => builder
+        TyData::Alias(alias_ty) => builder
             .db
-            .associated_ty_data(projection_ty.associated_ty_id)
+            .associated_ty_data(alias_ty.associated_ty_id)
             .to_program_clauses(builder),
         TyData::Function(quantified_ty) => quantified_ty
             .parameters

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -56,8 +56,8 @@ impl<'me, TF: TypeFamily> EnvElaborator<'me, TF> {
             }
             TyData::Placeholder(_) => {}
 
-            TyData::Projection(projection_ty) => {
-                self.visit_projection_ty(projection_ty);
+            TyData::Alias(alias_ty) => {
+                self.visit_projection_ty(alias_ty);
             }
 
             // FIXME(#203) -- We haven't fully figured out the implied

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -8,7 +8,7 @@ use crate::RustIrDatabase;
 use crate::Ty;
 use crate::TyData;
 use chalk_ir::family::TypeFamily;
-use chalk_ir::ProjectionTy;
+use chalk_ir::AliasTy;
 use rustc_hash::FxHashSet;
 
 /// When proving a `FromEnv` goal, we elaborate all `FromEnv` goals
@@ -43,9 +43,9 @@ impl<'me, TF: TypeFamily> EnvElaborator<'me, TF> {
         }
     }
 
-    fn visit_projection_ty(&mut self, projection_ty: &ProjectionTy<TF>) {
+    fn visit_alias_ty(&mut self, alias_ty: &AliasTy<TF>) {
         self.db
-            .associated_ty_data(projection_ty.associated_ty_id)
+            .associated_ty_data(alias_ty.associated_ty_id)
             .to_program_clauses(&mut self.builder);
     }
 
@@ -57,7 +57,7 @@ impl<'me, TF: TypeFamily> EnvElaborator<'me, TF> {
             TyData::Placeholder(_) => {}
 
             TyData::Alias(alias_ty) => {
-                self.visit_projection_ty(alias_ty);
+                self.visit_alias_ty(alias_ty);
             }
 
             // FIXME(#203) -- We haven't fully figured out the implied

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -510,18 +510,18 @@ impl<TF: TypeFamily> ToProgramClauses<TF> for AssociatedTyDatum<TF> {
     /// we generate the 'fallback' rule:
     ///
     /// ```notrust
-    /// -- Rule ProjectionEq-Placeholder
+    /// -- Rule AliasEq-Placeholder
     /// forall<Self, 'a, T> {
-    ///     ProjectionEq(<Self as Foo>::Assoc<'a, T> = (Foo::Assoc<'a, T>)<Self>).
+    ///     AliasEq(<Self as Foo>::Assoc<'a, T> = (Foo::Assoc<'a, T>)<Self>).
     /// }
     /// ```
     ///
     /// and
     ///
     /// ```notrust
-    /// -- Rule ProjectionEq-Normalize
+    /// -- Rule AliasEq-Normalize
     /// forall<Self, 'a, T, U> {
-    ///     ProjectionEq(<T as Foo>::Assoc<'a, T> = U) :-
+    ///     AliasEq(<T as Foo>::Assoc<'a, T> = U) :-
     ///         Normalize(<T as Foo>::Assoc -> U).
     /// }
     /// ```
@@ -530,14 +530,14 @@ impl<TF: TypeFamily> ToProgramClauses<TF> for AssociatedTyDatum<TF> {
     ///
     /// ```notrust
     /// forall<T> {
-    ///     T: Foo :- exists<U> { ProjectionEq(<T as Foo>::Assoc = U) }.
+    ///     T: Foo :- exists<U> { AliasEq(<T as Foo>::Assoc = U) }.
     /// }
     /// ```
     ///
     /// but this caused problems with the recursive solver. In
     /// particular, whenever normalization is possible, we cannot
     /// solve that projection uniquely, since we can now elaborate
-    /// `ProjectionEq` to fallback *or* normalize it. So instead we
+    /// `AliasEq` to fallback *or* normalize it. So instead we
     /// handle this kind of reasoning through the `FromEnv` predicate.
     ///
     /// We also generate rules specific to WF requirements and implied bounds:
@@ -594,7 +594,7 @@ impl<TF: TypeFamily> ToProgramClauses<TF> for AssociatedTyDatum<TF> {
             // and placeholder type.
             //
             //    forall<Self> {
-            //        ProjectionEq(<Self as Foo>::Assoc = (Foo::Assoc)<Self>).
+            //        AliasEq(<Self as Foo>::Assoc = (Foo::Assoc)<Self>).
             //    }
             builder.push_fact(alias_eq);
 

--- a/chalk-solve/src/coinductive_goal.rs
+++ b/chalk-solve/src/coinductive_goal.rs
@@ -22,7 +22,7 @@ impl<TF: TypeFamily> IsCoinductive<TF> for Goal<TF> {
                     db.trait_datum(tr.trait_id).is_auto_trait()
                         || db.trait_datum(tr.trait_id).is_coinductive_trait()
                 }
-                WhereClause::ProjectionEq(..) => false,
+                WhereClause::AliasEq(..) => false,
             },
             GoalData::DomainGoal(DomainGoal::WellFormed(WellFormed::Trait(..))) => true,
             GoalData::Quantified(QuantifierKind::ForAll, goal) => goal.value.is_coinductive(db),

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -131,7 +131,7 @@ fn projection_eq() {
         .unify(
             &environment0,
             &a,
-            &ty!(apply (item 0) (projection (item 1) (expr a))),
+            &ty!(apply (item 0) (alias (item 1) (expr a))),
         )
         .unwrap_err();
 }

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -215,7 +215,7 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
     /// type `ty` (which might also be a projection). Creates a goal like
     ///
     /// ```notrust
-    /// ProjectionEq(<T as Trait>::Item = U)
+    /// AliasEq(<T as Trait>::Item = U)
     /// ```
     fn unify_alias_ty(&mut self, alias: &AliasTy<TF>, ty: &Ty<TF>) -> Fallible<()> {
         Ok(self.goals.push(InEnvironment::new(

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -164,14 +164,14 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
             | (&TyData::Placeholder(_), &TyData::Alias(ref alias))
             | (&TyData::Function(_), &TyData::Alias(ref alias))
             | (&TyData::InferenceVar(_), &TyData::Alias(ref alias))
-            | (&TyData::Dyn(_), &TyData::Alias(ref alias)) => self.unify_projection_ty(alias, a),
+            | (&TyData::Dyn(_), &TyData::Alias(ref alias)) => self.unify_alias_ty(alias, a),
 
             (&TyData::Alias(ref alias), &TyData::Alias(_))
             | (&TyData::Alias(ref alias), &TyData::Apply(_))
             | (&TyData::Alias(ref alias), &TyData::Placeholder(_))
             | (&TyData::Alias(ref alias), &TyData::Function(_))
             | (&TyData::Alias(ref alias), &TyData::InferenceVar(_))
-            | (&TyData::Alias(ref alias), &TyData::Dyn(_)) => self.unify_projection_ty(alias, b),
+            | (&TyData::Alias(ref alias), &TyData::Dyn(_)) => self.unify_alias_ty(alias, b),
 
             (TyData::BoundVar(_), _) | (_, TyData::BoundVar(_)) => panic!(
                 "unification encountered bound variable: a={:?} b={:?}",
@@ -217,11 +217,11 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
     /// ```notrust
     /// ProjectionEq(<T as Trait>::Item = U)
     /// ```
-    fn unify_projection_ty(&mut self, proj: &ProjectionTy<TF>, ty: &Ty<TF>) -> Fallible<()> {
+    fn unify_alias_ty(&mut self, alias: &AliasTy<TF>, ty: &Ty<TF>) -> Fallible<()> {
         Ok(self.goals.push(InEnvironment::new(
             self.environment,
-            ProjectionEq {
-                projection: proj.clone(),
+            AliasEq {
+                alias: alias.clone(),
                 ty: ty.clone(),
             }
             .cast(),

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -160,18 +160,18 @@ impl<'t, TF: TypeFamily> Unifier<'t, TF> {
 
             // Unifying an associated type projection `<T as
             // Trait>::Item` with some other type `U`.
-            (&TyData::Apply(_), &TyData::Projection(ref proj))
-            | (&TyData::Placeholder(_), &TyData::Projection(ref proj))
-            | (&TyData::Function(_), &TyData::Projection(ref proj))
-            | (&TyData::InferenceVar(_), &TyData::Projection(ref proj))
-            | (&TyData::Dyn(_), &TyData::Projection(ref proj)) => self.unify_projection_ty(proj, a),
+            (&TyData::Apply(_), &TyData::Alias(ref alias))
+            | (&TyData::Placeholder(_), &TyData::Alias(ref alias))
+            | (&TyData::Function(_), &TyData::Alias(ref alias))
+            | (&TyData::InferenceVar(_), &TyData::Alias(ref alias))
+            | (&TyData::Dyn(_), &TyData::Alias(ref alias)) => self.unify_projection_ty(alias, a),
 
-            (&TyData::Projection(ref proj), &TyData::Projection(_))
-            | (&TyData::Projection(ref proj), &TyData::Apply(_))
-            | (&TyData::Projection(ref proj), &TyData::Placeholder(_))
-            | (&TyData::Projection(ref proj), &TyData::Function(_))
-            | (&TyData::Projection(ref proj), &TyData::InferenceVar(_))
-            | (&TyData::Projection(ref proj), &TyData::Dyn(_)) => self.unify_projection_ty(proj, b),
+            (&TyData::Alias(ref alias), &TyData::Alias(_))
+            | (&TyData::Alias(ref alias), &TyData::Apply(_))
+            | (&TyData::Alias(ref alias), &TyData::Placeholder(_))
+            | (&TyData::Alias(ref alias), &TyData::Function(_))
+            | (&TyData::Alias(ref alias), &TyData::InferenceVar(_))
+            | (&TyData::Alias(ref alias), &TyData::Dyn(_)) => self.unify_projection_ty(alias, b),
 
             (TyData::BoundVar(_), _) | (_, TyData::BoundVar(_)) => panic!(
                 "unification encountered bound variable: a={:?} b={:?}",

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -521,8 +521,8 @@ impl MayInvalidate {
                 self.aggregate_placeholder_tys(p1, p2)
             }
 
-            (TyData::Projection(apply1), TyData::Projection(apply2)) => {
-                self.aggregate_projection_tys(apply1, apply2)
+            (TyData::Alias(alias1), TyData::Alias(alias2)) => {
+                self.aggregate_projection_tys(alias1, alias2)
             }
 
             // For everything else, be conservative here and just say we may invalidate.
@@ -530,7 +530,7 @@ impl MayInvalidate {
             | (TyData::Dyn(_), _)
             | (TyData::Apply(_), _)
             | (TyData::Placeholder(_), _)
-            | (TyData::Projection(_), _) => true,
+            | (TyData::Alias(_), _) => true,
         }
     }
 

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -522,7 +522,7 @@ impl MayInvalidate {
             }
 
             (TyData::Alias(alias1), TyData::Alias(alias2)) => {
-                self.aggregate_projection_tys(alias1, alias2)
+                self.aggregate_alias_tys(alias1, alias2)
             }
 
             // For everything else, be conservative here and just say we may invalidate.
@@ -568,16 +568,16 @@ impl MayInvalidate {
         new != current
     }
 
-    fn aggregate_projection_tys<TF: TypeFamily>(
+    fn aggregate_alias_tys<TF: TypeFamily>(
         &mut self,
-        new: &ProjectionTy<TF>,
-        current: &ProjectionTy<TF>,
+        new: &AliasTy<TF>,
+        current: &AliasTy<TF>,
     ) -> bool {
-        let ProjectionTy {
+        let AliasTy {
             associated_ty_id: new_name,
             substitution: new_substitution,
         } = new;
-        let ProjectionTy {
+        let AliasTy {
             associated_ty_id: current_name,
             substitution: current_substitution,
         } = current;

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -183,12 +183,12 @@ impl<TF: TypeFamily> AntiUnifier<'_, TF> {
                 self.aggregate_application_tys(apply1, apply2)
             }
 
-            (TyData::Projection(apply1), TyData::Projection(apply2)) => {
-                self.aggregate_projection_tys(apply1, apply2)
+            (TyData::Alias(alias1), TyData::Alias(alias2)) => {
+                self.aggregate_alias_tys(alias1, alias2)
             }
 
-            (TyData::Placeholder(apply1), TyData::Placeholder(apply2)) => {
-                self.aggregate_placeholder_tys(apply1, apply2)
+            (TyData::Placeholder(placeholder1), TyData::Placeholder(placeholder2)) => {
+                self.aggregate_placeholder_tys(placeholder1, placeholder2)
             }
 
             // Mismatched base kinds.
@@ -197,7 +197,7 @@ impl<TF: TypeFamily> AntiUnifier<'_, TF> {
             | (TyData::Dyn(_), _)
             | (TyData::Function(_), _)
             | (TyData::Apply(_), _)
-            | (TyData::Projection(_), _)
+            | (TyData::Alias(_), _)
             | (TyData::Placeholder(_), _) => self.new_variable(),
         }
     }
@@ -235,23 +235,23 @@ impl<TF: TypeFamily> AntiUnifier<'_, TF> {
         }
     }
 
-    fn aggregate_projection_tys(
+    fn aggregate_alias_tys(
         &mut self,
-        proj1: &ProjectionTy<TF>,
-        proj2: &ProjectionTy<TF>,
+        alias1: &ProjectionTy<TF>,
+        alias2: &ProjectionTy<TF>,
     ) -> Ty<TF> {
         let ProjectionTy {
             associated_ty_id: name1,
             substitution: substitution1,
-        } = proj1;
+        } = alias1;
         let ProjectionTy {
             associated_ty_id: name2,
             substitution: substitution2,
-        } = proj2;
+        } = alias2;
 
         self.aggregate_name_and_substs(name1, substitution1, name2, substitution2)
             .map(|(&associated_ty_id, substitution)| {
-                TyData::Projection(ProjectionTy {
+                TyData::Alias(ProjectionTy {
                     associated_ty_id,
                     substitution,
                 })

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -235,23 +235,19 @@ impl<TF: TypeFamily> AntiUnifier<'_, TF> {
         }
     }
 
-    fn aggregate_alias_tys(
-        &mut self,
-        alias1: &ProjectionTy<TF>,
-        alias2: &ProjectionTy<TF>,
-    ) -> Ty<TF> {
-        let ProjectionTy {
+    fn aggregate_alias_tys(&mut self, alias1: &AliasTy<TF>, alias2: &AliasTy<TF>) -> Ty<TF> {
+        let AliasTy {
             associated_ty_id: name1,
             substitution: substitution1,
         } = alias1;
-        let ProjectionTy {
+        let AliasTy {
             associated_ty_id: name2,
             substitution: substitution2,
         } = alias2;
 
         self.aggregate_name_and_substs(name1, substitution1, name2, substitution2)
             .map(|(&associated_ty_id, substitution)| {
-                TyData::Alias(ProjectionTy {
+                TyData::Alias(AliasTy {
                     associated_ty_id,
                     substitution,
                 })

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -364,9 +364,7 @@ impl<TF: TypeFamily> Zipper<TF> for AnswerSubstitutor<'_, TF> {
 
             (TyData::Dyn(answer), TyData::Dyn(pending)) => Zip::zip_with(self, answer, pending),
 
-            (TyData::Projection(answer), TyData::Projection(pending)) => {
-                Zip::zip_with(self, answer, pending)
-            }
+            (TyData::Alias(answer), TyData::Alias(pending)) => Zip::zip_with(self, answer, pending),
 
             (TyData::Placeholder(answer), TyData::Placeholder(pending)) => {
                 Zip::zip_with(self, answer, pending)
@@ -389,7 +387,7 @@ impl<TF: TypeFamily> Zipper<TF> for AnswerSubstitutor<'_, TF> {
             (TyData::BoundVar(_), _)
             | (TyData::Apply(_), _)
             | (TyData::Dyn(_), _)
-            | (TyData::Projection(_), _)
+            | (TyData::Alias(_), _)
             | (TyData::Placeholder(_), _)
             | (TyData::Function(_), _) => panic!(
                 "structural mismatch between answer `{:?}` and pending goal `{:?}`",

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -15,16 +15,16 @@ pub trait Split<TF: TypeFamily>: RustIrDatabase<TF> {
     /// any type parameters itself.
     fn split_projection<'p>(
         &self,
-        projection: &'p ProjectionTy<TF>,
+        alias: &'p AliasTy<TF>,
     ) -> (
         Arc<AssociatedTyDatum<TF>>,
         &'p [Parameter<TF>],
         &'p [Parameter<TF>],
     ) {
-        let ProjectionTy {
+        let AliasTy {
             associated_ty_id,
             ref substitution,
-        } = *projection;
+        } = *alias;
         let parameters = substitution.parameters();
         let associated_ty_data = &self.associated_ty_data(associated_ty_id);
         let trait_datum = &self.trait_datum(associated_ty_data.trait_id);
@@ -37,18 +37,15 @@ pub trait Split<TF: TypeFamily>: RustIrDatabase<TF> {
     /// Given a projection `<P0 as Trait<P1..Pn>>::Item<Pn..Pm>`,
     /// returns the trait parameters `[P0..Pn]` (see
     /// `split_projection`).
-    fn trait_parameters_from_projection<'p>(
-        &self,
-        projection: &'p ProjectionTy<TF>,
-    ) -> &'p [Parameter<TF>] {
-        let (_, trait_params, _) = self.split_projection(projection);
+    fn trait_parameters_from_projection<'p>(&self, alias: &'p AliasTy<TF>) -> &'p [Parameter<TF>] {
+        let (_, trait_params, _) = self.split_projection(alias);
         trait_params
     }
 
     /// Given a projection `<P0 as Trait<P1..Pn>>::Item<Pn..Pm>`,
     /// returns the trait parameters `[P0..Pn]` (see
     /// `split_projection`).
-    fn trait_ref_from_projection<'p>(&self, projection: &'p ProjectionTy<TF>) -> TraitRef<TF> {
+    fn trait_ref_from_projection<'p>(&self, projection: &'p AliasTy<TF>) -> TraitRef<TF> {
         let (associated_ty_data, trait_params, _) = self.split_projection(&projection);
         TraitRef {
             trait_id: associated_ty_data.trait_id,
@@ -121,7 +118,7 @@ pub trait Split<TF: TypeFamily>: RustIrDatabase<TF> {
         &self,
         parameters: &'p [Parameter<TF>],
         associated_ty_value: &AssociatedTyValue<TF>,
-    ) -> (&'p [Parameter<TF>], ProjectionTy<TF>) {
+    ) -> (&'p [Parameter<TF>], AliasTy<TF>) {
         debug_heading!(
             "impl_parameters_and_projection_from_associated_ty_value(parameters={:?})",
             parameters,
@@ -149,16 +146,16 @@ pub trait Split<TF: TypeFamily>: RustIrDatabase<TF> {
                 .cloned(),
         );
 
-        let projection = ProjectionTy {
+        let alias = AliasTy {
             associated_ty_id: associated_ty_value.associated_ty_id,
             substitution: projection_substitution,
         };
 
         debug!("impl_parameters: {:?}", impl_parameters);
         debug!("trait_ref: {:?}", trait_ref);
-        debug!("projection: {:?}", projection);
+        debug!("alias: {:?}", alias);
 
-        (impl_parameters, projection)
+        (impl_parameters, alias)
     }
 }
 

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -87,9 +87,9 @@ impl<TF: TypeFamily> FoldInputTypes for Ty<TF> {
                 qwc.bounds.fold(accumulator);
             }
 
-            TyData::Projection(proj) => {
+            TyData::Alias(alias) => {
                 accumulator.push(self.clone());
-                proj.substitution.fold(accumulator);
+                alias.substitution.fold(accumulator);
             }
 
             TyData::Placeholder(_) => {
@@ -121,7 +121,7 @@ impl<TF: TypeFamily> FoldInputTypes for TraitRef<TF> {
 
 impl<TF: TypeFamily> FoldInputTypes for ProjectionEq<TF> {
     fn fold(&self, accumulator: &mut Vec<Ty<TF>>) {
-        TyData::Projection(self.projection.clone())
+        TyData::Alias(self.projection.clone())
             .intern()
             .fold(accumulator);
         self.ty.fold(accumulator);

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -119,11 +119,9 @@ impl<TF: TypeFamily> FoldInputTypes for TraitRef<TF> {
     }
 }
 
-impl<TF: TypeFamily> FoldInputTypes for ProjectionEq<TF> {
+impl<TF: TypeFamily> FoldInputTypes for AliasEq<TF> {
     fn fold(&self, accumulator: &mut Vec<Ty<TF>>) {
-        TyData::Alias(self.projection.clone())
-            .intern()
-            .fold(accumulator);
+        TyData::Alias(self.alias.clone()).intern().fold(accumulator);
         self.ty.fold(accumulator);
     }
 }
@@ -132,7 +130,7 @@ impl<TF: TypeFamily> FoldInputTypes for WhereClause<TF> {
     fn fold(&self, accumulator: &mut Vec<Ty<TF>>) {
         match self {
             WhereClause::Implemented(tr) => tr.fold(accumulator),
-            WhereClause::ProjectionEq(p) => p.fold(accumulator),
+            WhereClause::AliasEq(p) => p.fold(accumulator),
         }
     }
 }

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -215,7 +215,7 @@ fn atc_accounting() {
             "ForAll<type> { \
              ForAll<lifetime> { \
              ForAll<type> { \
-             all(ProjectionEq(<^2 as Iterable>::Iter<'^1> = ^0), \
+             all(AliasEq(<^2 as Iterable>::Iter<'^1> = ^0), \
              Implemented(^2: Iterable)) \
              } \
              } \


### PR DESCRIPTION
Most types with `projection` in the name were renamed to `alias`, but I've kept the projection-specific code (mostly `program_clauses.rs` and `split.rs` mostly the same. It's not entirely clear to me which parts will need to be generalized to all kinds of aliases, and which parts stay specific to associated type projections.