### PR TITLE
Changes needed to build in rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ rustyline = "1.0"
 salsa = "0.10.0"
 serde = "1.0"
 serde_derive = "1.0"
-stacker = "0.1.5"
 
 [dependencies.chalk-parse]
 version = "0.1.0"

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -424,7 +424,7 @@ impl<C: Context> AnswerResult<C> {
 }
 
 impl<C: Context> Debug for AnswerResult<C> {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AnswerResult::Answer(answer) => write!(fmt, "{:?}", answer),
             AnswerResult::Floundered => write!(fmt, "Floundered"),

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -137,7 +137,7 @@ pub enum SubstitutionResult<S> {
 }
 
 impl<S: Display> Display for SubstitutionResult<S> {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SubstitutionResult::Definite(subst) => write!(fmt, "{}", subst),
             SubstitutionResult::Ambiguous(subst) => write!(fmt, "Ambiguous({})", subst),

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -56,11 +56,6 @@
 #[macro_use]
 extern crate chalk_macros;
 
-#[cfg(feature = "stack_protection")]
-extern crate stacker;
-
-extern crate rustc_hash;
-
 use crate::context::Context;
 use std::cmp::min;
 use std::usize;

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -40,8 +40,8 @@ pub(crate) struct SelectedSubgoal<C: Context> {
     pub(crate) universe_map: C::UniverseMap,
 }
 
-impl<'table, C: Context> Debug for Strand<C> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+impl<C: Context> Debug for Strand<C> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         fmt.debug_struct("Strand")
             .field("ex_clause", &self.ex_clause)
             .field("selected_subgoal", &self.selected_subgoal)

--- a/chalk-integration/src/error.rs
+++ b/chalk-integration/src/error.rs
@@ -96,7 +96,7 @@ pub enum RustIrError {
 }
 
 impl std::fmt::Display for RustIrError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             RustIrError::InvalidTypeName(name) => write!(f, "invalid type name `{}`", name),
             RustIrError::InvalidLifetimeName(name) => write!(f, "invalid lifetime name `{}`", name),

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -3,44 +3,44 @@ use std::fmt::{Debug, Display, Error, Formatter};
 use super::*;
 
 impl Debug for RawId {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "#{}", self.index)
     }
 }
 
 impl<I: Interner> Debug for TraitId<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         I::debug_trait_id(*self, fmt).unwrap_or_else(|| write!(fmt, "TraitId({:?})", self.0))
     }
 }
 
 impl<I: Interner> Debug for StructId<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         I::debug_struct_id(*self, fmt).unwrap_or_else(|| write!(fmt, "StructId({:?})", self.0))
     }
 }
 
 impl<I: Interner> Debug for AssocTypeId<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         I::debug_assoc_type_id(*self, fmt)
             .unwrap_or_else(|| write!(fmt, "AssocTypeId({:?})", self.0))
     }
 }
 
 impl Display for UniverseIndex {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "U{}", self.counter)
     }
 }
 
 impl Debug for UniverseIndex {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "U{}", self.counter)
     }
 }
 
 impl<I: Interner> Debug for TypeName<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             TypeName::Struct(id) => write!(fmt, "{:?}", id),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
@@ -49,13 +49,13 @@ impl<I: Interner> Debug for TypeName<I> {
     }
 }
 impl<I: Interner> Debug for Ty<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{:?}", self.data())
     }
 }
 
 impl<I: Interner> Debug for TyData<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             TyData::BoundVar(depth) => write!(fmt, "^{}", depth),
             TyData::Dyn(clauses) => write!(fmt, "{:?}", clauses),
@@ -69,20 +69,20 @@ impl<I: Interner> Debug for TyData<I> {
 }
 
 impl<I: Interner> Debug for DynTy<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let DynTy { bounds } = self;
         write!(fmt, "dyn {:?}", bounds)
     }
 }
 
 impl Debug for InferenceVar {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "?{}", self.index)
     }
 }
 
 impl<I: Interner> Debug for Fn<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         // FIXME -- we should introduce some names or something here
         let Fn {
             num_binders,
@@ -93,13 +93,13 @@ impl<I: Interner> Debug for Fn<I> {
 }
 
 impl<I: Interner> Debug for Lifetime<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{:?}", self.data())
     }
 }
 
 impl<I: Interner> Debug for LifetimeData<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             LifetimeData::BoundVar(depth) => write!(fmt, "'^{}", depth),
             LifetimeData::InferenceVar(var) => write!(fmt, "'{:?}", var),
