### PR TITLE
Add `FnDef` to `TypeName`

### DIFF
--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -10,6 +10,7 @@ use chalk_ir::AssocTypeId;
 use chalk_ir::Canonical;
 use chalk_ir::ConstrainedSubst;
 use chalk_ir::Environment;
+use chalk_ir::FnDefId;
 use chalk_ir::GenericArg;
 use chalk_ir::Goal;
 use chalk_ir::ImplId;
@@ -22,6 +23,7 @@ use chalk_rust_ir::AdtDatum;
 use chalk_rust_ir::AssociatedTyDatum;
 use chalk_rust_ir::AssociatedTyValue;
 use chalk_rust_ir::AssociatedTyValueId;
+use chalk_rust_ir::FnDefDatum;
 use chalk_rust_ir::ImplDatum;
 use chalk_rust_ir::OpaqueTyDatum;
 use chalk_rust_ir::TraitDatum;
@@ -112,6 +114,10 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
 
     fn adt_datum(&self, id: AdtId<ChalkIr>) -> Arc<AdtDatum<ChalkIr>> {
         self.program_ir().unwrap().adt_datum(id)
+    }
+
+    fn fn_def_datum(&self, id: FnDefId<ChalkIr>) -> Arc<FnDefDatum<ChalkIr>> {
+        self.program_ir().unwrap().fn_def_datum(id)
     }
 
     fn impls_for_trait(

--- a/chalk-integration/src/lib.rs
+++ b/chalk-integration/src/lib.rs
@@ -22,6 +22,7 @@ pub use interner::{Identifier, RawId};
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TypeSort {
     Struct,
+    FnDef,
     Trait,
     Opaque,
 }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -940,12 +940,9 @@ impl LowerFnDefn for FnDefn {
             })
         })?;
 
-        let flags = rust_ir::FnDefFlags {};
-
         Ok(rust_ir::FnDefDatum {
             id: fn_def_id,
             binders,
-            flags,
         })
     }
 }

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -3,13 +3,13 @@ use crate::{tls, Identifier, TypeKind};
 use chalk_ir::could_match::CouldMatch;
 use chalk_ir::debug::Angle;
 use chalk_ir::{
-    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, GenericArg, Goal, Goals,
-    ImplId, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication,
+    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, FnDefId, GenericArg,
+    Goal, Goals, ImplId, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication,
     ProgramClauses, ProjectionTy, Substitution, TraitId, Ty,
 };
 use chalk_rust_ir::{
-    AdtDatum, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ImplDatum, ImplType,
-    OpaqueTyDatum, TraitDatum, WellKnownTrait,
+    AdtDatum, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, FnDefDatum, ImplDatum,
+    ImplType, OpaqueTyDatum, TraitDatum, WellKnownTrait,
 };
 use chalk_solve::split::Split;
 use chalk_solve::RustIrDatabase;
@@ -25,6 +25,10 @@ pub struct Program {
     /// For each ADT:
     pub adt_kinds: BTreeMap<AdtId<ChalkIr>, TypeKind>,
 
+    pub fn_def_ids: BTreeMap<Identifier, FnDefId<ChalkIr>>,
+
+    pub fn_def_kinds: BTreeMap<FnDefId<ChalkIr>, TypeKind>,
+
     /// From trait name to item-id. Used during lowering only.
     pub trait_ids: BTreeMap<Identifier, TraitId<ChalkIr>>,
 
@@ -33,6 +37,8 @@ pub struct Program {
 
     /// For each ADT:
     pub adt_data: BTreeMap<AdtId<ChalkIr>, Arc<AdtDatum<ChalkIr>>>,
+
+    pub fn_def_data: BTreeMap<FnDefId<ChalkIr>, Arc<FnDefDatum<ChalkIr>>>,
 
     /// For each impl:
     pub impl_data: BTreeMap<ImplId<ChalkIr>, Arc<ImplDatum<ChalkIr>>>,
@@ -332,6 +338,10 @@ impl RustIrDatabase<ChalkIr> for Program {
 
     fn adt_datum(&self, id: AdtId<ChalkIr>) -> Arc<AdtDatum<ChalkIr>> {
         self.adt_data[&id].clone()
+    }
+
+    fn fn_def_datum(&self, id: FnDefId<ChalkIr>) -> Arc<FnDefDatum<ChalkIr>> {
+        self.fn_def_data[&id].clone()
     }
 
     fn impls_for_trait(

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -303,6 +303,15 @@ where
     }
 }
 
+impl<I> CastTo<TypeName<I>> for FnDefId<I>
+where
+    I: Interner,
+{
+    fn cast_to(self, _interner: &I) -> TypeName<I> {
+        TypeName::FnDef(self)
+    }
+}
+
 impl<T> CastTo<T> for &T
 where
     T: Clone + HasInterner,

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -21,6 +21,12 @@ impl<I: Interner> Debug for AssocTypeId<I> {
     }
 }
 
+impl<I: Interner> Debug for FnDefId<I> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        I::debug_fn_def_id(*self, fmt).unwrap_or_else(|| write!(fmt, "FnDefId({:?})", self.0))
+    }
+}
+
 impl<I: Interner> Debug for Ty<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         I::debug_ty(self, fmt).unwrap_or_else(|| write!(fmt, "{:?}", self.interned))
