### PR TITLE
Flounder if truncation would happen

### DIFF
--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -1,5 +1,5 @@
 use crate::context::{
-    Context, ContextOps, Floundered, InferenceTable, ResolventOps, UnificationOps,
+    Context, ContextOps, Floundered, InferenceTable, ResolventOps, TruncateOps, UnificationOps,
 };
 use crate::fallible::NoSolution;
 use crate::forest::Forest;

--- a/tests/test/cycle.rs
+++ b/tests/test/cycle.rs
@@ -164,7 +164,7 @@ fn overflow() {
         goal {
             S<Z>: Q
         } yields {
-            "No possible solution"
+            "Ambiguous; no inference guidance"
         }
     }
 }

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -308,12 +308,12 @@ fn cached_answers_1() {
 
         goal {
             exists<T> { T: Sour }
-        } yields_all[SolverChoice::slg(2, None)] {
+        } yields_first[SolverChoice::slg(2, None)] {
             "substitution [?0 := Lemon], lifetime constraints []",
             "substitution [?0 := Vinegar], lifetime constraints []",
             "substitution [?0 := HotSauce<Lemon>], lifetime constraints []",
             "substitution [?0 := HotSauce<Vinegar>], lifetime constraints []",
-            "Ambiguous(for<?U0> { substitution [?0 := HotSauce<^0>], lifetime constraints [] })"
+            "Floundered"
         }
     }
 }
@@ -335,12 +335,12 @@ fn cached_answers_2() {
 
         goal {
             exists<T> { T: Sour }
-        } yields_all[SolverChoice::slg(2, None)] {
+        } yields_first[SolverChoice::slg(2, None)] {
             "substitution [?0 := Lemon], lifetime constraints []",
             "substitution [?0 := Vinegar], lifetime constraints []",
             "substitution [?0 := HotSauce<Lemon>], lifetime constraints []",
             "substitution [?0 := HotSauce<Vinegar>], lifetime constraints []",
-            "Ambiguous(for<?U0> { substitution [?0 := HotSauce<^0>], lifetime constraints [] })"
+            "Floundered"
         }
     }
 }
@@ -362,12 +362,11 @@ fn cached_answers_3() {
 
         goal {
             exists<T> { T: Sour }
-        } yields_all[SolverChoice::slg(2, None)] {
+        } yields_first[SolverChoice::slg(2, None)] {
             "substitution [?0 := Lemon], lifetime constraints []",
             "substitution [?0 := HotSauce<Lemon>], lifetime constraints []",
             "substitution [?0 := Vinegar], lifetime constraints []",
-            "Ambiguous(for<?U0> { substitution [?0 := HotSauce<^0>], lifetime constraints [] })",
-            "substitution [?0 := HotSauce<Vinegar>], lifetime constraints []"
+            "Floundered"
         }
     }
 }

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -72,7 +72,8 @@ fn subgoal_abstraction() {
 
         goal {
             exists<T> { T: Foo }
-        } yields_all[SolverChoice::slg(50, None)] {
+        } yields_first[SolverChoice::slg(50, None)] {
+            "Floundered"
         }
     }
 }
@@ -169,25 +170,25 @@ fn subgoal_cycle_uninhabited() {
             impl<T> Foo for Box<T> where Box<Vec<T>>: Foo { }
         }
 
-        // There is no solution here with a finite proof, so we get
-        // back: 0 answer(s) found.
+        // Infinite recursion -> we flounder
         goal {
             exists<T> { T: Foo }
-        } yields_all[SolverChoice::slg(2, None)] {
+        } yields_first[SolverChoice::slg(2, None)] {
+            "Floundered"
         }
 
-        // Unsurprisingly, applying negation succeeds then.
+        // Unsurprisingly, applying negation also flounders.
         goal {
             not { exists<T> { T: Foo } }
-        } yields_all[SolverChoice::slg(2, None)] {
-            "substitution [], lifetime constraints []"
+        } yields_first[SolverChoice::slg(2, None)] {
+            "Floundered"
         }
 
         // Equivalent to the previous.
         goal {
             forall<T> { not { T: Foo } }
-        } yields_all[SolverChoice::slg(2, None)] {
-            "substitution [], lifetime constraints []"
+        } yields_first[SolverChoice::slg(2, None)] {
+            "Floundered"
         }
 
         // However, if we come across a negative goal that exceeds our
@@ -208,8 +209,9 @@ fn subgoal_cycle_uninhabited() {
         // Here, due to the hypothesis, there does indeed exist a suitable T, `U`.
         goal {
             forall<U> { if (U: Foo) { exists<T> { T: Foo } } }
-        } yields_all[SolverChoice::slg(2, None)] {
-            "substitution [?0 := !1_0], lifetime constraints []"
+        } yields_first[SolverChoice::slg(2, None)] {
+            "substitution [?0 := !1_0], lifetime constraints []",
+            "Floundered"
         }
     }
 }
@@ -226,10 +228,12 @@ fn subgoal_cycle_inhabited() {
             impl Foo for u32 { }
         }
 
+        // Exceeds size threshold -> flounder
         goal {
             exists<T> { T: Foo }
-        } yields_all[SolverChoice::slg(3, None)] {
-            "substitution [?0 := u32], lifetime constraints []"
+        } yields_first[SolverChoice::slg(3, None)] {
+            "substitution [?0 := u32], lifetime constraints []",
+            "Floundered"
         }
     }
 }


### PR DESCRIPTION
Fixes #301 (this is caused by bad truncation)
cc. #302 (should fix many known cases of this, but theoretically the problem still exists)
cc. #318 (needs more investigation)

This keeps all existing truncation code intact, just doesn't use the resulting substs or goals. But could change it to short-circuit to a bool.

Could add some documentation to `abstract_*_literal` to explain why we discard the goal if it would get truncated, but overall changes are pretty minimal/complete.