### PR TITLE
Change CI mdbook output path to make the URL consistent.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           touch target/doc/.nojekyll
           curl -LsSf https://raw.githubusercontent.com/rust-lang/simpleinfra/master/setup-deploy-keys/src/deploy.rs | rustc - -o /tmp/deploy
-          cp -r book/book target/doc/book
+          cp -r book/book/html target/doc/book
           (cd target/doc && /tmp/deploy)
         env:
           GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}


### PR DESCRIPTION
In recent changes, it seems the address of Chalk book has changed from http://rust-lang.github.io/chalk/book/ to http://rust-lang.github.io/chalk/book/html . This PR reverts this.