### PR TITLE
Don't return definite guidance if we find one solution and then flounder

### DIFF
--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -70,6 +70,10 @@ impl<I: Interner> context::AggregateOps<SlgContext<I>> for SlgContextOps<'_, I> 
                 break Guidance::Unknown;
             }
 
+            if let AnswerResult::Floundered = answers.peek_answer(|| should_continue()) {
+                break Guidance::Unknown;
+            }
+
             if !answers
                 .any_future_answer(|ref mut new_subst| new_subst.may_invalidate(interner, &subst))
             {

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -96,6 +96,63 @@ fn flounder() {
     }
 }
 
+/// Don't return definite guidance if we flounder after finding one solution.
+#[test]
+fn flounder_ambiguous() {
+    test! {
+        program {
+            trait IntoIterator { }
+            #[non_enumerable]
+            trait OtherTrait { }
+
+            struct Ref<T> { }
+            struct A { }
+
+            impl IntoIterator for Ref<A> { }
+            impl<T> IntoIterator for Ref<T> where T: OtherTrait { }
+        }
+
+        goal {
+            exists<T> { Ref<T>: IntoIterator }
+        } yields {
+            "Ambiguous; no inference guidance"
+        }
+    }
+}
+
+/// Don't return definite guidance if we are able to merge two solutions and the
+/// third one matches that as well (the fourth may not).
+#[test]
+fn normalize_ambiguous() {
+    test! {
+        program {
+            trait IntoIterator { type Item; }
+
+            struct Ref<T> { }
+            struct A { }
+            struct B { }
+            struct C { }
+
+            struct D { }
+
+            impl IntoIterator for Ref<A> { type Item = Ref<A>; }
+            impl IntoIterator for Ref<B> { type Item = Ref<B>; }
+            impl IntoIterator for Ref<C> { type Item = Ref<C>; }
+            impl IntoIterator for Ref<D> { type Item = D; }
+        }
+
+        goal {
+            exists<T, U> {
+                Normalize(<Ref<T> as IntoIterator>::Item -> U)
+            }
+        } yields {
+            // FIXME: this is wrong!
+            "Ambiguous; definite substitution"
+            // "Ambiguous; no inference guidance"
+        }
+    }
+}
+
 // Test that, when solving `?T: Sized`, we only wind up pulling a few
 // answers before we stop.
 // Also tests that we search breadth-first.


### PR DESCRIPTION
If we find one solution and then flounder, this previously resulted in a `Guidance::Definite` result. I think the reason is that `any_future_answer` has no answers to check and hence returns true.
