### PR TITLE
Make it possible to cache the result of env elaboration

### DIFF
--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -8,6 +8,7 @@ use chalk_ir::tls;
 use chalk_ir::AssocTypeId;
 use chalk_ir::Canonical;
 use chalk_ir::ConstrainedSubst;
+use chalk_ir::Environment;
 use chalk_ir::Goal;
 use chalk_ir::ImplId;
 use chalk_ir::InEnvironment;
@@ -17,7 +18,7 @@ use chalk_ir::ProgramClause;
 use chalk_ir::StructId;
 use chalk_ir::TraitId;
 use chalk_ir::TypeName;
-use chalk_ir::UCanonical;
+use chalk_ir::{ProgramClauses, UCanonical};
 use chalk_rust_ir::AssociatedTyDatum;
 use chalk_rust_ir::AssociatedTyValue;
 use chalk_rust_ir::AssociatedTyValueId;
@@ -148,6 +149,13 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         self.program_ir()
             .unwrap()
             .well_known_trait_id(well_known_trait)
+    }
+
+    fn program_clauses_for_env(
+        &self,
+        environment: &Environment<ChalkIr>,
+    ) -> ProgramClauses<ChalkIr> {
+        chalk_solve::program_clauses_for_env(self, environment)
     }
 
     fn interner(&self) -> &ChalkIr {

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -390,6 +390,13 @@ impl RustIrDatabase<ChalkIr> for Program {
         self.well_known_traits.get(&well_known_trait).map(|x| *x)
     }
 
+    fn program_clauses_for_env(
+        &self,
+        environment: &chalk_ir::Environment<ChalkIr>,
+    ) -> ProgramClauses<ChalkIr> {
+        chalk_solve::program_clauses_for_env(self, environment)
+    }
+
     fn interner(&self) -> &ChalkIr {
         &ChalkIr
     }

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -124,6 +124,7 @@ pub(crate) fn program_clauses_for_goal<'db, I: Interner>(
     );
     let interner = db.interner();
 
+    // FIXME: change this to use `.chain().filter()`
     let mut vec = vec![];
     vec.extend(db.custom_clauses());
     program_clauses_that_could_match(db, environment, goal, &mut vec)?;

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -87,8 +87,14 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// Returns id of a trait lang item, if found
     fn well_known_trait_id(&self, well_known_trait: WellKnownTrait) -> Option<TraitId<I>>;
 
+    /// Calculates program clauses from an env. This is intended to call the
+    /// `program_clauses_for_env` function and then possibly cache the clauses.
+    fn program_clauses_for_env(&self, environment: &Environment<I>) -> ProgramClauses<I>;
+
     fn interner(&self) -> &I;
 }
+
+pub use clauses::program_clauses_for_env;
 
 pub use solve::Guidance;
 pub use solve::Solution;


### PR DESCRIPTION
`program_clauses_for_env` can take a huge amount of time -- rust-analyzer is unusably slow on the Chalk codebase itself, spending most of that time in env elaboration because one `I: Interner` results in ~300 clauses, which gets repeated tens of times per query.

This adds a method to `RustIrDatabase` that should basically just be a pass-through for `program_clauses_for_env`, but which makes it possible to cache the results in Salsa.

The effect of this is a ~20% speedup of analysis of rust-analyzer on itself, and turning analysis of the Chalk codebase from seemingly forever to ~1 minute.