### PR TITLE
Enabled the link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Install mdbook
         run: cd book && curl -L https://github.com/rust-lang/mdBook/releases/download/v0.3.5/mdbook-v0.3.5-x86_64-unknown-linux-gnu.tar.gz | tar xz
 
+      - name: Install mdbook-linkcheck
+        run: |
+          cd book
+          curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.5.0/mdbook-linkcheck-v0.5.0-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          # Add the book directory to the $PATH
+          echo "::add-path::$GITHUB_WORKSPACE/book"
+
       - name: Execute tests for Chalk book
         run: cd book && ./mdbook test
 

--- a/book/book.toml
+++ b/book/book.toml
@@ -3,3 +3,8 @@ authors = []
 language = "en"
 multilingual = false
 src = "src"
+
+[output.html]
+
+[output.linkcheck]
+follow-web-links = true

--- a/book/src/engine/logic/coinduction.md
+++ b/book/src/engine/logic/coinduction.md
@@ -95,13 +95,6 @@ This is true for all `A, B`
 * When all subgoals have been tested, and there are remaining delayed co-inductive subgoals, this is propogated up, marking the current `Strand` as co-inductive
 * When the co-inductive `Strand`s reach the root table, we only then pursue an answer
 
-### Failing tests
-
-* Tests were added for the tricky cases above:
-    * [First](https://github.com/rust-lang/chalk/pull/272/commits/7be2d42c6ea36dd4416774d6872c43e3988f05bd#diff-721709466568566f24fc2e8634c40dcbR140)
-    * [Second](https://github.com/rust-lang/chalk/pull/272/commits/7be2d42c6ea36dd4416774d6872c43e3988f05bd#diff-721709466568566f24fc2e8634c40dcbR171)
-* Both *are* provable to have no solutions, but are returned as ambiguous
-
 ## Niko's proposed solution
 
 ### High-level idea


### PR DESCRIPTION
The start of the book mentions that *Chalk* is still under development and asks for people to let you know if there are dead links. The [mdbook-linkcheck](https://crates.io/crates/mdbook-linkcheck) tool was created for just this purpose, so I thought you may want to enable link checking every time the book gets built.

---

After running the linkchecker over the entire book, it could only find two broken links. 

They both point to particular lines in the diff for #272 which have since disappeared (probably during a rebase) and I wasn't able to figure out which issues were being referred to. 

@jackh726 it looks like you were the original author, do you know what the links should be updated to?

```
2020-04-22 04:23:54 [INFO] (mdbook::book): Book building has started
2020-04-22 04:23:54 [INFO] (mdbook::book): Running the html backend
2020-04-22 04:23:55 [INFO] (mdbook::book): Running the linkcheck backend
2020-04-22 04:23:55 [INFO] (mdbook::renderer): Invoking the "linkcheck" renderer
error: The server responded with 404 Not Found for "https://github.com/rust-lang/chalk/pull/272/commits/7be2d42c6ea36dd4416774d6872c43e3988f05bd"

     ┌── engine/logic/coinduction.md:101:7 ───
     │
 101 │     * [First](https://github.com/rust-lang/chalk/pull/272/commits/7be2d42c6ea36dd4416774d6872c43e3988f05bd#diff-721709466568566f24fc2e8634c40dcbR140)
     │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Server responded with 404 Not Found
     │

error: The server responded with 404 Not Found for "https://github.com/rust-lang/chalk/pull/272/commits/7be2d42c6ea36dd4416774d6872c43e3988f05bd"

     ┌── engine/logic/coinduction.md:102:7 ───
     │
 102 │     * [Second](https://github.com/rust-lang/chalk/pull/272/commits/7be2d42c6ea36dd4416774d6872c43e3988f05bd#diff-721709466568566f24fc2e8634c40dcbR171)
     │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Server responded with 404 Not Found
     │

Error: ErrorMessage { msg: "One or more incorrect links" }
2020-04-22 04:23:58 [ERROR] (mdbook::renderer): Renderer exited with non-zero return code.
2020-04-22 04:23:58 [ERROR] (mdbook::utils): Error: Rendering failed
2020-04-22 04:23:58 [ERROR] (mdbook::utils): 	Caused By: The "linkcheck" renderer failed
```