### PR TITLE
Remove default dependency on lalrpop-intern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,6 @@ dependencies = [
  "salsa 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "stacker 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -913,17 +912,6 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "stacker"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "string_cache"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,7 +1189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum stacker 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb79482f57cf598af52094ec4cc3b3c42499d3ce5bd426f2ac41515b7e57404b"
 "checksum string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25d70109977172b127fe834e5449e5ab1740b9ba49fa18a2020f509174f25423"
 "checksum string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "35293b05cf1494e8ddd042a7df6756bf18d07f42d234f32e71dce8a7aabb0191"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"

--- a/chalk-integration/Cargo.toml
+++ b/chalk-integration/Cargo.toml
@@ -27,6 +27,7 @@ path = "../chalk-parse"
 [dependencies.chalk-ir]
 version = "0.1.0"
 path = "../chalk-ir"
+features = ["default-interner"]
 
 [dependencies.chalk-rust-ir]
 version = "0.1.0"

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -96,7 +96,10 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         self.program_ir().unwrap().impl_datum(id)
     }
 
-    fn associated_ty_value(&self, id: AssociatedTyValueId) -> Arc<AssociatedTyValue<ChalkIr>> {
+    fn associated_ty_value(
+        &self,
+        id: AssociatedTyValueId<ChalkIr>,
+    ) -> Arc<AssociatedTyValue<ChalkIr>> {
         self.program_ir().unwrap().associated_ty_values[&id].clone()
     }
 

--- a/chalk-integration/src/lib.rs
+++ b/chalk-integration/src/lib.rs
@@ -10,3 +10,19 @@ pub mod lowering;
 pub mod program;
 pub mod program_environment;
 pub mod query;
+
+pub use chalk_ir::interner::Identifier;
+use chalk_ir::Binders;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TypeSort {
+    Struct,
+    Trait,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TypeKind {
+    pub sort: TypeSort,
+    pub name: Identifier,
+    pub binders: Binders<()>,
+}

--- a/chalk-integration/src/lib.rs
+++ b/chalk-integration/src/lib.rs
@@ -11,7 +11,7 @@ pub mod program;
 pub mod program_environment;
 pub mod query;
 
-pub use chalk_ir::interner::Identifier;
+pub use chalk_ir::interner::{Identifier, RawId};
 use chalk_ir::Binders;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -10,14 +10,15 @@ use std::sync::Arc;
 
 use crate::error::RustIrError;
 use crate::program::Program as LoweredProgram;
-use crate::{Identifier as Ident, TypeKind, TypeSort};
+use crate::{Identifier as Ident, RawId, TypeKind, TypeSort};
 
 type StructIds = BTreeMap<Ident, chalk_ir::StructId<ChalkIr>>;
 type TraitIds = BTreeMap<Ident, chalk_ir::TraitId<ChalkIr>>;
 type StructKinds = BTreeMap<chalk_ir::StructId<ChalkIr>, TypeKind>;
 type TraitKinds = BTreeMap<chalk_ir::TraitId<ChalkIr>, TypeKind>;
 type AssociatedTyLookups = BTreeMap<(chalk_ir::TraitId<ChalkIr>, Ident), AssociatedTyLookup>;
-type AssociatedTyValueIds = BTreeMap<(chalk_ir::ImplId<ChalkIr>, Ident), AssociatedTyValueId>;
+type AssociatedTyValueIds =
+    BTreeMap<(chalk_ir::ImplId<ChalkIr>, Ident), AssociatedTyValueId<ChalkIr>>;
 type ParameterMap = BTreeMap<chalk_ir::ParameterKind<Ident>, usize>;
 
 pub type LowerResult<T> = Result<T, RustIrError>;
@@ -171,10 +172,10 @@ pub(crate) trait LowerProgram {
 impl LowerProgram for Program {
     fn lower(&self) -> LowerResult<LoweredProgram> {
         let mut index = 0;
-        let mut next_item_id = || -> chalk_ir::RawId {
+        let mut next_item_id = || -> RawId {
             let i = index;
             index += 1;
-            chalk_ir::RawId { index: i }
+            RawId { index: i }
         };
 
         // Make a vector mapping each thing in `items` to an id,

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -10,16 +10,15 @@ use std::sync::Arc;
 
 use crate::error::RustIrError;
 use crate::program::Program as LoweredProgram;
+use crate::{Identifier as Ident, TypeKind, TypeSort};
 
-type StructIds = BTreeMap<chalk_ir::Identifier, chalk_ir::StructId<ChalkIr>>;
-type TraitIds = BTreeMap<chalk_ir::Identifier, chalk_ir::TraitId<ChalkIr>>;
-type StructKinds = BTreeMap<chalk_ir::StructId<ChalkIr>, rust_ir::TypeKind>;
-type TraitKinds = BTreeMap<chalk_ir::TraitId<ChalkIr>, rust_ir::TypeKind>;
-type AssociatedTyLookups =
-    BTreeMap<(chalk_ir::TraitId<ChalkIr>, chalk_ir::Identifier), AssociatedTyLookup>;
-type AssociatedTyValueIds =
-    BTreeMap<(chalk_ir::ImplId<ChalkIr>, chalk_ir::Identifier), AssociatedTyValueId>;
-type ParameterMap = BTreeMap<chalk_ir::ParameterKind<chalk_ir::Identifier>, usize>;
+type StructIds = BTreeMap<Ident, chalk_ir::StructId<ChalkIr>>;
+type TraitIds = BTreeMap<Ident, chalk_ir::TraitId<ChalkIr>>;
+type StructKinds = BTreeMap<chalk_ir::StructId<ChalkIr>, TypeKind>;
+type TraitKinds = BTreeMap<chalk_ir::TraitId<ChalkIr>, TypeKind>;
+type AssociatedTyLookups = BTreeMap<(chalk_ir::TraitId<ChalkIr>, Ident), AssociatedTyLookup>;
+type AssociatedTyValueIds = BTreeMap<(chalk_ir::ImplId<ChalkIr>, Ident), AssociatedTyValueId>;
+type ParameterMap = BTreeMap<chalk_ir::ParameterKind<Ident>, usize>;
 
 pub type LowerResult<T> = Result<T, RustIrError>;
 
@@ -116,11 +115,11 @@ impl<'k> Env<'k> {
         Err(RustIrError::InvalidLifetimeName(name))
     }
 
-    fn struct_kind(&self, id: chalk_ir::StructId<ChalkIr>) -> &rust_ir::TypeKind {
+    fn struct_kind(&self, id: chalk_ir::StructId<ChalkIr>) -> &TypeKind {
         &self.struct_kinds[&id]
     }
 
-    fn trait_kind(&self, id: chalk_ir::TraitId<ChalkIr>) -> &rust_ir::TypeKind {
+    fn trait_kind(&self, id: chalk_ir::TraitId<ChalkIr>) -> &TypeKind {
         &self.trait_kinds[&id]
     }
 
@@ -129,7 +128,7 @@ impl<'k> Env<'k> {
     /// will be assigned in order as they are iterated.
     fn introduce<I>(&self, binders: I) -> LowerResult<Self>
     where
-        I: IntoIterator<Item = chalk_ir::ParameterKind<chalk_ir::Identifier>>,
+        I: IntoIterator<Item = chalk_ir::ParameterKind<Ident>>,
         I::IntoIter: ExactSizeIterator,
     {
         let binders = binders.into_iter().enumerate().map(|(i, k)| (k, i));
@@ -151,7 +150,7 @@ impl<'k> Env<'k> {
 
     fn in_binders<I, T, OP>(&self, binders: I, op: OP) -> LowerResult<chalk_ir::Binders<T>>
     where
-        I: IntoIterator<Item = chalk_ir::ParameterKind<chalk_ir::Identifier>>,
+        I: IntoIterator<Item = chalk_ir::ParameterKind<Ident>>,
         I::IntoIter: ExactSizeIterator,
         OP: FnOnce(&Self) -> LowerResult<T>,
     {
@@ -369,13 +368,13 @@ impl LowerProgram for Program {
 }
 
 trait LowerTypeKind {
-    fn lower_type_kind(&self) -> LowerResult<rust_ir::TypeKind>;
+    fn lower_type_kind(&self) -> LowerResult<TypeKind>;
 }
 
 trait LowerParameterMap {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<chalk_ir::Identifier>>;
+    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<Ident>>;
     fn declared_parameters(&self) -> &[ParameterKind];
-    fn all_parameters(&self) -> Vec<chalk_ir::ParameterKind<chalk_ir::Identifier>> {
+    fn all_parameters(&self) -> Vec<chalk_ir::ParameterKind<Ident>> {
         self.synthetic_parameters()
             .into_iter()
             .chain(self.declared_parameters().iter().map(|id| id.lower()))
@@ -415,7 +414,7 @@ trait LowerParameterMap {
 }
 
 impl LowerParameterMap for StructDefn {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<chalk_ir::Identifier>> {
+    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<Ident>> {
         None
     }
 
@@ -425,7 +424,7 @@ impl LowerParameterMap for StructDefn {
 }
 
 impl LowerParameterMap for Impl {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<chalk_ir::Identifier>> {
+    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<Ident>> {
         None
     }
 
@@ -435,7 +434,7 @@ impl LowerParameterMap for Impl {
 }
 
 impl LowerParameterMap for AssocTyDefn {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<chalk_ir::Identifier>> {
+    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<Ident>> {
         None
     }
 
@@ -445,7 +444,7 @@ impl LowerParameterMap for AssocTyDefn {
 }
 
 impl LowerParameterMap for AssocTyValue {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<chalk_ir::Identifier>> {
+    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<Ident>> {
         None
     }
 
@@ -455,7 +454,7 @@ impl LowerParameterMap for AssocTyValue {
 }
 
 impl LowerParameterMap for TraitDefn {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<chalk_ir::Identifier>> {
+    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<Ident>> {
         Some(chalk_ir::ParameterKind::Ty(intern(SELF)))
     }
 
@@ -465,7 +464,7 @@ impl LowerParameterMap for TraitDefn {
 }
 
 impl LowerParameterMap for Clause {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<chalk_ir::Identifier>> {
+    fn synthetic_parameters(&self) -> Option<chalk_ir::ParameterKind<Ident>> {
         None
     }
 
@@ -475,11 +474,11 @@ impl LowerParameterMap for Clause {
 }
 
 trait LowerParameterKind {
-    fn lower(&self) -> chalk_ir::ParameterKind<chalk_ir::Identifier>;
+    fn lower(&self) -> chalk_ir::ParameterKind<Ident>;
 }
 
 impl LowerParameterKind for ParameterKind {
-    fn lower(&self) -> chalk_ir::ParameterKind<chalk_ir::Identifier> {
+    fn lower(&self) -> chalk_ir::ParameterKind<Ident> {
         match *self {
             ParameterKind::Ty(ref n) => chalk_ir::ParameterKind::Ty(n.str),
             ParameterKind::Lifetime(ref n) => chalk_ir::ParameterKind::Lifetime(n.str),
@@ -499,9 +498,9 @@ trait LowerWhereClauses {
 }
 
 impl LowerTypeKind for StructDefn {
-    fn lower_type_kind(&self) -> LowerResult<rust_ir::TypeKind> {
-        Ok(rust_ir::TypeKind {
-            sort: rust_ir::TypeSort::Struct,
+    fn lower_type_kind(&self) -> LowerResult<TypeKind> {
+        Ok(TypeKind {
+            sort: TypeSort::Struct,
             name: self.name.str,
             binders: chalk_ir::Binders {
                 binders: self.all_parameters().anonymize(),
@@ -518,10 +517,10 @@ impl LowerWhereClauses for StructDefn {
 }
 
 impl LowerTypeKind for TraitDefn {
-    fn lower_type_kind(&self) -> LowerResult<rust_ir::TypeKind> {
+    fn lower_type_kind(&self) -> LowerResult<TypeKind> {
         let binders: Vec<_> = self.parameter_kinds.iter().map(|p| p.lower()).collect();
-        Ok(rust_ir::TypeKind {
-            sort: rust_ir::TypeSort::Trait,
+        Ok(TypeKind {
+            sort: TypeSort::Trait,
             name: self.name.str,
             binders: chalk_ir::Binders {
                 // for the purposes of the *type*, ignore `Self`:
@@ -728,7 +727,7 @@ impl LowerTraitBound for TraitBound {
         let trait_id = env.lookup_trait(self.trait_name)?;
 
         let k = env.trait_kind(trait_id);
-        if k.sort != rust_ir::TypeSort::Trait {
+        if k.sort != TypeSort::Trait {
             Err(RustIrError::NotTrait(self.trait_name))?;
         }
 

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -1,14 +1,14 @@
+use crate::{Identifier, TypeKind};
 use chalk_ir::could_match::CouldMatch;
 use chalk_ir::debug::Angle;
 use chalk_ir::interner::ChalkIr;
 use chalk_ir::tls;
 use chalk_ir::{
-    AliasTy, AssocTypeId, Identifier, ImplId, Parameter, ProgramClause, StructId, TraitId, TyData,
-    TypeName,
+    AliasTy, AssocTypeId, ImplId, Parameter, ProgramClause, StructId, TraitId, TyData, TypeName,
 };
 use chalk_rust_ir::{
     AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ImplDatum, ImplType, StructDatum,
-    TraitDatum, TypeKind,
+    TraitDatum,
 };
 use chalk_solve::split::Split;
 use chalk_solve::RustIrDatabase;

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -37,7 +37,8 @@ pub struct Program {
     pub impl_data: BTreeMap<ImplId<ChalkIr>, Arc<ImplDatum<ChalkIr>>>,
 
     /// For each associated ty value `type Foo = XXX` found in an impl:
-    pub associated_ty_values: BTreeMap<AssociatedTyValueId, Arc<AssociatedTyValue<ChalkIr>>>,
+    pub associated_ty_values:
+        BTreeMap<AssociatedTyValueId<ChalkIr>, Arc<AssociatedTyValue<ChalkIr>>>,
 
     /// For each trait:
     pub trait_data: BTreeMap<TraitId<ChalkIr>, Arc<TraitDatum<ChalkIr>>>,
@@ -138,7 +139,10 @@ impl RustIrDatabase<ChalkIr> for Program {
         self.impl_data[&id].clone()
     }
 
-    fn associated_ty_value(&self, id: AssociatedTyValueId) -> Arc<AssociatedTyValue<ChalkIr>> {
+    fn associated_ty_value(
+        &self,
+        id: AssociatedTyValueId<ChalkIr>,
+    ) -> Arc<AssociatedTyValue<ChalkIr>> {
         self.associated_ty_values[&id].clone()
     }
 

--- a/chalk-ir/Cargo.toml
+++ b/chalk-ir/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["compiler", "traits", "prolog"]
 edition = "2018"
 
 [dependencies]
-lalrpop-intern = "0.15.1"
+lalrpop-intern = { version = "0.15.1", optional = true }
 
 [dependencies.chalk-macros]
 version = "0.1.0"
@@ -23,3 +23,7 @@ path = "../chalk-engine"
 [dependencies.chalk-derive]
 version = "0.1.0"
 path = "../chalk-derive"
+
+[features]
+default = []
+default-interner = ["lalrpop-intern"]

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -2,12 +2,6 @@ use std::fmt::{Debug, Display, Error, Formatter};
 
 use super::*;
 
-impl Debug for RawId {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        write!(fmt, "#{}", self.index)
-    }
-}
-
 impl<I: Interner> Debug for TraitId<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         I::debug_trait_id(*self, fmt).unwrap_or_else(|| write!(fmt, "TraitId({:?})", self.0))

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -109,7 +109,6 @@ macro_rules! copy_fold {
     };
 }
 
-copy_fold!(Identifier);
 copy_fold!(UniverseIndex);
 copy_fold!(usize);
 copy_fold!(PlaceholderIndex);

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -212,10 +212,21 @@ pub trait HasInterner {
 mod default {
     use super::*;
     use crate::tls;
-    use crate::RawId;
     use lalrpop_intern::InternedString;
+    use std::fmt;
 
     pub type Identifier = InternedString;
+
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct RawId {
+        pub index: u32,
+    }
+
+    impl Debug for RawId {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(fmt, "#{}", self.index)
+        }
+    }
 
     /// The default "interner" and the only interner used by chalk
     /// itself. In this interner, no interning actually occurs.

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -152,12 +152,6 @@ pub struct AssocTypeId<I: Interner>(pub I::DefId);
 
 impl_debugs!(ImplId, ClauseId);
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[allow(non_camel_case_types)]
-pub struct RawId {
-    pub index: u32,
-}
-
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasInterner)]
 pub struct Ty<I: Interner> {
     interned: I::InternedType,

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -3,7 +3,6 @@ use crate::fold::shift::Shift;
 use crate::fold::{Fold, Folder, Subst, SuperFold};
 use chalk_derive::{Fold, HasInterner};
 use chalk_engine::fallible::*;
-use lalrpop_intern::InternedString;
 use std::iter;
 use std::marker::PhantomData;
 
@@ -38,9 +37,8 @@ use interner::{HasInterner, Interner, TargetInterner};
 
 pub mod could_match;
 pub mod debug;
+#[cfg(any(test, feature = "default-interner"))]
 pub mod tls;
-
-pub type Identifier = InternedString;
 
 #[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner)]
 /// The set of assumptions we've made so far, and the current number of
@@ -158,12 +156,6 @@ impl_debugs!(ImplId, ClauseId);
 #[allow(non_camel_case_types)]
 pub struct RawId {
     pub index: u32,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum TypeSort {
-    Struct,
-    Trait,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasInterner)]
@@ -456,6 +448,16 @@ impl<T> ParameterKind<T> {
     pub fn map<OP, U>(self, op: OP) -> ParameterKind<U>
     where
         OP: FnOnce(T) -> U,
+    {
+        match self {
+            ParameterKind::Ty(t) => ParameterKind::Ty(op(t)),
+            ParameterKind::Lifetime(t) => ParameterKind::Lifetime(op(t)),
+        }
+    }
+
+    pub fn map_ref<OP, U>(&self, op: OP) -> ParameterKind<U>
+    where
+        OP: FnOnce(&T) -> U,
     {
         match self {
             ParameterKind::Ty(t) => ParameterKind::Ty(op(t)),

--- a/chalk-ir/src/macros.rs
+++ b/chalk-ir/src/macros.rs
@@ -25,7 +25,7 @@ macro_rules! ty {
 
     (alias (item $n:tt) $($arg:tt)*) => {
         $crate::TyData::Alias(AliasTy {
-            associated_ty_id: AssocTypeId(RawId { index: $n }),
+            associated_ty_id: AssocTypeId(chalk_ir::interner::RawId { index: $n }),
             substitution: $crate::Substitution::from(vec![$(arg!($arg)),*] as Vec<$crate::Parameter<_>>),
         }).intern()
     };
@@ -84,6 +84,6 @@ macro_rules! lifetime {
 #[macro_export]
 macro_rules! ty_name {
     ((item $n:expr)) => {
-        $crate::TypeName::Struct(StructId(RawId { index: $n }))
+        $crate::TypeName::Struct(StructId(chalk_ir::interner::RawId { index: $n }))
     };
 }

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -158,7 +158,6 @@ eq_zip!(I => StructId<I>);
 eq_zip!(I => TraitId<I>);
 eq_zip!(I => AssocTypeId<I>);
 eq_zip!(I => TypeName<I>);
-eq_zip!(I => Identifier);
 eq_zip!(I => QuantifierKind);
 eq_zip!(I => PhantomData<I>);
 eq_zip!(I => PlaceholderIndex);

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -7,9 +7,9 @@ use chalk_ir::cast::Cast;
 use chalk_ir::fold::{shift::Shift, Fold, Folder};
 use chalk_ir::interner::{HasInterner, Interner, TargetInterner};
 use chalk_ir::{
-    AliasEq, AliasTy, AssocTypeId, Binders, Identifier, ImplId, LifetimeData, Parameter,
-    ParameterKind, QuantifiedWhereClause, RawId, StructId, Substitution, TraitId, TraitRef, Ty,
-    TyData, TypeName, WhereClause,
+    AliasEq, AliasTy, AssocTypeId, Binders, ImplId, LifetimeData, Parameter, ParameterKind,
+    QuantifiedWhereClause, RawId, StructId, Substitution, TraitId, TraitRef, Ty, TyData, TypeName,
+    WhereClause,
 };
 use std::iter;
 
@@ -245,15 +245,15 @@ impl<I: Interner> AliasEqBound<I> {
 
 pub trait Anonymize {
     /// Utility function that converts from a list of generic parameters
-    /// which *have* names (`ParameterKind<Identifier>`) to a list of
+    /// which *have* names (`ParameterKind<T>`) to a list of
     /// "anonymous" generic parameters that just preserves their
     /// kinds (`ParameterKind<()>`). Often convenient in lowering.
     fn anonymize(&self) -> Vec<ParameterKind<()>>;
 }
 
-impl Anonymize for [ParameterKind<Identifier>] {
+impl<T> Anonymize for [ParameterKind<T>] {
     fn anonymize(&self) -> Vec<ParameterKind<()>> {
-        self.iter().map(|pk| pk.map(|_| ())).collect()
+        self.iter().map(|pk| pk.map_ref(|_| ())).collect()
     }
 }
 
@@ -301,7 +301,7 @@ pub struct AssociatedTyDatum<I: Interner> {
     pub id: AssocTypeId<I>,
 
     /// Name of this associated type.
-    pub name: Identifier,
+    pub name: I::Identifier,
 
     /// These binders represent the `P0...Pm` variables.  The binders
     /// are in the order `[Pn..Pm; P0..Pn]`. That is, the variables
@@ -413,19 +413,6 @@ pub struct AssociatedTyValue<I: Interner> {
 pub struct AssociatedTyValueBound<I: Interner> {
     /// Type that we normalize to. The X in `type Foo<'a> = X`.
     pub ty: Ty<I>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TypeKind {
-    pub sort: TypeSort,
-    pub name: Identifier,
-    pub binders: Binders<()>,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum TypeSort {
-    Struct,
-    Trait,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -8,7 +8,7 @@ use chalk_ir::fold::{shift::Shift, Fold, Folder};
 use chalk_ir::interner::{HasInterner, Interner, TargetInterner};
 use chalk_ir::{
     AliasEq, AliasTy, AssocTypeId, Binders, ImplId, LifetimeData, Parameter, ParameterKind,
-    QuantifiedWhereClause, RawId, StructId, Substitution, TraitId, TraitRef, Ty, TyData, TypeName,
+    QuantifiedWhereClause, StructId, Substitution, TraitId, TraitRef, Ty, TyData, TypeName,
     WhereClause,
 };
 use std::iter;
@@ -18,14 +18,14 @@ pub enum LangItem {}
 
 /// Identifier for an "associated type value" found in some impl.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AssociatedTyValueId(pub RawId);
+pub struct AssociatedTyValueId<I: Interner>(pub I::DefId);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ImplDatum<I: Interner> {
     pub polarity: Polarity,
     pub binders: Binders<ImplDatumBound<I>>,
     pub impl_type: ImplType,
-    pub associated_ty_value_ids: Vec<AssociatedTyValueId>,
+    pub associated_ty_value_ids: Vec<AssociatedTyValueId<I>>,
 }
 
 impl<I: Interner> ImplDatum<I> {

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -34,7 +34,7 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     fn impl_datum(&self, impl_id: ImplId<I>) -> Arc<ImplDatum<I>>;
 
     /// Returns the `AssociatedTyValue` with the given id.
-    fn associated_ty_value(&self, id: AssociatedTyValueId) -> Arc<AssociatedTyValue<I>>;
+    fn associated_ty_value(&self, id: AssociatedTyValueId<I>) -> Arc<AssociatedTyValue<I>>;
 
     /// If `id` is a struct id, returns `Some(id)` (but cast to `StructId`).
     fn as_struct_id(&self, id: &TypeName<I>) -> Option<StructId<I>>;

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -327,7 +327,7 @@ where
     ///     forall<'a> { WellFormed(Box<&'a T>) },
     /// }
     /// ```
-    fn compute_assoc_ty_goal(&self, assoc_ty_id: AssociatedTyValueId) -> Option<Goal<I>> {
+    fn compute_assoc_ty_goal(&self, assoc_ty_id: AssociatedTyValueId<I>) -> Option<Goal<I>> {
         let assoc_ty = &self.db.associated_ty_value(assoc_ty_id);
 
         // The substitutions for the binders on this associated type


### PR DESCRIPTION
Closes #295 

So, the default interner (`ChalkIr`) is now available only with `cfg(test)` or `cfg(feature = "default-interner")`. The former for obvious reasons; the latter because of `chalk-integration`. Interner now has an `Identifier` associated type for the whole *one* place it's used in `chalk-ir` (`AssociatedTyDatum`). `RawId` has also been moved to the same configuration, along with the dependency on `lalrpop-intern`. I figured this is enough to close the linked issue, since these two cases (tests and chalk-integration) *we* control and know they are single-threaded. We could, in the future, change out lalrpop-intern for a library (like string_cache) that *is* thread-safe.

Also moved `TypeSort` and `TypeKind` to `chalk-integration` since they weren't used in `chalk_ir`.