### PR TITLE
Stop leaking truncated goal

### DIFF
--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -348,9 +348,7 @@ impl<I: Interner> TruncatingInferenceTable<I> {
 
 impl<I: Interner> context::TruncateOps<SlgContext<I>> for TruncatingInferenceTable<I> {
     fn goal_needs_truncation(&mut self, interner: &I, subgoal: &InEnvironment<Goal<I>>) -> bool {
-        // We only want to check the goal itself. We keep the environment intact.
-        // See rust-lang/chalk#280
-        truncate::needs_truncation(interner, &mut self.infer, self.max_size, &subgoal.goal)
+        truncate::needs_truncation(interner, &mut self.infer, self.max_size, &subgoal)
     }
 
     fn answer_needs_truncation(&mut self, interner: &I, subst: &Substitution<I>) -> bool {

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -712,7 +712,7 @@ fn rust_analyzer_regression() {
                     PI: ParallelIterator
                 }
             }
-        } yields_all[SolverChoice::slg(4, None)] {
+        } yields_all[SolverChoice::slg(5, None)] {
             "substitution [], lifetime constraints []"
         }
     }

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -712,8 +712,8 @@ fn rust_analyzer_regression() {
                     PI: ParallelIterator
                 }
             }
-        } yields_all[SolverChoice::slg(5, None)] {
-            "substitution [], lifetime constraints []"
+        } yields_first[SolverChoice::slg(4, None)] {
+            "Floundered"
         }
     }
 }


### PR DESCRIPTION
Closes #306 

As noted in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/Contribution.20to.20chalk/near/193511696), it makes sense to return `Floundered` if we were to truncate and avoid leaking the truncated result. If the approach seems fine, I will make sure to change the comments where needed.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>