### PR TITLE
Change force_impl_for to return Option<bool>

### DIFF
--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -13,8 +13,11 @@ pub fn add_builtin_program_clauses<I: Interner>(
     trait_ref: &TraitRef<I>,
     ty: &TyData<I>,
 ) {
-    if db.force_impl_for(well_known, ty) {
-        builder.push_fact(trait_ref.clone());
+    if let Some(force_impl) = db.force_impl_for(well_known, ty) {
+        if force_impl {
+            builder.push_fact(trait_ref.clone());
+        }
+        return;
     }
 
     match well_known {

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -71,9 +71,13 @@ pub trait RustIrDatabase<I: Interner>: Debug {
 
     /// A stop-gap solution to force an impl for a given well-known trait.
     /// Useful when the logic for a given trait is absent or incomplete.
+    /// A value of `Some(true)` means that the the clause for the impl will be
+    /// added. A value of `Some(false)` means that the clause for the impl will
+    /// not be added, and fallback logic will not be checked. A value of `None`
+    /// means that the clause will not be added, but fallback logic may add logic.
     #[allow(unused_variables)]
-    fn force_impl_for(&self, well_known: WellKnownTrait, ty: &TyData<I>) -> bool {
-        false
+    fn force_impl_for(&self, well_known: WellKnownTrait, ty: &TyData<I>) -> Option<bool> {
+        None
     }
 
     /// Returns id of a trait lang item, if found

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -62,7 +62,7 @@ impl<'i, I: Interner> InputTypeCollector<'i, I> {
     }
 }
 
-impl<'i, 't, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
+impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
     type Result = ();
 
     fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, Result = Self::Result> {


### PR DESCRIPTION
This builtin logic is currently not completely ready, since we don't have knowledge of non-struct application types.

The example I'm running into with rustc integration currently is str: !Sized.

Also includes a removal of an unused lifetime.