@@ -110,14 +110,14 @@ impl<I: Interner> Debug for LifetimeData<I> {
 }
 
 impl Debug for PlaceholderIndex {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let PlaceholderIndex { ui, idx } = self;
         write!(fmt, "!{}_{}", ui.counter, idx)
     }
 }
 
 impl<I: Interner> Debug for ApplicationTy<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let ApplicationTy { name, substitution } = self;
         write!(fmt, "{:?}{:?}", name, substitution.with_angle())
     }
@@ -142,7 +142,7 @@ impl<I: Interner> TraitRef<I> {
 }
 
 impl<I: Interner> Debug for TraitRef<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Debug::fmt(&self.with_as(), fmt)
     }
 }
@@ -153,7 +153,7 @@ struct SeparatorTraitRef<'me, I: Interner> {
 }
 
 impl<I: Interner> Debug for SeparatorTraitRef<'_, I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let parameters = self.trait_ref.substitution.parameters();
         write!(
             fmt,
@@ -167,7 +167,7 @@ impl<I: Interner> Debug for SeparatorTraitRef<'_, I> {
 }
 
 impl<I: Interner> Debug for AliasTy<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         I::debug_alias(self, fmt).unwrap_or_else(|| {
             write!(
                 fmt,
@@ -179,10 +179,10 @@ impl<I: Interner> Debug for AliasTy<I> {
     }
 }
 
-pub struct Angle<'a, T: 'a>(pub &'a [T]);
+pub struct Angle<'a, T>(pub &'a [T]);
 
 impl<'a, T: Debug> Debug for Angle<'a, T> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         if self.0.len() > 0 {
             write!(fmt, "<")?;
             for (index, elem) in self.0.iter().enumerate() {
@@ -199,19 +199,19 @@ impl<'a, T: Debug> Debug for Angle<'a, T> {
 }
 
 impl<I: Interner> Debug for Normalize<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "Normalize({:?} -> {:?})", self.alias, self.ty)
     }
 }
 
 impl<I: Interner> Debug for AliasEq<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "AliasEq({:?} = {:?})", self.alias, self.ty)
     }
 }
 
 impl<I: Interner> Debug for WhereClause<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             WhereClause::Implemented(tr) => write!(fmt, "Implemented({:?})", tr.with_colon()),
             WhereClause::AliasEq(a) => write!(fmt, "{:?}", a),
@@ -220,7 +220,7 @@ impl<I: Interner> Debug for WhereClause<I> {
 }
 
 impl<I: Interner> Debug for FromEnv<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             FromEnv::Trait(t) => write!(fmt, "FromEnv({:?})", t.with_colon()),
             FromEnv::Ty(t) => write!(fmt, "FromEnv({:?})", t),
@@ -229,7 +229,7 @@ impl<I: Interner> Debug for FromEnv<I> {
 }
 
 impl<I: Interner> Debug for WellFormed<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             WellFormed::Trait(t) => write!(fmt, "WellFormed({:?})", t.with_colon()),
             WellFormed::Ty(t) => write!(fmt, "WellFormed({:?})", t),
@@ -238,7 +238,7 @@ impl<I: Interner> Debug for WellFormed<I> {
 }
 
 impl<I: Interner> Debug for DomainGoal<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             DomainGoal::Holds(n) => write!(fmt, "{:?}", n),
             DomainGoal::WellFormed(n) => write!(fmt, "{:?}", n),
