### PR TITLE
[WIP] Opaque type generics

### DIFF
--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -337,7 +337,10 @@ fn program_clauses_that_could_match<I: Interner>(
                     trait_parameters,
                 );
             }
-            AliasTy::Opaque(_) => (),
+            AliasTy::Opaque(opaque_ty) => {
+                db.opaque_ty_data(opaque_ty.opaque_ty_id)
+                    .to_program_clauses(builder);
+            }
         },
         DomainGoal::LocalImplAllowed(trait_ref) => db
             .trait_datum(trait_ref.trait_id)

--- a/tests/test/existential_types.rs
+++ b/tests/test/existential_types.rs
@@ -3,52 +3,6 @@
 use super::*;
 
 #[test]
-fn opaque_bounds() {
-    test! {
-        program {
-            struct Ty { }
-
-            trait Clone { }
-            opaque type T: Clone = Ty;
-        }
-
-        goal {
-            T: Clone
-        } yields {
-            "Unique; substitution []"
-        }
-    }
-}
-
-#[test]
-fn opaque_reveal() {
-    test! {
-        program {
-            struct Ty { }
-            trait Trait { }
-            impl Trait for Ty { }
-
-            trait Clone { }
-            opaque type T: Clone = Ty;
-        }
-
-        goal {
-            if (Reveal) {
-                T: Trait
-            }
-        } yields {
-            "Unique; substitution []"
-        }
-
-        goal {
-            T: Trait
-        } yields {
-            "No possible solution"
-        }
-    }
-}
-
-#[test]
 fn dyn_Clone_is_Clone() {
     test! {
         program {

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -313,6 +313,7 @@ mod implied_bounds;
 mod impls;
 mod misc;
 mod negation;
+mod opaque_types;
 mod projection;
 mod unify;
 mod wf_goals;

--- a/tests/test/opaque_types.rs
+++ b/tests/test/opaque_types.rs
@@ -1,0 +1,49 @@
+//! Tests related to opaque types
+
+use super::*;
+
+#[test]
+fn opaque_bounds() {
+    test! {
+        program {
+            struct Ty { }
+
+            trait Clone { }
+            opaque type T: Clone = Ty;
+        }
+
+        goal {
+            T: Clone
+        } yields {
+            "Unique; substitution []"
+        }
+    }
+}
+
+#[test]
+fn opaque_reveal() {
+    test! {
+        program {
+            struct Ty { }
+            trait Trait { }
+            impl Trait for Ty { }
+
+            trait Clone { }
+            opaque type T: Clone = Ty;
+        }
+
+        goal {
+            if (Reveal) {
+                T: Trait
+            }
+        } yields {
+            "Unique; substitution []"
+        }
+
+        goal {
+            T: Trait
+        } yields {
+            "No possible solution"
+        }
+    }
+}

--- a/tests/test/opaque_types.rs
+++ b/tests/test/opaque_types.rs
@@ -47,3 +47,36 @@ fn opaque_reveal() {
         }
     }
 }
+
+#[test]
+fn opaque_generics() {
+    test! {
+        program {
+            trait Iterator { type Item; }
+
+            struct Vec<T> { }
+            struct u32 { }
+            impl<T> Iterator for Vec<T> {
+                type Item = T;
+            }
+
+            opaque type Foo<X>: Iterator<Item = X> = Vec<X>;
+        }
+
+        goal {
+            Foo<u32>: Iterator<Item = u32>
+        } yields {
+            "Unique; substitution []"
+        }
+
+        goal {
+            forall<T> {
+                if (T: Iterator) {
+                    Foo<T>: Iterator<Item = T>
+                }
+            }
+        } yields {
+            "Unique; substitution []"
+        }
+    }
+}


### PR DESCRIPTION
Opaque types should accept generic parameters, probably something like this:
```
program {
    trait Iterator { type Item; }

    struct Vec<T> { }
    struct u32 { }
    impl<T> Iterator for Vec<T> {
        type Item = T;
    }

    opaque type Foo<X>: Iterator<Item = X> = Vec<X>;
}

goal {
    Foo<u32>: Iterator<Item = u32>
} yields {
    "Unique; substitution []"
}
```