### PR TITLE
Update rustc-guide to rustc-dev-guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,4 +92,4 @@ of the terminology used in chalk.
 ### Trait solving in rustc-dev-guide
 The rustc-dev-guide describes [new-style trait solving][trait-solving], which is slowly replacing the old trait resolution.
 
-[trait-solving]: https://rust-lang.github.io/rustc-dev-guide/traits/index.html
+[trait-solving]: https://rustc-dev-guide.rust-lang.org/traits/index.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ machinery inside of chalk.
 In addition to the blog posts there is a [glossary](GLOSSARY.md) explaining some
 of the terminology used in chalk.
 
-### Trait solving in rustc guide
-The rustc guide describes [new-style trait solving][trait-solving], which is slowly replacing the old trait resolution.
+### Trait solving in rustc-dev-guide
+The rustc-dev-guide describes [new-style trait solving][trait-solving], which is slowly replacing the old trait resolution.
 
-[trait-solving]: https://rust-lang.github.io/rustc-guide/traits/index.html
+[trait-solving]: https://rust-lang.github.io/rustc-dev-guide/traits/index.html

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the compiler, but also for experimentation.
 
 ## FAQ
 
-**How does chalk relate to rustc?** The plan is to have rustc use the `chalk-engine` crate (in this repo), which defines chalk's solver. The rest of chalk can then be considered an elaborate unit testing harness. For more details, see [the Traits chapter of the rustc-dev-guide](https://rust-lang.github.io/rustc-dev-guide/traits/index.html).
+**How does chalk relate to rustc?** The plan is to have rustc use the `chalk-engine` crate (in this repo), which defines chalk's solver. The rest of chalk can then be considered an elaborate unit testing harness. For more details, see [the Traits chapter of the rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/traits/index.html).
 
 **Where does the name come from?** `chalk` is named after [Chalkidiki], the area where [Aristotle] was
 born. Since Prolog is a logic programming language, this seemed a

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the compiler, but also for experimentation.
 
 ## FAQ
 
-**How does chalk relate to rustc?** The plan is to have rustc use the `chalk-engine` crate (in this repo), which defines chalk's solver. The rest of chalk can then be considered an elaborate unit testing harness. For more details, see [the Traits chapter of the rustc-guide](https://rust-lang.github.io/rustc-guide/traits/index.html).
+**How does chalk relate to rustc?** The plan is to have rustc use the `chalk-engine` crate (in this repo), which defines chalk's solver. The rest of chalk can then be considered an elaborate unit testing harness. For more details, see [the Traits chapter of the rustc-dev-guide](https://rust-lang.github.io/rustc-dev-guide/traits/index.html).
 
 **Where does the name come from?** `chalk` is named after [Chalkidiki], the area where [Aristotle] was
 born. Since Prolog is a logic programming language, this seemed a

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -44,9 +44,9 @@ pub trait Context: Clone + Debug {
 
     /// A canonicalized `GoalInEnvironment` -- that is, one where all
     /// free inference variables have been bound into the canonical
-    /// binder. See [the rustc-guide] for more information.
+    /// binder. See [the rustc-dev-guide] for more information.
     ///
-    /// [the rustc-guide]: https://rust-lang.github.io/rustc-guide/traits/canonicalization.html
+    /// [the rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
     type CanonicalGoalInEnvironment: Debug;
 
     /// A u-canonicalized `GoalInEnvironment` -- this is one where the

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -46,7 +46,7 @@ pub trait Context: Clone + Debug {
     /// free inference variables have been bound into the canonical
     /// binder. See [the rustc-dev-guide] for more information.
     ///
-    /// [the rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/traits/canonicalization.html
+    /// [the rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
     type CanonicalGoalInEnvironment: Debug;
 
     /// A u-canonicalized `GoalInEnvironment` -- this is one where the

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -2,7 +2,7 @@
 //! implements the well-formed semantics. For an overview of how the solver
 //! works, see [The On-Demand SLG Solver][guide] in the rustc-dev-guide.
 //!
-//! [guide]: https://rust-lang.github.io/rustc-dev-guide/traits/slg.html
+//! [guide]: https://rustc-dev-guide.rust-lang.org/traits/slg.html
 //!
 //! This algorithm is very closed based on the description found in the
 //! following paper, which I will refer to in the comments as EWFS:

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -1,8 +1,8 @@
 //! An alternative solver based around the SLG algorithm, which
 //! implements the well-formed semantics. For an overview of how the solver
-//! works, see [The On-Demand SLG Solver][guide] in the rustc guide.
+//! works, see [The On-Demand SLG Solver][guide] in the rustc-dev-guide.
 //!
-//! [guide]: https://rust-lang.github.io/rustc-guide/traits/slg.html
+//! [guide]: https://rust-lang.github.io/rustc-dev-guide/traits/slg.html
 //!
 //! This algorithm is very closed based on the description found in the
 //! following paper, which I will refer to in the comments as EWFS:

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -111,7 +111,7 @@ pub enum TypeName<I: Interner> {
 /// `forall<T> { Goal(T) }` (syntactical representation)
 /// `forall { Goal(?0) }` (used a DeBruijn index)
 /// `Goal(!U1)` (the quantifier was moved to the environment and replaced with a universe index)
-/// See https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html#placeholders-and-universes for more.
+/// See https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference.html#placeholders-and-universes for more.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UniverseIndex {
     pub counter: usize,

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -111,7 +111,7 @@ pub enum TypeName<I: Interner> {
 /// `forall<T> { Goal(T) }` (syntactical representation)
 /// `forall { Goal(?0) }` (used a DeBruijn index)
 /// `Goal(!U1)` (the quantifier was moved to the environment and replaced with a universe index)
-/// See https://rust-lang.github.io/rustc-guide/borrow_check/region_inference.html#placeholders-and-universes for more.
+/// See https://rust-lang.github.io/rustc-dev-guide/borrow_check/region_inference.html#placeholders-and-universes for more.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UniverseIndex {
     pub counter: usize,


### PR DESCRIPTION
The `rustc-guide` is being renamed to the `rustc-dev-guide`. The discussion is in rust-lang/rustc-guide#470.

This PR revises `rustc-guide` to `rustc-dev-guide` in this project.

Transition tracker: rust-lang/rustc-guide#602