@@ -146,6 +152,7 @@ impl<I: Interner> Debug for TypeName<I> {
             TypeName::Tuple(arity) => write!(fmt, "{:?}", arity),
             TypeName::OpaqueType(opaque_ty) => write!(fmt, "!{:?}", opaque_ty),
             TypeName::Slice => write!(fmt, "{{slice}}"),
+            TypeName::FnDef(fn_def) => write!(fmt, "{:?}", fn_def),
             TypeName::Raw(mutability) => write!(fmt, "{:?}", mutability),
             TypeName::Ref(mutability) => write!(fmt, "{:?}", mutability),
             TypeName::Error => write!(fmt, "{{error}}"),

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -281,6 +281,7 @@ id_fold!(AdtId, transfer_adt_id);
 id_fold!(TraitId);
 id_fold!(AssocTypeId);
 id_fold!(OpaqueTyId);
+id_fold!(FnDefId);
 
 impl<I: Interner, TI: TargetInterner<I>> SuperFold<I, TI> for ProgramClauseData<I> {
     fn super_fold_with<'i>(

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -4,6 +4,7 @@ use crate::ApplicationTy;
 use crate::AssocTypeId;
 use crate::CanonicalVarKind;
 use crate::CanonicalVarKinds;
+use crate::FnDefId;
 use crate::GenericArg;
 use crate::GenericArgData;
 use crate::Goal;
@@ -201,6 +202,14 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     #[allow(unused_variables)]
     fn debug_opaque_ty_id(
         opaque_ty_id: OpaqueTyId<Self>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> Option<fmt::Result> {
+        None
+    }
+
+    #[allow(unused_variables)]
+    fn debug_fn_def_id(
+        fn_def_id: FnDefId<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
         None

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -169,6 +169,9 @@ pub enum TypeName<I: Interner> {
     /// a placeholder for opaque types like `impl Trait`
     OpaqueType(OpaqueTyId<I>),
 
+    /// a function definition
+    FnDef(FnDefId<I>),
+
     /// the string primitive type
     Str,
 
@@ -236,6 +239,9 @@ pub struct AssocTypeId<I: Interner>(pub I::DefId);
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpaqueTyId<I: Interner>(pub I::DefId);
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FnDefId<I: Interner>(pub I::DefId);
 
 impl_debugs!(ImplId, ClauseId);
 

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -5,8 +5,8 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::{
-    AdtId, AssocTypeId, ClausePriority, DebruijnIndex, FloatTy, GenericArg, Goals, ImplId, IntTy,
-    Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauseData,
+    AdtId, AssocTypeId, ClausePriority, DebruijnIndex, FloatTy, FnDefId, GenericArg, Goals, ImplId,
+    IntTy, Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauseData,
     ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution, SuperVisit,
     TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
 };
@@ -236,6 +236,7 @@ id_visit!(AdtId);
 id_visit!(TraitId);
 id_visit!(OpaqueTyId);
 id_visit!(AssocTypeId);
+id_visit!(FnDefId);
 
 impl<I: Interner> SuperVisit<I> for ProgramClause<I> {
     fn super_visit_with<'i, R: VisitResult>(

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -50,11 +50,7 @@ pub struct FnDefn {
     pub where_clauses: Vec<QuantifiedWhereClause>,
     pub argument_types: Vec<Ty>,
     pub return_type: Ty,
-    pub flags: FnDefFlags,
 }
-
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct FnDefFlags {}
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TraitDefn {

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -21,6 +21,7 @@ pub struct Program {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Item {
     StructDefn(StructDefn),
+    FnDefn(FnDefn),
     TraitDefn(TraitDefn),
     OpaqueTyDefn(OpaqueTyDefn),
     Impl(Impl),
@@ -41,6 +42,19 @@ pub struct StructFlags {
     pub upstream: bool,
     pub fundamental: bool,
 }
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FnDefn {
+    pub name: Identifier,
+    pub variable_kinds: Vec<VariableKind>,
+    pub where_clauses: Vec<QuantifiedWhereClause>,
+    pub argument_types: Vec<Ty>,
+    pub return_type: Ty,
+    pub flags: FnDefFlags,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FnDefFlags {}
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TraitDefn {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -14,6 +14,7 @@ Items: Vec<Item> = {
 Item: Option<Item> = {
     Comment => None,
     StructDefn => Some(Item::StructDefn(<>)),
+    FnDefn => Some(Item::FnDefn(<>)),
     TraitDefn => Some(Item::TraitDefn(<>)),
     OpaqueTyDefn => Some(Item::OpaqueTyDefn(<>)),
     Impl => Some(Item::Impl(<>)),
@@ -65,6 +66,32 @@ StructDefn: StructDefn = {
             fundamental: fundamental.is_some(),
         },
     }
+};
+
+FnReturn: Ty = {
+    "->" <ty:Ty> => ty,
+};
+
+FnDefn: FnDefn = {
+    "fn" <n:Id> <p:Angle<VariableKind>>"(" <args:FnArgs> ")" 
+        <ret_ty:FnReturn?> <w:QuantifiedWhereClauses> ";" => FnDefn
+    {
+        name: n,
+        variable_kinds: p,
+        where_clauses: w,
+        argument_types: args,
+        return_type: ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() }),
+        flags: FnDefFlags {
+        },
+    }
+};
+
+FnArg: Ty = {
+    Id ":" <arg_ty: Ty> => arg_ty
+};
+
+FnArgs: Vec<Ty> = {
+    <Comma<FnArg>>
 };
 
 TraitDefn: TraitDefn = {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -81,8 +81,6 @@ FnDefn: FnDefn = {
         where_clauses: w,
         argument_types: args,
         return_type: ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() }),
-        flags: FnDefFlags {
-        },
     }
 };
 

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -107,7 +107,6 @@ pub struct AdtFlags {
 pub struct FnDefDatum<I: Interner> {
     pub id: FnDefId<I>,
     pub binders: Binders<FnDefDatumBound<I>>,
-    pub flags: FnDefFlags,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
@@ -116,9 +115,6 @@ pub struct FnDefDatumBound<I: Interner> {
     pub return_type: Ty<I>,
     pub where_clauses: Vec<QuantifiedWhereClause<I>>,
 }
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct FnDefFlags {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 /// A rust intermediate representation (rust_ir) of a Trait Definition. For

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -9,9 +9,9 @@ use chalk_ir::cast::Cast;
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::interner::{Interner, TargetInterner};
 use chalk_ir::{
-    AdtId, AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, GenericArg, ImplId, OpaqueTyId,
-    ProjectionTy, QuantifiedWhereClause, Substitution, ToGenericArg, TraitId, TraitRef, Ty, TyData,
-    TypeName, VariableKind, WhereClause, WithKind,
+    AdtId, AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, FnDefId, GenericArg, ImplId,
+    OpaqueTyId, ProjectionTy, QuantifiedWhereClause, Substitution, ToGenericArg, TraitId, TraitRef,
+    Ty, TyData, TypeName, VariableKind, WhereClause, WithKind,
 };
 use std::iter;
 
@@ -102,6 +102,23 @@ pub struct AdtFlags {
     pub upstream: bool,
     pub fundamental: bool,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct FnDefDatum<I: Interner> {
+    pub id: FnDefId<I>,
+    pub binders: Binders<FnDefDatumBound<I>>,
+    pub flags: FnDefFlags,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+pub struct FnDefDatumBound<I: Interner> {
+    pub argument_types: Vec<Ty<I>>,
+    pub return_type: Ty<I>,
+    pub where_clauses: Vec<QuantifiedWhereClause<I>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct FnDefFlags {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 /// A rust intermediate representation (rust_ir) of a Trait Definition. For

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -104,15 +104,45 @@ pub struct AdtFlags {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// A rust intermediate represention (rust_ir) of a function definition/declaration.
+/// For example, in the following rust code:
+///
+/// ```ignore
+/// fn foo<T>() -> i32 where T: Eq;
+/// ```
+///
+/// This would represent the declaration of `foo`.
+///
+/// Note this is distinct from a function pointer, which points to
+/// a function with a given type signature, whereas this represents
+/// a specific function definition.
 pub struct FnDefDatum<I: Interner> {
     pub id: FnDefId<I>,
     pub binders: Binders<FnDefDatumBound<I>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+/// Represents the bounds on a `FnDefDatum`, including
+/// the function definition's type signature and where clauses.
 pub struct FnDefDatumBound<I: Interner> {
+    /// Types of the function's arguments
+    /// ```ignore
+    /// fn foo<T>(bar: i32, baz: T);
+    ///                ^^^       ^
+    /// ```
+    ///
     pub argument_types: Vec<Ty<I>>,
+    /// Return type of the function
+    /// ```ignore
+    /// fn foo<T>() -> i32;
+    ///                ^^^
+    /// ```
     pub return_type: Ty<I>,
+    /// Where clauses defined on the function
+    /// ```ignore
+    /// fn foo<T>() where T: Eq;
+    ///             ^^^^^^^^^^^
+    /// ```
     pub where_clauses: Vec<QuantifiedWhereClause<I>>,
 }
 

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -412,6 +412,10 @@ fn match_type_name<I: Interner>(
         TypeName::Slice => builder.push_fact(WellFormed::Ty(application.clone().intern(interner))),
         TypeName::Raw(_) => builder.push_fact(WellFormed::Ty(application.clone().intern(interner))),
         TypeName::Ref(_) => builder.push_fact(WellFormed::Ty(application.clone().intern(interner))),
+        TypeName::FnDef(fn_def_id) => builder
+            .db
+            .fn_def_datum(fn_def_id)
+            .to_program_clauses(builder),
     }
 }
 

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -38,6 +38,8 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// Returns the datum for the impl with the given id.
     fn adt_datum(&self, adt_id: AdtId<I>) -> Arc<AdtDatum<I>>;
 
+    fn fn_def_datum(&self, fn_def_id: FnDefId<I>) -> Arc<FnDefDatum<I>>;
+
     /// Returns the datum for the impl with the given id.
     fn impl_datum(&self, impl_id: ImplId<I>) -> Arc<ImplDatum<I>>;
 

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -559,3 +559,28 @@ fn slices() {
         }
     }
 }
+
+#[test]
+fn fn_defs() {
+    lowering_success! {
+        program {
+            trait Quux { }
+
+            fn foo<'a, T>(bar: T, baz: &'a mut T) -> u32
+                where T: Quux;
+        }
+    }
+
+    lowering_error! {
+        program {
+            trait Quux { }
+
+            fn foo<T>(bar: TT) -> T
+                where T: Quux;
+        }
+
+        error_msg {
+            "invalid type name `TT`"
+        }
+    }
+}

--- a/tests/test/functions.rs
+++ b/tests/test/functions.rs
@@ -23,3 +23,42 @@ fn functions_are_sized() {
         }
     }
 }
+
+#[test]
+fn fn_defs() {
+    test! {
+        program {
+            trait Foo { }
+
+            struct Bar { }
+
+            struct Xyzzy { }
+            impl Foo for Xyzzy { }
+
+            fn baz<T>(quux: T) -> T
+                where T: Foo;
+
+            fn garply(thud: i32) -> i32;
+        }
+
+        goal {
+            WellFormed(baz<Bar>)
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            WellFormed(baz<Xyzzy>)
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            WellFormed(garply)
+        } yields {
+            "Unique"
+        }
+
+
+    }
+}

--- a/tests/test/functions.rs
+++ b/tests/test/functions.rs
@@ -59,6 +59,26 @@ fn fn_defs() {
             "Unique"
         }
 
+    }
+}
 
+#[test]
+fn fn_def_implied_bounds_from_env() {
+    test! {
+        program {
+            trait Foo { }
+
+            struct Bar { }
+            impl Foo for Bar { }
+
+            fn baz<T>() where T: Foo;
+        }
+        goal {
+            if (FromEnv(baz<Bar>)) {
+                Bar: Foo
+            }
+        } yields {
+            "Unique"
+        }
     }
 }


### PR DESCRIPTION
Addresses the `FnDef` part of #368.

Lowering and program clause generation are probably the areas that need the most review. I'm also a bit unsure about if/how the builtin traits apply to `FnDef`, so some guidance on that would be helpful. For parsing I've chosen to only handle function declarations for simplicity's sake (plus I'm not sure why we would need to inspect the function bodies).

In its current state the PR could use some refactoring/polish, but I'll defer that until the more substantive aspects of the PR are in good shape.