@@ -257,13 +257,13 @@ impl<I: Interner> Debug for DomainGoal<I> {
 }
 
 impl<I: Interner> Debug for EqGoal<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "({:?} = {:?})", self.a, self.b)
     }
 }
 
 impl<I: Interner> Debug for Goal<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self.data() {
             GoalData::Quantified(qkind, ref subgoal) => {
                 write!(fmt, "{:?}<", qkind)?;
@@ -289,7 +289,7 @@ impl<I: Interner> Debug for Goal<I> {
 }
 
 impl<I: Interner> Debug for Goals<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "(")?;
         for (goal, index) in self.iter().zip(0..) {
             if index > 0 {
@@ -303,7 +303,7 @@ impl<I: Interner> Debug for Goals<I> {
 }
 
 impl<T: Debug> Debug for Binders<T> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let Binders {
             ref binders,
             ref value,
@@ -326,7 +326,7 @@ impl<T: Debug> Debug for Binders<T> {
 }
 
 impl<I: Interner> Debug for ProgramClause<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             ProgramClause::Implies(pc) => write!(fmt, "{:?}", pc),
             ProgramClause::ForAll(pc) => write!(fmt, "{:?}", pc),
@@ -335,7 +335,7 @@ impl<I: Interner> Debug for ProgramClause<I> {
 }
 
 impl<I: Interner> Debug for ProgramClauseImplication<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "{:?}", self.consequence)?;
 
         let conditions = self.conditions.as_slice();
@@ -354,13 +354,13 @@ impl<I: Interner> Debug for ProgramClauseImplication<I> {
 }
 
 impl<I: Interner> Debug for Environment<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         write!(fmt, "Env({:?})", self.clauses)
     }
 }
 
 impl<T: Display> Display for Canonical<T> {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let Canonical { binders, value } = self;
 
         if binders.is_empty() {
@@ -383,7 +383,7 @@ impl<T: Display> Display for Canonical<T> {
 }
 
 impl<T: Debug, L: Debug> Debug for ParameterKind<T, L> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match *self {
             ParameterKind::Ty(ref n) => write!(fmt, "Ty({:?})", n),
             ParameterKind::Lifetime(ref n) => write!(fmt, "Lifetime({:?})", n),
@@ -392,7 +392,7 @@ impl<T: Debug, L: Debug> Debug for ParameterKind<T, L> {
 }
 
 impl<I: Interner> Debug for Parameter<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self.data() {
             ParameterKind::Ty(n) => write!(fmt, "{:?}", n),
             ParameterKind::Lifetime(n) => write!(fmt, "{:?}", n),
@@ -401,7 +401,7 @@ impl<I: Interner> Debug for Parameter<I> {
 }
 
 impl<I: Interner> Debug for Constraint<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
             Constraint::LifetimeEq(a, b) => write!(fmt, "{:?} == {:?}", a, b),
         }
@@ -409,7 +409,7 @@ impl<I: Interner> Debug for Constraint<I> {
 }
 
 impl<I: Interner> Display for ConstrainedSubst<I> {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let ConstrainedSubst { subst, constraints } = self;
 
         write!(
@@ -429,13 +429,13 @@ impl<I: Interner> Substitution<I> {
 }
 
 impl<I: Interner> Debug for Substitution<I> {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         Display::fmt(self, fmt)
     }
 }
 
 impl<I: Interner> Display for Substitution<I> {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let mut first = true;
 
         write!(f, "[")?;

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -42,7 +42,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// converted back (by the [`ty_data`] method). The interned form
     /// must also introduce indirection, either via a `Box`, `&`, or
     /// other pointer type.
-    type InternedType: Debug + Clone + Eq + Ord + Hash;
+    type InternedType: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of lifetimes.  In normal user code,
     /// `Self::InternedLifetime` is not referenced Instead, we refer to
@@ -51,7 +51,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// An `InternedLifetime` must be something that can be created
     /// from a `LifetimeData` (by the [`intern_lifetime`] method) and
     /// then later converted back (by the [`lifetime_data`] method).
-    type InternedLifetime: Debug + Clone + Eq + Ord + Hash;
+    type InternedLifetime: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a "generic parameter", which can
     /// be either a type or a lifetime.  In normal user code,
@@ -60,7 +60,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     ///
     /// An `InternedType` is created by `intern_parameter` and can be
     /// converted back to its underlying data via `parameter_data`.
-    type InternedParameter: Debug + Clone + Eq + Ord + Hash;
+    type InternedParameter: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a "goal".  In normal user code,
     /// `Self::InternedGoal` is not referenced. Instead, we refer to
@@ -68,7 +68,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     ///
     /// An `InternedGoal` is created by `intern_goal` and can be
     /// converted back to its underlying data via `goal_data`.
-    type InternedGoal: Debug + Clone + Eq + Ord + Hash;
+    type InternedGoal: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a list of goals.  In normal user code,
     /// `Self::InternedGoals` is not referenced. Instead, we refer to
@@ -76,7 +76,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     ///
     /// An `InternedGoals` is created by `intern_goals` and can be
     /// converted back to its underlying data via `goals_data`.
-    type InternedGoals: Debug + Clone + Eq + Ord + Hash;
+    type InternedGoals: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a "substitution".  In normal user code,
     /// `Self::InternedSubstitution` is not referenced. Instead, we refer to
@@ -84,7 +84,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     ///
     /// An `InternedSubstitution` is created by `intern_substitution` and can be
     /// converted back to its underlying data via `substitution_data`.
-    type InternedSubstitution: Debug + Clone + Eq + Ord + Hash;
+    type InternedSubstitution: Debug + Clone + Eq + Hash;
 
     /// The core "id" type used for struct-ids and the like.
     type DefId: Debug + Copy + Eq + Ord + Hash;

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -4,7 +4,6 @@ use crate::fold::{Fold, Folder, Subst, SuperFold};
 use chalk_derive::{Fold, HasInterner};
 use chalk_engine::fallible::*;
 use lalrpop_intern::InternedString;
-use std::collections::BTreeSet;
 use std::iter;
 use std::marker::PhantomData;
 
@@ -22,9 +21,6 @@ macro_rules! impl_debugs {
         )*
     };
 }
-
-extern crate chalk_engine;
-extern crate lalrpop_intern;
 
 #[macro_use]
 mod macros;
@@ -46,7 +42,7 @@ pub mod tls;
 
 pub type Identifier = InternedString;
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 /// The set of assumptions we've made so far, and the current number of
 /// universal (forall) quantifiers we're within.
 pub struct Environment<I: Interner> {
@@ -63,13 +59,12 @@ impl<I: Interner> Environment<I> {
         II: IntoIterator<Item = ProgramClause<I>>,
     {
         let mut env = self.clone();
-        let env_clauses: BTreeSet<_> = env.clauses.into_iter().chain(clauses).collect();
-        env.clauses = env_clauses.into_iter().collect();
+        env.clauses = env.clauses.into_iter().chain(clauses).collect();
         env
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold)]
 pub struct InEnvironment<G: HasInterner> {
     pub environment: Environment<G::Interner>,
     pub goal: G,
@@ -229,7 +224,7 @@ impl<I: Interner> Ty<I> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, HasInterner)]
 pub enum TyData<I: Interner> {
     /// An "application" type is one that applies the set of type
     /// arguments to some base type. For example, `Vec<u32>` would be
@@ -307,7 +302,7 @@ impl<I: Interner> TyData<I> {
 /// known. It is referenced within the type using `^1`, indicating
 /// a bound type with debruijn index 1 (i.e., skipping through one
 /// level of binder).
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold)]
 pub struct DynTy<I: Interner> {
     pub bounds: Binders<Vec<QuantifiedWhereClause<I>>>,
 }
@@ -339,7 +334,7 @@ impl InferenceVar {
 
 /// for<'a...'z> X -- all binders are instantiated at once,
 /// and we use deBruijn indices within `self.ty`
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, HasInterner)]
 pub struct Fn<I: Interner> {
     pub num_binders: usize,
     pub parameters: Vec<Parameter<I>>,
@@ -420,7 +415,7 @@ impl PlaceholderIndex {
 }
 
 // Fold derive intentionally omitted, folded through Ty
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Fold, Ord, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub struct ApplicationTy<I: Interner> {
     pub name: TypeName<I>,
     pub substitution: Substitution<I>,
@@ -566,7 +561,7 @@ impl<I: Interner> ParameterData<I> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub struct AliasTy<I: Interner> {
     pub associated_ty_id: AssocTypeId<I>,
     pub substitution: Substitution<I>,
@@ -578,7 +573,7 @@ impl<I: Interner> AliasTy<I> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub struct TraitRef<I: Interner> {
     pub trait_id: TraitId<I>,
     pub substitution: Substitution<I>,
@@ -603,13 +598,13 @@ impl<I: Interner> TraitRef<I> {
 }
 
 /// Where clauses that can be written by a Rust programmer.
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub enum WhereClause<I: Interner> {
     Implemented(TraitRef<I>),
     AliasEq(AliasEq<I>),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub enum WellFormed<I: Interner> {
     /// A predicate which is true is some trait ref is well-formed.
     /// For example, given the following trait definitions:
@@ -639,7 +634,7 @@ pub enum WellFormed<I: Interner> {
     Ty(Ty<I>),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub enum FromEnv<I: Interner> {
     /// A predicate which enables deriving everything which should be true if we *know* that
     /// some trait ref is well-formed. For example given the above trait definitions, we can use
@@ -671,7 +666,7 @@ pub enum FromEnv<I: Interner> {
 /// A "domain goal" is a goal that is directly about Rust, rather than a pure
 /// logical statement. As much as possible, the Chalk solver should avoid
 /// decomposing this enum, and instead treat its values opaquely.
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub enum DomainGoal<I: Interner> {
     Holds(WhereClause<I>),
 
@@ -786,7 +781,7 @@ impl<I: Interner> DomainGoal<I> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold)]
 pub struct EqGoal<I: Interner> {
     pub a: Parameter<I>,
     pub b: Parameter<I>,
@@ -796,7 +791,7 @@ pub struct EqGoal<I: Interner> {
 /// type. A projection `T::Foo` normalizes to the type `U` if we can
 /// **match it to an impl** and that impl has a `type Foo = V` where
 /// `U = V`.
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold)]
 pub struct Normalize<I: Interner> {
     pub alias: AliasTy<I>,
     pub ty: Ty<I>,
@@ -805,7 +800,7 @@ pub struct Normalize<I: Interner> {
 /// Proves **equality** between a projection `T::Foo` and a type
 /// `U`. Equality can be proven via normalization, but we can also
 /// prove that `T::Foo = V::Foo` if `T = V` without normalizing.
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold)]
 pub struct AliasEq<I: Interner> {
     pub alias: AliasTy<I>,
     pub ty: Ty<I>,
@@ -946,13 +941,13 @@ impl<V: IntoIterator> Iterator for BindersIntoIterator<V> {
 /// Represents one clause of the form `consequence :- conditions` where
 /// `conditions = cond_1 && cond_2 && ...` is the conjunction of the individual
 /// conditions.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Fold, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub struct ProgramClauseImplication<I: Interner> {
     pub consequence: DomainGoal<I>,
     pub conditions: Goals<I>,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum ProgramClause<I: Interner> {
     Implies(ProgramClauseImplication<I>),
     ForAll(Binders<ProgramClauseImplication<I>>),
@@ -1010,7 +1005,7 @@ impl<T> UCanonical<T> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, HasInterner)]
 /// A list of goals.
 pub struct Goals<I: Interner> {
     goals: I::InternedGoals,
@@ -1163,7 +1158,7 @@ where
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
 /// A general goal; this is the full range of questions you can pose to Chalk.
 pub enum GoalData<I: Interner> {
     /// Introduces a binding at depth 0, shifting other bindings up
@@ -1210,13 +1205,13 @@ pub enum QuantifierKind {
 /// lifetime constraints, instead gathering them up to return with our solution
 /// for later checking. This allows for decoupling between type and region
 /// checking in the compiler.
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Fold, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub enum Constraint<I: Interner> {
     LifetimeEq(Lifetime<I>, Lifetime<I>),
 }
 
 /// A mapping of inference variables to instantiations thereof.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, HasInterner)]
 pub struct Substitution<I: Interner> {
     /// Map free variable with given index to the value with the same
     /// index. Naturally, the kind of the variable must agree with
@@ -1372,13 +1367,13 @@ impl<I: Interner> Folder<I> for &Substitution<I> {
 /// substitution stores the values for the query's unknown variables,
 /// and the constraints represents any region constraints that must
 /// additionally be solved.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Fold, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub struct ConstrainedSubst<I: Interner> {
     pub subst: Substitution<I>, /* NB: The `is_trivial` routine relies on the fact that `subst` is folded first. */
     pub constraints: Vec<InEnvironment<Constraint<I>>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Fold, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
 pub struct AnswerSubst<I: Interner> {
     pub subst: Substitution<I>, /* NB: The `is_trivial` routine relies on the fact that `subst` is folded first. */
     pub constraints: Vec<InEnvironment<Constraint<I>>>,

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -15,7 +15,7 @@ macro_rules! impl_debugs {
     ($($id:ident), *) => {
         $(
             impl<I: Interner> std::fmt::Debug for $id<I> {
-                fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+                fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
                     write!(fmt, "{}({:?})", stringify!($id), self.0)
                 }
             }

--- a/chalk-ir/src/tls.rs
+++ b/chalk-ir/src/tls.rs
@@ -12,25 +12,25 @@ pub trait DebugContext {
     fn debug_struct_id(
         &self,
         id: StructId<ChalkIr>,
-        fmt: &mut fmt::Formatter,
+        fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 
     fn debug_trait_id(
         &self,
         id: TraitId<ChalkIr>,
-        fmt: &mut fmt::Formatter,
+        fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 
     fn debug_assoc_type_id(
         &self,
         id: AssocTypeId<ChalkIr>,
-        fmt: &mut fmt::Formatter,
+        fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 
     fn debug_alias(
         &self,
         alias: &AliasTy<ChalkIr>,
-        fmt: &mut fmt::Formatter,
+        fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 }
 

--- a/chalk-macros/src/index.rs
+++ b/chalk-macros/src/index.rs
@@ -31,7 +31,7 @@ macro_rules! index_struct {
         }
 
         impl ::std::fmt::Debug for $n {
-            fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 write!(fmt, "{}({})", stringify!($n), self.value)
             }
         }

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -4,7 +4,7 @@ use chalk_ir::fold::{Fold, Folder};
 use chalk_ir::interner::HasInterner;
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use super::canonicalize::Canonicalized;
 use super::{EnaVariable, InferenceTable};
@@ -99,16 +99,16 @@ impl<I: Interner> InferenceTable<I> {
 
 struct Inverter<'q, I: Interner> {
     table: &'q mut InferenceTable<I>,
-    inverted_ty: HashMap<PlaceholderIndex, EnaVariable<I>>,
-    inverted_lifetime: HashMap<PlaceholderIndex, EnaVariable<I>>,
+    inverted_ty: FxHashMap<PlaceholderIndex, EnaVariable<I>>,
+    inverted_lifetime: FxHashMap<PlaceholderIndex, EnaVariable<I>>,
 }
 
 impl<'q, I: Interner> Inverter<'q, I> {
     fn new(table: &'q mut InferenceTable<I>) -> Self {
         Inverter {
             table,
-            inverted_ty: HashMap::new(),
-            inverted_lifetime: HashMap::new(),
+            inverted_ty: FxHashMap::default(),
+            inverted_lifetime: FxHashMap::default(),
         }
     }
 }

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -124,7 +124,7 @@ impl<I: Interner> UnifyValue for InferenceValue<I> {
 }
 
 impl<I: Interner> fmt::Debug for EnaVariable<I> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(fmt, "{:?}", self.var)
     }
 }

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -51,7 +51,7 @@ impl<I: Interner> Solution<I> {
 }
 
 impl<I: Interner> fmt::Display for Solution<I> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Solution::Unique(constrained) => write!(f, "Unique; {}", constrained,),
             Solution::Ambig(Guidance::Definite(subst)) => {


### PR DESCRIPTION
Basically just four types of changes:
1) Removing `Ord` and `PartialOrd` on interned types
2) Using `FxHashMap` instead of `HashMap`
3) Adding the explicit `'_` to `Formatter`
4) Removing `extern crate`
