### PR TITLE
Some cleanups and add a `solve_limited`

### DIFF
--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -189,6 +189,16 @@ pub trait Context: Clone + Debug {
     /// `HhGoal`, but the goals contained within are left as context
     /// goals.
     fn into_hh_goal(goal: Self::Goal) -> HhGoal<Self>;
+
+    // Used by: simplify
+    fn add_clauses(env: &Self::Environment, clauses: Self::ProgramClauses) -> Self::Environment;
+
+    /// Upcast this domain goal into a more general goal.
+    fn into_goal(domain_goal: Self::DomainGoal) -> Self::Goal;
+
+    /// Selects the next appropriate subgoal index for evaluation.
+    /// Used by: logic
+    fn next_subgoal_index(ex_clause: &ExClause<Self>) -> usize;
 }
 
 pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
@@ -262,17 +272,7 @@ pub trait AggregateOps<C: Context> {
 
 /// An "inference table" contains the state to support unification and
 /// other operations on terms.
-pub trait InferenceTable<C: Context>: ResolventOps<C> + TruncateOps<C> + UnificationOps<C> {
-    // Used by: simplify
-    fn add_clauses(&mut self, env: &C::Environment, clauses: C::ProgramClauses) -> C::Environment;
-
-    /// Upcast this domain goal into a more general goal.
-    fn into_goal(&self, domain_goal: C::DomainGoal) -> C::Goal;
-
-    /// Selects the next appropriate subgoal index for evaluation.
-    /// Used by: logic
-    fn next_subgoal_index(&mut self, ex_clause: &ExClause<C>) -> usize;
-}
+pub trait InferenceTable<C: Context>: ResolventOps<C> + TruncateOps<C> + UnificationOps<C> {}
 
 /// Error type for the `UnificationOps::program_clauses` method --
 /// indicates that the complete set of program clauses for this goal

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -179,6 +179,16 @@ pub trait Context: Clone + Debug {
     fn identity_constrained_subst(
         goal: &Self::UCanonicalGoalInEnvironment,
     ) -> Self::CanonicalConstrainedSubst;
+
+    /// Convert the context's goal type into the `HhGoal` type that
+    /// the SLG solver understands. The expectation is that the
+    /// context's goal type has the same set of variants, but with
+    /// different names and a different setup. If you inspect
+    /// `HhGoal`, you will see that this is a "shallow" or "lazy"
+    /// conversion -- that is, we convert the outermost goal into an
+    /// `HhGoal`, but the goals contained within are left as context
+    /// goals.
+    fn into_hh_goal(goal: Self::Goal) -> HhGoal<Self>;
 }
 
 pub trait ContextOps<C: Context>: Sized + Clone + Debug + AggregateOps<C> {
@@ -253,16 +263,6 @@ pub trait AggregateOps<C: Context> {
 /// An "inference table" contains the state to support unification and
 /// other operations on terms.
 pub trait InferenceTable<C: Context>: ResolventOps<C> + TruncateOps<C> + UnificationOps<C> {
-    /// Convert the context's goal type into the `HhGoal` type that
-    /// the SLG solver understands. The expectation is that the
-    /// context's goal type has the same set of variants, but with
-    /// different names and a different setup. If you inspect
-    /// `HhGoal`, you will see that this is a "shallow" or "lazy"
-    /// conversion -- that is, we convert the outermost goal into an
-    /// `HhGoal`, but the goals contained within are left as context
-    /// goals.
-    fn into_hh_goal(&mut self, goal: C::Goal) -> HhGoal<C>;
-
     // Used by: simplify
     fn add_clauses(&mut self, env: &C::Environment, clauses: C::ProgramClauses) -> C::Environment;
 

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -267,6 +267,7 @@ pub trait AggregateOps<C: Context> {
         &self,
         root_goal: &C::UCanonicalGoalInEnvironment,
         answers: impl AnswerStream<C>,
+        should_continue: impl Fn() -> bool,
     ) -> Option<C::Solution>;
 }
 
@@ -412,6 +413,13 @@ impl<C: Context> AnswerResult<C> {
     pub fn is_no_more_solutions(&self) -> bool {
         match self {
             Self::NoMoreSolutions => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_quantum_exceeded(&self) -> bool {
+        match self {
+            Self::QuantumExceeded => true,
             _ => false,
         }
     }

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -59,8 +59,9 @@ impl<C: Context> Forest<C> {
         &mut self,
         context: &impl ContextOps<C>,
         goal: &C::UCanonicalGoalInEnvironment,
+        should_continue: impl Fn() -> bool,
     ) -> Option<C::Solution> {
-        context.make_solution(&goal, self.iter_answers(context, goal))
+        context.make_solution(&goal, self.iter_answers(context, goal), should_continue)
     }
 
     /// Solves a given goal, producing the solution. This will do only

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -204,7 +204,7 @@ impl<C: Context> Forest<C> {
     }
 
     pub(super) fn any_future_answer(
-        &mut self,
+        &self,
         table: TableIndex,
         answer: AnswerIndex,
         mut test: impl FnMut(&C::InferenceNormalizedSubst) -> bool,
@@ -214,7 +214,7 @@ impl<C: Context> Forest<C> {
             return test(C::inference_normalized_subst_from_subst(&answer.subst));
         }
 
-        self.tables[table].strands_mut().any(|strand| {
+        self.tables[table].strands().any(|strand| {
             test(C::inference_normalized_subst_from_ex_clause(
                 &strand.canonical_ex_clause,
             ))
@@ -1418,7 +1418,7 @@ impl<C: Context> Forest<C> {
         // untruncated literal.  Suppose that we truncate the selected
         // goal to:
         //
-        //     // Vec<Vec<T>: Sized
+        //     // Vec<Vec<T>>: Sized
         //
         // Clearly this table will have some solutions that don't
         // apply to us.  e.g., `Vec<Vec<u32>>: Sized` is a solution to

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -966,7 +966,7 @@ impl<C: Context> Forest<C> {
                     continue;
                 }
 
-                let subgoal_index = strand.infer.next_subgoal_index(&strand.ex_clause);
+                let subgoal_index = C::next_subgoal_index(&strand.ex_clause);
 
                 // Get or create table for this subgoal.
                 match self.get_or_create_table_for_subgoal(

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -1228,7 +1228,7 @@ impl<C: Context> Forest<C> {
         goal: C::Goal,
     ) {
         let table_ref = &mut self.tables[table];
-        match infer.into_hh_goal(goal) {
+        match C::into_hh_goal(goal) {
             HhGoal::DomainGoal(domain_goal) => {
                 match context.program_clauses(&environment, &domain_goal, &mut infer) {
                     Ok(clauses) => {

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -31,19 +31,19 @@ impl<C: Context> Forest<C> {
             match hh_goal {
                 HhGoal::ForAll(subgoal) => {
                     let subgoal = infer.instantiate_binders_universally(&subgoal);
-                    pending_goals.push((environment, infer.into_hh_goal(subgoal)));
+                    pending_goals.push((environment, C::into_hh_goal(subgoal)));
                 }
                 HhGoal::Exists(subgoal) => {
                     let subgoal = infer.instantiate_binders_existentially(&subgoal);
-                    pending_goals.push((environment, infer.into_hh_goal(subgoal)))
+                    pending_goals.push((environment, C::into_hh_goal(subgoal)))
                 }
                 HhGoal::Implies(wc, subgoal) => {
                     let new_environment = infer.add_clauses(&environment, wc);
-                    pending_goals.push((new_environment, infer.into_hh_goal(subgoal)));
+                    pending_goals.push((new_environment, C::into_hh_goal(subgoal)));
                 }
                 HhGoal::All(subgoals) => {
                     for subgoal in subgoals {
-                        pending_goals.push((environment.clone(), infer.into_hh_goal(subgoal)));
+                        pending_goals.push((environment.clone(), C::into_hh_goal(subgoal)));
                     }
                 }
                 HhGoal::Not(subgoal) => {

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -38,7 +38,7 @@ impl<C: Context> Forest<C> {
                     pending_goals.push((environment, C::into_hh_goal(subgoal)))
                 }
                 HhGoal::Implies(wc, subgoal) => {
-                    let new_environment = infer.add_clauses(&environment, wc);
+                    let new_environment = C::add_clauses(&environment, wc);
                     pending_goals.push((new_environment, C::into_hh_goal(subgoal)));
                 }
                 HhGoal::All(subgoals) => {
@@ -66,7 +66,7 @@ impl<C: Context> Forest<C> {
                         .subgoals
                         .push(Literal::Positive(C::goal_in_environment(
                             &environment,
-                            infer.into_goal(domain_goal),
+                            C::into_goal(domain_goal),
                         )));
                 }
                 HhGoal::CannotProve => {

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -70,6 +70,10 @@ impl<C: Context> Table<C> {
         self.strands.iter_mut()
     }
 
+    pub(crate) fn strands(&self) -> impl Iterator<Item = &CanonicalStrand<C>> {
+        self.strands.iter()
+    }
+
     pub(crate) fn take_strands(&mut self) -> VecDeque<CanonicalStrand<C>> {
         mem::replace(&mut self.strands, VecDeque::new())
     }

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -162,7 +162,7 @@ impl<TF: TypeFamily> Solver<TF> {
         &mut self,
         program: &dyn RustIrDatabase<TF>,
         goal: &UCanonical<InEnvironment<Goal<TF>>>,
-        should_continue: impl Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> Option<Solution<TF>> {
         let ops = self.forest.context().ops(program);
         self.forest.solve(&ops, goal, should_continue)

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -151,7 +151,9 @@ impl<TF: TypeFamily> Solver<TF> {
     ///     each time you invoke `solve`, as otherwise the cached data may be
     ///     invalid.
     /// - `goal` the goal to solve
-    /// - `should_continue` if `false` is returned, the no further solving will be done
+    /// - `should_continue` if `false` is returned, the no further solving
+    ///   will be done. A `Guidance(Suggested(...))` will be returned a
+    ///   `Solution`, using any answers that were generated up to that point.
     ///
     /// # Returns
     ///

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -191,6 +191,27 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
             GoalData::CannotProve(()) => HhGoal::CannotProve,
         }
     }
+
+    // Used by: simplify
+    fn add_clauses(env: &Environment<TF>, clauses: Vec<ProgramClause<TF>>) -> Environment<TF> {
+        Environment::add_clauses(env, clauses)
+    }
+
+    fn into_goal(domain_goal: DomainGoal<TF>) -> Goal<TF> {
+        domain_goal.cast()
+    }
+
+    // Used by: logic
+    fn next_subgoal_index(ex_clause: &ExClause<SlgContext<TF>>) -> usize {
+        // For now, we always pick the last subgoal in the
+        // list.
+        //
+        // FIXME(rust-lang-nursery/chalk#80) -- we should be more
+        // selective. For example, we don't want to pick a
+        // negative literal that will flounder, and we don't want
+        // to pick things like `?T: Sized` if we can help it.
+        ex_clause.subgoals.len() - 1
+    }
 }
 
 impl<'me, TF: TypeFamily> context::ContextOps<SlgContext<TF>> for SlgContextOps<'me, TF> {
@@ -339,32 +360,7 @@ impl<TF: TypeFamily> context::TruncateOps<SlgContext<TF>> for TruncatingInferenc
     }
 }
 
-impl<TF: TypeFamily> context::InferenceTable<SlgContext<TF>> for TruncatingInferenceTable<TF> {
-    // Used by: simplify
-    fn add_clauses(
-        &mut self,
-        env: &Environment<TF>,
-        clauses: Vec<ProgramClause<TF>>,
-    ) -> Environment<TF> {
-        Environment::add_clauses(env, clauses)
-    }
-
-    fn into_goal(&self, domain_goal: DomainGoal<TF>) -> Goal<TF> {
-        domain_goal.cast()
-    }
-
-    // Used by: logic
-    fn next_subgoal_index(&mut self, ex_clause: &ExClause<SlgContext<TF>>) -> usize {
-        // For now, we always pick the last subgoal in the
-        // list.
-        //
-        // FIXME(rust-lang-nursery/chalk#80) -- we should be more
-        // selective. For example, we don't want to pick a
-        // negative literal that will flounder, and we don't want
-        // to pick things like `?T: Sized` if we can help it.
-        ex_clause.subgoals.len() - 1
-    }
-}
+impl<TF: TypeFamily> context::InferenceTable<SlgContext<TF>> for TruncatingInferenceTable<TF> {}
 
 impl<TF: TypeFamily> context::UnificationOps<SlgContext<TF>> for TruncatingInferenceTable<TF> {
     fn instantiate_binders_universally(&mut self, arg: &Binders<Goal<TF>>) -> Goal<TF> {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -174,6 +174,23 @@ impl<TF: TypeFamily> context::Context for SlgContext<TF> {
             })
             .quantified
     }
+
+    fn into_hh_goal(goal: Goal<TF>) -> HhGoal<SlgContext<TF>> {
+        match goal.data().clone() {
+            GoalData::Quantified(QuantifierKind::ForAll, binders_goal) => {
+                HhGoal::ForAll(binders_goal)
+            }
+            GoalData::Quantified(QuantifierKind::Exists, binders_goal) => {
+                HhGoal::Exists(binders_goal)
+            }
+            GoalData::Implies(dg, subgoal) => HhGoal::Implies(dg, subgoal),
+            GoalData::All(goals) => HhGoal::All(goals),
+            GoalData::Not(g1) => HhGoal::Not(g1),
+            GoalData::EqGoal(EqGoal { a, b }) => HhGoal::Unify((), a, b),
+            GoalData::DomainGoal(domain_goal) => HhGoal::DomainGoal(domain_goal),
+            GoalData::CannotProve(()) => HhGoal::CannotProve,
+        }
+    }
 }
 
 impl<'me, TF: TypeFamily> context::ContextOps<SlgContext<TF>> for SlgContextOps<'me, TF> {
@@ -323,23 +340,6 @@ impl<TF: TypeFamily> context::TruncateOps<SlgContext<TF>> for TruncatingInferenc
 }
 
 impl<TF: TypeFamily> context::InferenceTable<SlgContext<TF>> for TruncatingInferenceTable<TF> {
-    fn into_hh_goal(&mut self, goal: Goal<TF>) -> HhGoal<SlgContext<TF>> {
-        match goal.data().clone() {
-            GoalData::Quantified(QuantifierKind::ForAll, binders_goal) => {
-                HhGoal::ForAll(binders_goal)
-            }
-            GoalData::Quantified(QuantifierKind::Exists, binders_goal) => {
-                HhGoal::Exists(binders_goal)
-            }
-            GoalData::Implies(dg, subgoal) => HhGoal::Implies(dg, subgoal),
-            GoalData::All(goals) => HhGoal::All(goals),
-            GoalData::Not(g1) => HhGoal::Not(g1),
-            GoalData::EqGoal(EqGoal { a, b }) => HhGoal::Unify((), a, b),
-            GoalData::DomainGoal(domain_goal) => HhGoal::DomainGoal(domain_goal),
-            GoalData::CannotProve(()) => HhGoal::CannotProve,
-        }
-    }
-
     // Used by: simplify
     fn add_clauses(
         &mut self,

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -19,7 +19,7 @@ impl<TF: TypeFamily> context::AggregateOps<SlgContext<TF>> for SlgContextOps<'_,
         &self,
         root_goal: &UCanonical<InEnvironment<Goal<TF>>>,
         mut answers: impl context::AnswerStream<SlgContext<TF>>,
-        should_continue: impl Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> Option<Solution<TF>> {
         let CompleteAnswer { subst, ambiguous } = match answers.next_answer(|| should_continue()) {
             AnswerResult::NoMoreSolutions => {


### PR DESCRIPTION
This *could* be two separate PRs, but the cleanups are small:
- Moved methods from `InferenceTable` onto `Context` directly, since they don't need an `&self`
- Made `any_future_answer` take a `&self` instead of a `&mut self`

The bulk of the PR involves adding a `should_continue` argument to `peek_answer` and `next_answer`, which allows stopping of solving before an answer is ready, when a `QuantumExceeded` has been returned. Right now, it's a argument-less function, so there's no real "feedback", so it's pretty much limited to either a time-based or call number-based implementation.
However, some ideas for how to extend this:
- Pass the current (or expected) substitution to the function. This could allow the caller to accept that an answer is "good enough".
- Be a bit smarter with the returned answer after `false` is returned. Right now, the returned answer is the current substitution as `Guidance(Suggested(...))`. Instead, we could take into account the *possible* answers (similar to how `any_future_answer` works). Or, maybe we just return `None` instead.