### PR TITLE
Improve opaque type debug output

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -446,6 +446,7 @@ impl LowerProgram for Program {
             associated_ty_values,
             associated_ty_data,
             opaque_ty_ids,
+            opaque_ty_kinds,
             opaque_ty_data,
             custom_clauses,
         };

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -46,6 +46,9 @@ pub struct Program {
     pub opaque_ty_ids: BTreeMap<Identifier, OpaqueTyId<ChalkIr>>,
 
     /// For each opaque type:
+    pub opaque_ty_kinds: BTreeMap<OpaqueTyId<ChalkIr>, TypeKind>,
+
+    /// For each opaque type:
     pub opaque_ty_data: BTreeMap<OpaqueTyId<ChalkIr>, Arc<OpaqueTyDatum<ChalkIr>>>,
 
     /// For each trait:
@@ -120,8 +123,8 @@ impl tls::DebugContext for Program {
         opaque_ty_id: OpaqueTyId<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error> {
-        if let Some(d) = self.opaque_ty_data.get(&opaque_ty_id) {
-            write!(fmt, "{:?}", d.bound.skip_binders().hidden_ty)
+        if let Some(k) = self.opaque_ty_kinds.get(&opaque_ty_id) {
+            write!(fmt, "{}", k.name)
         } else {
             fmt.debug_struct("InvalidItemId")
                 .field("index", &opaque_ty_id.0)
@@ -162,7 +165,7 @@ impl tls::DebugContext for Program {
         opaque_ty: &OpaqueTy<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error> {
-        write!(fmt, "impl {:?}", opaque_ty.opaque_ty_id)
+        write!(fmt, "{:?}", opaque_ty.opaque_ty_id)
     }
 
     fn debug_ty(&self, ty: &Ty<ChalkIr>, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -141,7 +141,7 @@ impl<I: Interner> Debug for TypeName<I> {
         match self {
             TypeName::Struct(id) => write!(fmt, "{:?}", id),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
-            TypeName::OpaqueType(opaque_ty) => write!(fmt, "{:?}", opaque_ty),
+            TypeName::OpaqueType(opaque_ty) => write!(fmt, "!{:?}", opaque_ty),
             TypeName::Error => write!(fmt, "{{error}}"),
         }
     }


### PR DESCRIPTION
Properly show things like `AliasEq(T = !T)` and `AliasEq(T = Ty) :- Reveal` in debug output, instead of `AliasEq(impl Ty = Ty)` and `AliasEq(impl Ty = Ty) :- Reveal`