### PR TITLE
Fix outdated dev guide links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,4 +92,4 @@ of the terminology used in chalk.
 ### Trait solving in rustc-dev-guide
 The rustc-dev-guide describes [new-style trait solving][trait-solving], which is slowly replacing the old trait resolution.
 
-[trait-solving]: https://rustc-dev-guide.rust-lang.org/traits/index.html
+[trait-solving]: https://rustc-dev-guide.rust-lang.org/traits/chalk.html

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ See the [Chalk book](https://rust-lang.github.io/chalk/book/) for more informati
 
 ## FAQ
 
-**How does chalk relate to rustc?** The plan is to have rustc use the `chalk-engine` crate (in this repo), which defines chalk's solver. The rest of chalk can then be considered an elaborate unit testing harness. For more details, see [the Traits chapter of the rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/traits/index.html).
+**How does chalk relate to rustc?** The plan is to have rustc use the `chalk-engine` crate (in this repo), which defines
+chalk's solver. The rest of chalk can then be considered an elaborate unit testing harness. For more details, see
+[this chapter of the rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/traits/chalk.html).
 
 **Where does the name come from?** `chalk` is named after [Chalkidiki], the area where [Aristotle] was
 born. Since Prolog is a logic programming language, this seemed a

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ See the [Chalk book](https://rust-lang.github.io/chalk/book/) for more informati
 
 ## FAQ
 
-**How does chalk relate to rustc?** The plan is to have rustc use the `chalk-engine` crate (in this repo), which defines
-chalk's solver. The rest of chalk can then be considered an elaborate unit testing harness. For more details, see
-[this chapter of the rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/traits/chalk.html).
+**How does chalk relate to rustc?** The plan is to have rustc use the
+`chalk-solve` crate (in this repo) to answer questions about Rust programs, for
+example, "Does `Vec<u32>` implement `Debug`?". Internally, chalk converts
+Rust-specific information into logic and uses a logic engine to find the answer
+to the original query. For more details, see
+[this explanation in the chalk book][chalk-lowering-details].
 
 **Where does the name come from?** `chalk` is named after [Chalkidiki], the area where [Aristotle] was
 born. Since Prolog is a logic programming language, this seemed a
@@ -22,6 +25,7 @@ suitable reference.
 [Prolog]: https://en.wikipedia.org/wiki/Prolog
 [Chalkidiki]: https://en.wikipedia.org/wiki/Chalkidiki
 [Aristotle]: https://en.wikipedia.org/wiki/Aristotle
+[chalk-lowering-details]: http://rust-lang.github.io/chalk/book/#chalk-works-by-converting-rust-goals-into-logical-inference-rules
 
 ## Blog posts
 [blog-posts]: #blog-posts

--- a/book/src/what_is_chalk.md
+++ b/book/src/what_is_chalk.md
@@ -2,7 +2,7 @@
 
 > Chalk is under heavy development, so if any of these links are broken or if
 > any of the information is inconsistent with the code or outdated, please
-> [open an issue][rustc-issues] so we can fix it. If you are able to fix the
+> [open an issue][issues] so we can fix it. If you are able to fix the
 > issue yourself, we would love your contribution!
 
 Chalk is a library that implements the Rust trait system. The implementation is
@@ -11,7 +11,7 @@ full specification. It is also meant to be an independent library that can be
 integrated both into the main rustc compiler and also other programs and
 contexts.
 
-[rustc-issues]: https://github.com/rust-lang/rustc-dev-guide/issues
+[issues]: https://github.com/rust-lang/chalk/issues
 
 ## High-level view of how chalk works
 

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -44,9 +44,9 @@ pub trait Context: Clone + Debug {
 
     /// A canonicalized `GoalInEnvironment` -- that is, one where all
     /// free inference variables have been bound into the canonical
-    /// binder. See [the rustc-dev-guide] for more information.
+    /// binder. See [the chalk book] for more information.
     ///
-    /// [the rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/traits/canonicalization.html
+    /// [the chalk book]: https://rust-lang.github.io/chalk/book/canonical_queries/canonicalization.html
     type CanonicalGoalInEnvironment: Debug;
 
     /// A u-canonicalized `GoalInEnvironment` -- this is one where the

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -1,8 +1,8 @@
 //! An alternative solver based around the SLG algorithm, which
 //! implements the well-formed semantics. For an overview of how the solver
-//! works, see [The On-Demand SLG Solver][guide] in the rustc-dev-guide.
+//! works, see [The On-Demand SLG Solver][guide] in the chalk book.
 //!
-//! [guide]: https://rustc-dev-guide.rust-lang.org/traits/slg.html
+//! [guide]: https://rust-lang.github.io/chalk/book/engine/slg.html
 //!
 //! This algorithm is very closed based on the description found in the
 //! following paper, which I will refer to in the comments as EWFS:


### PR DESCRIPTION
Fixes the "open an issue" link in the book to go to this repository, and fixes some out of date (broken) links to the rustc dev guide.