### PR TITLE
Remove the context prelude for engine.

### DIFF
--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -11,8 +11,6 @@ use crate::{CompleteAnswer, ExClause};
 use std::fmt::Debug;
 use std::hash::Hash;
 
-pub(crate) mod prelude;
-
 /// The "context" in which the SLG solver operates. It defines all the
 /// types that the SLG solver may need to refer to, as well as a few
 /// very simple interconversion methods.

--- a/chalk-engine/src/context/prelude.rs
+++ b/chalk-engine/src/context/prelude.rs
@@ -1,8 +1,0 @@
-#![allow(unused_imports)] // rustc bug
-
-pub(crate) use super::AggregateOps;
-pub(crate) use super::Context;
-pub(crate) use super::ContextOps;
-pub(crate) use super::InferenceTable;
-pub(crate) use super::ResolventOps;
-pub(crate) use super::TruncateOps;

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -1,6 +1,4 @@
-use crate::context::prelude::*;
-use crate::context::AnswerResult;
-use crate::context::AnswerStream;
+use crate::context::{AnswerResult, AnswerStream, Context, ContextOps};
 use crate::logic::RootSearchFail;
 use crate::stack::{Stack, StackIndex};
 use crate::table::AnswerIndex;

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -1,4 +1,6 @@
-use crate::context::{prelude::*, Floundered, UnificationOps};
+use crate::context::{
+    Context, ContextOps, Floundered, InferenceTable, ResolventOps, UnificationOps,
+};
 use crate::fallible::NoSolution;
 use crate::forest::Forest;
 use crate::hh::HhGoal;

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -1,4 +1,4 @@
-use crate::context::prelude::*;
+use crate::context::{Context, InferenceTable};
 use crate::fallible::Fallible;
 use crate::forest::Forest;
 use crate::hh::HhGoal;

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -1,4 +1,4 @@
-use crate::context::prelude::*;
+use crate::context::Context;
 use crate::strand::CanonicalStrand;
 use crate::Answer;
 use rustc_hash::FxHashMap;

--- a/chalk-engine/src/tables.rs
+++ b/chalk-engine/src/tables.rs
@@ -1,4 +1,4 @@
-use crate::context::prelude::*;
+use crate::context::Context;
 use crate::table::Table;
 use crate::TableIndex;
 use rustc_hash::FxHashMap;


### PR DESCRIPTION
Seems mostly unnecessary and an extra indirection.