### PR TITLE
Make lowering failure tests less fragile

### DIFF
--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -471,7 +471,7 @@ fn scalars() {
         }
 
         error_msg {
-            "parse error: UnrecognizedToken { token: (8, Token(53, \"i32\"), 11), expected: [\"r#\\\"([A-Za-z]|_)([A-Za-z0-9]|_)*\\\"#\"] }"
+            "parse error: UnrecognizedToken"
         }
     }
 }
@@ -495,7 +495,7 @@ fn raw_pointers() {
             struct *const i32 { }
         }
         error_msg {
-            "parse error: UnrecognizedToken { token: (8, Token(8, \"*\"), 9), expected: [\"r#\\\"([A-Za-z]|_)([A-Za-z0-9]|_)*\\\"#\"] }"
+            "parse error: UnrecognizedToken"
         }
     }
 
@@ -505,7 +505,7 @@ fn raw_pointers() {
             impl Foo for *i32 { }
         }
         error_msg {
-            "parse error: UnrecognizedToken { token: (30, Token(53, \"i32\"), 33), expected: [\"\\\"const\\\"\", \"\\\"mut\\\"\"] }"
+            "parse error: UnrecognizedToken"
         }
     }
 }
@@ -529,7 +529,7 @@ fn refs() {
         }
 
         error_msg {
-            "parse error: UnrecognizedToken { token: (36, Token(1, \"T\"), 37), expected: [\"r#\\\"\\\\\\\'([A-Za-z]|_)([A-Za-z0-9]|_)*\\\"#\"] }"
+            "parse error: UnrecognizedToken"
         }
     }
 }
@@ -555,7 +555,7 @@ fn slices() {
         }
 
         error_msg {
-            "parse error: UnrecognizedToken { token: (29, Token(31, \"]\"), 30), expected: [\"\\\"&\\\"\", \"\\\"(\\\"\", \"\\\"*\\\"\", \"\\\"<\\\"\", \"\\\"[\\\"\", \"\\\"bool\\\"\", \"\\\"char\\\"\", \"\\\"dyn\\\"\", \"\\\"f32\\\"\", \"\\\"f64\\\"\", \"\\\"fn\\\"\", \"\\\"for\\\"\", \"\\\"i128\\\"\", \"\\\"i16\\\"\", \"\\\"i32\\\"\", \"\\\"i64\\\"\", \"\\\"i8\\\"\", \"\\\"isize\\\"\", \"\\\"str\\\"\", \"\\\"u128\\\"\", \"\\\"u16\\\"\", \"\\\"u32\\\"\", \"\\\"u64\\\"\", \"\\\"u8\\\"\", \"\\\"usize\\\"\", \"r#\\\"([A-Za-z]|_)([A-Za-z0-9]|_)*\\\"#\"] }"
+            "parse error: UnrecognizedToken"
         }
     }
 }

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -8,6 +8,8 @@ use chalk_solve::ext::*;
 use chalk_solve::RustIrDatabase;
 use chalk_solve::{Solution, SolverChoice};
 
+use crate::test_util::assert_same;
+
 #[cfg(feature = "bench")]
 mod bench;
 mod coherence;
@@ -30,15 +32,6 @@ fn assert_result(mut result: Option<Solution<ChalkIr>>, expected: &str) {
     };
 
     assert_same(&result, expected);
-}
-
-fn assert_same(result: &str, expected: &str) {
-    println!("expected:\n{}", expected);
-    println!("actual:\n{}", result);
-
-    let expected1: String = expected.chars().filter(|w| !w.is_whitespace()).collect();
-    let result1: String = result.chars().filter(|w| !w.is_whitespace()).collect();
-    assert!(!expected1.is_empty() && result1.starts_with(&expected1));
 }
 
 // different goals

--- a/tests/test_util.rs
+++ b/tests/test_util.rs
@@ -27,8 +27,18 @@ macro_rules! lowering_error {
             chalk_solve::SolverChoice::default(),
         )
         .checked_program()
-        .unwrap_err();
-        let expected = $expected;
-        assert_eq!(error.to_string(), expected.to_string());
+        .unwrap_err()
+        .to_string();
+        let expected = $expected.to_string();
+        crate::test_util::assert_same(&error, &expected);
     };
+}
+
+pub fn assert_same(result: &str, expected: &str) {
+    println!("expected:\n{}", expected);
+    println!("actual:\n{}", result);
+
+    let expected1: String = expected.chars().filter(|w| !w.is_whitespace()).collect();
+    let result1: String = result.chars().filter(|w| !w.is_whitespace()).collect();
+    assert!(!expected1.is_empty() && result1.starts_with(&expected1));
 }


### PR DESCRIPTION
The current lowering failure tests check that the error message resulting from the lowering attempt matches a given string exactly. This is fine in most cases, but tests which expect parsing errors are incredibly fragile in that the contents of their error messages change whenever the lexer or parser is modified.

This PR makes a small change so that lowering failure tests which produce a parsing error only have to provide the expected error kind (such as "UnrecognizedToken", etc.) instead of a full error message, which makes the tests less fragile to parser/lexer changes.

It's not exactly a beautiful fix, but it at least alleviates the immediate annoyance of tests frequently breaking.