### PR TITLE
Rename struct types to ADT types and introduce new interned ADT ID

### DIFF
--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -5,6 +5,7 @@ use crate::program::Program;
 use crate::query::{Lowering, LoweringDatabase};
 use crate::tls;
 use chalk_engine::forest::SubstitutionResult;
+use chalk_ir::AdtId;
 use chalk_ir::AssocTypeId;
 use chalk_ir::Canonical;
 use chalk_ir::ConstrainedSubst;
@@ -15,15 +16,14 @@ use chalk_ir::ImplId;
 use chalk_ir::InEnvironment;
 use chalk_ir::OpaqueTyId;
 use chalk_ir::ProgramClause;
-use chalk_ir::StructId;
 use chalk_ir::TraitId;
 use chalk_ir::{ProgramClauses, UCanonical};
+use chalk_rust_ir::AdtDatum;
 use chalk_rust_ir::AssociatedTyDatum;
 use chalk_rust_ir::AssociatedTyValue;
 use chalk_rust_ir::AssociatedTyValueId;
 use chalk_rust_ir::ImplDatum;
 use chalk_rust_ir::OpaqueTyDatum;
-use chalk_rust_ir::StructDatum;
 use chalk_rust_ir::TraitDatum;
 use chalk_rust_ir::WellKnownTrait;
 use chalk_solve::RustIrDatabase;
@@ -110,8 +110,8 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         self.program_ir().unwrap().opaque_ty_data(id)
     }
 
-    fn struct_datum(&self, id: StructId<ChalkIr>) -> Arc<StructDatum<ChalkIr>> {
-        self.program_ir().unwrap().struct_datum(id)
+    fn adt_datum(&self, id: AdtId<ChalkIr>) -> Arc<AdtDatum<ChalkIr>> {
+        self.program_ir().unwrap().adt_datum(id)
     }
 
     fn impls_for_trait(
@@ -130,14 +130,10 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
             .local_impls_to_coherence_check(trait_id)
     }
 
-    fn impl_provided_for(
-        &self,
-        auto_trait_id: TraitId<ChalkIr>,
-        struct_id: StructId<ChalkIr>,
-    ) -> bool {
+    fn impl_provided_for(&self, auto_trait_id: TraitId<ChalkIr>, adt_id: AdtId<ChalkIr>) -> bool {
         self.program_ir()
             .unwrap()
-            .impl_provided_for(auto_trait_id, struct_id)
+            .impl_provided_for(auto_trait_id, adt_id)
     }
 
     fn well_known_trait_id(&self, well_known_trait: WellKnownTrait) -> Option<TraitId<ChalkIr>> {

--- a/chalk-integration/src/interner.rs
+++ b/chalk-integration/src/interner.rs
@@ -1,14 +1,14 @@
 use crate::tls;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::{
-    AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKind, CanonicalVarKinds, Goals, Lifetime,
+    AdtId, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKind, CanonicalVarKinds, Goals, Lifetime,
     OpaqueTy, OpaqueTyId, ProgramClauseImplication, ProgramClauses, ProjectionTy,
     QuantifiedWhereClauses, SeparatorTraitRef, Substitution, TraitId, Ty, VariableKind,
     VariableKinds,
 };
 use chalk_ir::{
     GenericArg, GenericArgData, Goal, GoalData, LifetimeData, ProgramClause, ProgramClauseData,
-    QuantifiedWhereClause, StructId, TyData,
+    QuantifiedWhereClause, TyData,
 };
 use std::fmt;
 use std::fmt::Debug;
@@ -46,13 +46,14 @@ impl Interner for ChalkIr {
     type InternedVariableKinds = Vec<VariableKind<ChalkIr>>;
     type InternedCanonicalVarKinds = Vec<CanonicalVarKind<ChalkIr>>;
     type DefId = RawId;
+    type InternedAdtId = RawId;
     type Identifier = Identifier;
 
-    fn debug_struct_id(
-        type_kind_id: StructId<ChalkIr>,
+    fn debug_adt_id(
+        type_kind_id: AdtId<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_struct_id(type_kind_id, fmt)))
+        tls::with_current_program(|prog| Some(prog?.debug_adt_id(type_kind_id, fmt)))
     }
 
     fn debug_trait_id(

--- a/chalk-integration/src/interner.rs
+++ b/chalk-integration/src/interner.rs
@@ -1,8 +1,8 @@
 use crate::tls;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::{
-    AdtId, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKind, CanonicalVarKinds, Goals, Lifetime,
-    OpaqueTy, OpaqueTyId, ProgramClauseImplication, ProgramClauses, ProjectionTy,
+    AdtId, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKind, CanonicalVarKinds, Goals,
+    Lifetime, OpaqueTy, OpaqueTyId, ProgramClauseImplication, ProgramClauses, ProjectionTy,
     QuantifiedWhereClauses, SeparatorTraitRef, Substitution, TraitId, Ty, VariableKind,
     VariableKinds,
 };

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -3,9 +3,9 @@ use crate::{tls, Identifier, TypeKind};
 use chalk_ir::could_match::CouldMatch;
 use chalk_ir::debug::Angle;
 use chalk_ir::{
-    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, GenericArg, Goal, Goals, ImplId,
-    Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication, ProgramClauses,
-    ProjectionTy, Substitution, TraitId, Ty,
+    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, GenericArg, Goal, Goals,
+    ImplId, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication,
+    ProgramClauses, ProjectionTy, Substitution, TraitId, Ty,
 };
 use chalk_rust_ir::{
     AdtDatum, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ImplDatum, ImplType,

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -3,13 +3,13 @@ use crate::{tls, Identifier, TypeKind};
 use chalk_ir::could_match::CouldMatch;
 use chalk_ir::debug::Angle;
 use chalk_ir::{
-    debug::SeparatorTraitRef, AliasTy, ApplicationTy, AssocTypeId, GenericArg, Goal, Goals, ImplId,
+    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, GenericArg, Goal, Goals, ImplId,
     Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication, ProgramClauses,
-    ProjectionTy, StructId, Substitution, TraitId, Ty,
+    ProjectionTy, Substitution, TraitId, Ty,
 };
 use chalk_rust_ir::{
-    AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ImplDatum, ImplType, OpaqueTyDatum,
-    StructDatum, TraitDatum, WellKnownTrait,
+    AdtDatum, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ImplDatum, ImplType,
+    OpaqueTyDatum, TraitDatum, WellKnownTrait,
 };
 use chalk_solve::split::Split;
 use chalk_solve::RustIrDatabase;
@@ -19,11 +19,11 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Program {
-    /// From struct name to item-id. Used during lowering only.
-    pub struct_ids: BTreeMap<Identifier, StructId<ChalkIr>>,
+    /// From ADT name to item-id. Used during lowering only.
+    pub adt_ids: BTreeMap<Identifier, AdtId<ChalkIr>>,
 
-    /// For each struct:
-    pub struct_kinds: BTreeMap<StructId<ChalkIr>, TypeKind>,
+    /// For each ADT:
+    pub adt_kinds: BTreeMap<AdtId<ChalkIr>, TypeKind>,
 
     /// From trait name to item-id. Used during lowering only.
     pub trait_ids: BTreeMap<Identifier, TraitId<ChalkIr>>,
@@ -31,8 +31,8 @@ pub struct Program {
     /// For each trait:
     pub trait_kinds: BTreeMap<TraitId<ChalkIr>, TypeKind>,
 
-    /// For each struct:
-    pub struct_data: BTreeMap<StructId<ChalkIr>, Arc<StructDatum<ChalkIr>>>,
+    /// For each ADT:
+    pub adt_data: BTreeMap<AdtId<ChalkIr>, Arc<AdtDatum<ChalkIr>>>,
 
     /// For each impl:
     pub impl_data: BTreeMap<ImplId<ChalkIr>, Arc<ImplDatum<ChalkIr>>>,
@@ -78,16 +78,16 @@ impl Program {
 }
 
 impl tls::DebugContext for Program {
-    fn debug_struct_id(
+    fn debug_adt_id(
         &self,
-        struct_id: StructId<ChalkIr>,
+        adt_id: AdtId<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error> {
-        if let Some(k) = self.struct_kinds.get(&struct_id) {
+        if let Some(k) = self.adt_kinds.get(&adt_id) {
             write!(fmt, "{}", k.name)
         } else {
-            fmt.debug_struct("InvalidStructId")
-                .field("index", &struct_id.0)
+            fmt.debug_struct("InvalidAdtId")
+                .field("index", &adt_id.0)
                 .finish()
         }
     }
@@ -330,8 +330,8 @@ impl RustIrDatabase<ChalkIr> for Program {
         self.opaque_ty_data[&id].clone()
     }
 
-    fn struct_datum(&self, id: StructId<ChalkIr>) -> Arc<StructDatum<ChalkIr>> {
-        self.struct_data[&id].clone()
+    fn adt_datum(&self, id: AdtId<ChalkIr>) -> Arc<AdtDatum<ChalkIr>> {
+        self.adt_data[&id].clone()
     }
 
     fn impls_for_trait(
@@ -367,17 +367,13 @@ impl RustIrDatabase<ChalkIr> for Program {
             .collect()
     }
 
-    fn impl_provided_for(
-        &self,
-        auto_trait_id: TraitId<ChalkIr>,
-        struct_id: StructId<ChalkIr>,
-    ) -> bool {
+    fn impl_provided_for(&self, auto_trait_id: TraitId<ChalkIr>, adt_id: AdtId<ChalkIr>) -> bool {
         let interner = self.interner();
         // Look for an impl like `impl Send for Foo` where `Foo` is
-        // the struct.  See `push_auto_trait_impls` for more.
+        // the ADT.  See `push_auto_trait_impls` for more.
         self.impl_data.values().any(|impl_datum| {
             impl_datum.trait_id() == auto_trait_id
-                && impl_datum.self_type_struct_id(interner) == Some(struct_id)
+                && impl_datum.self_type_adt_id(interner) == Some(adt_id)
         })
     }
 

--- a/chalk-integration/src/query.rs
+++ b/chalk-integration/src/query.rs
@@ -100,8 +100,8 @@ fn checked_program(db: &impl LoweringDatabase) -> Result<Arc<Program>, ChalkErro
 
     let () = tls::set_current_program(&program, || -> Result<(), ChalkError> {
         let solver = wf::WfSolver::new(db, db.solver_choice());
-        for &id in program.struct_data.keys() {
-            solver.verify_struct_decl(id)?;
+        for &id in program.adt_data.keys() {
+            solver.verify_adt_decl(id)?;
         }
 
         for &impl_id in program.impl_data.keys() {
@@ -136,7 +136,7 @@ fn environment(db: &impl LoweringDatabase) -> Result<Arc<ProgramEnvironment>, Ch
         .for_each(|d| d.to_program_clauses(builder));
 
     program
-        .struct_data
+        .adt_data
         .values()
         .for_each(|d| d.to_program_clauses(builder));
 
@@ -145,8 +145,8 @@ fn environment(db: &impl LoweringDatabase) -> Result<Arc<ProgramEnvironment>, Ch
         .iter()
         .filter(|(_, auto_trait)| auto_trait.is_auto_trait())
     {
-        for &struct_id in program.struct_data.keys() {
-            chalk_solve::clauses::push_auto_trait_impls(builder, auto_trait_id, struct_id);
+        for &adt_id in program.adt_data.keys() {
+            chalk_solve::clauses::push_auto_trait_impls(builder, auto_trait_id, adt_id);
         }
     }
 

--- a/chalk-integration/src/tls.rs
+++ b/chalk-integration/src/tls.rs
@@ -1,8 +1,8 @@
 use crate::interner::ChalkIr;
 use chalk_ir::{
-    debug::SeparatorTraitRef, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKinds, GenericArg,
+    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKinds, GenericArg,
     Goal, Goals, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication,
-    ProgramClauses, ProjectionTy, QuantifiedWhereClauses, StructId, Substitution, TraitId, Ty,
+    ProgramClauses, ProjectionTy, QuantifiedWhereClauses, Substitution, TraitId, Ty,
     VariableKinds,
 };
 use std::cell::RefCell;
@@ -14,9 +14,9 @@ thread_local! {
 }
 
 pub trait DebugContext {
-    fn debug_struct_id(
+    fn debug_adt_id(
         &self,
-        id: StructId<ChalkIr>,
+        id: AdtId<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 

--- a/chalk-integration/src/tls.rs
+++ b/chalk-integration/src/tls.rs
@@ -1,9 +1,9 @@
 use crate::interner::ChalkIr;
 use chalk_ir::{
-    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKinds, GenericArg,
-    Goal, Goals, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication,
-    ProgramClauses, ProjectionTy, QuantifiedWhereClauses, Substitution, TraitId, Ty,
-    VariableKinds,
+    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKinds,
+    GenericArg, Goal, Goals, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause,
+    ProgramClauseImplication, ProgramClauses, ProjectionTy, QuantifiedWhereClauses, Substitution,
+    TraitId, Ty, VariableKinds,
 };
 use std::cell::RefCell;
 use std::fmt;

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -294,12 +294,12 @@ where
     }
 }
 
-impl<I> CastTo<TypeName<I>> for StructId<I>
+impl<I> CastTo<TypeName<I>> for AdtId<I>
 where
     I: Interner,
 {
     fn cast_to(self, _interner: &I) -> TypeName<I> {
-        TypeName::Struct(self)
+        TypeName::Adt(self)
     }
 }
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -8,9 +8,9 @@ impl<I: Interner> Debug for TraitId<I> {
     }
 }
 
-impl<I: Interner> Debug for StructId<I> {
+impl<I: Interner> Debug for AdtId<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        I::debug_struct_id(*self, fmt).unwrap_or_else(|| write!(fmt, "StructId({:?})", self.0))
+        I::debug_adt_id(*self, fmt).unwrap_or_else(|| write!(fmt, "AdtId({:?})", self.0))
     }
 }
 
@@ -139,7 +139,7 @@ impl Debug for UniverseIndex {
 impl<I: Interner> Debug for TypeName<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
-            TypeName::Struct(id) => write!(fmt, "{:?}", id),
+            TypeName::Adt(id) => write!(fmt, "{:?}", id),
             TypeName::AssociatedType(assoc_ty) => write!(fmt, "{:?}", assoc_ty),
             TypeName::Scalar(scalar) => write!(fmt, "{:?}", scalar),
             TypeName::Str => write!(fmt, "Str"),

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -253,6 +253,10 @@ copy_fold!(Mutability);
 #[macro_export]
 macro_rules! id_fold {
     ($t:ident) => {
+        $crate::id_fold!($t, transfer_def_id);
+    };
+
+    ($t:ident, $transfer_fn:ident) => {
         impl<I: Interner, TI: TargetInterner<I>> $crate::fold::Fold<I, TI> for $t<I> {
             type Result = $t<TI>;
             fn fold_with<'i>(
@@ -265,7 +269,7 @@ macro_rules! id_fold {
                 TI: 'i,
             {
                 let $t(def_id_tf) = *self;
-                let def_id_ttf = TI::transfer_def_id(def_id_tf);
+                let def_id_ttf = TI::$transfer_fn(def_id_tf);
                 Ok($t(def_id_ttf))
             }
         }
@@ -273,7 +277,7 @@ macro_rules! id_fold {
 }
 
 id_fold!(ImplId);
-id_fold!(StructId);
+id_fold!(AdtId, transfer_adt_id);
 id_fold!(TraitId);
 id_fold!(AssocTypeId);
 id_fold!(OpaqueTyId);

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -1,3 +1,4 @@
+use crate::AdtId;
 use crate::AliasTy;
 use crate::ApplicationTy;
 use crate::AssocTypeId;
@@ -20,7 +21,6 @@ use crate::ProjectionTy;
 use crate::QuantifiedWhereClause;
 use crate::QuantifiedWhereClauses;
 use crate::SeparatorTraitRef;
-use crate::StructId;
 use crate::Substitution;
 use crate::TraitId;
 use crate::Ty;
@@ -127,7 +127,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// and can be converted back to its underlying data via `quantified_where_clauses_data`.
     type InternedQuantifiedWhereClauses: Debug + Clone + Eq + Hash;
 
-    /// "Interned" representation of a list of variable kinds.  
+    /// "Interned" representation of a list of variable kinds.
     /// In normal user code, `Self::InternedVariableKinds` is not referenced.
     /// Instead, we refer to `VariableKinds<Self>`, which wraps this type.
     ///
@@ -135,7 +135,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// and can be converted back to its underlying data via `variable_kinds_data`.
     type InternedVariableKinds: Debug + Clone + Eq + Hash;
 
-    /// "Interned" representation of a list of variable kinds with universe index.  
+    /// "Interned" representation of a list of variable kinds with universe index.
     /// In normal user code, `Self::InternedCanonicalVarKinds` is not referenced.
     /// Instead, we refer to `CanonicalVarKinds<Self>`, which wraps this type.
     ///
@@ -144,8 +144,11 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// to its underlying data via `canonical_var_kinds_data`.
     type InternedCanonicalVarKinds: Debug + Clone + Eq + Hash;
 
-    /// The core "id" type used for struct-ids and the like.
+    /// The core "id" type used for trait-ids and the like.
     type DefId: Debug + Copy + Eq + Ord + Hash;
+
+    /// The ID type for ADTs
+    type InternedAdtId: Debug + Copy + Eq + Ord + Hash;
 
     type Identifier: Debug + Clone + Eq + Hash;
 
@@ -157,10 +160,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// Returns `None` to fallback to the default debug output (e.g.,
     /// if no info about current program is available from TLS).
     #[allow(unused_variables)]
-    fn debug_struct_id(
-        struct_id: StructId<Self>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Option<fmt::Result> {
+    fn debug_adt_id(adt_id: AdtId<Self>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
         None
     }
 
@@ -608,6 +608,8 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 pub trait TargetInterner<I: Interner>: Interner {
     fn transfer_def_id(def_id: I::DefId) -> Self::DefId;
 
+    fn transfer_adt_id(adt_id: I::InternedAdtId) -> Self::InternedAdtId;
+
     fn transfer_variable_kinds(
         variable_kinds: I::InternedVariableKinds,
     ) -> Self::InternedVariableKinds;
@@ -620,6 +622,10 @@ pub trait TargetInterner<I: Interner>: Interner {
 impl<I: Interner> TargetInterner<I> for I {
     fn transfer_def_id(def_id: I::DefId) -> Self::DefId {
         def_id
+    }
+
+    fn transfer_adt_id(adt_id: I::InternedAdtId) -> Self::InternedAdtId {
+        adt_id
     }
 
     fn transfer_variable_kinds(

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -144,8 +144,9 @@ pub enum Mutability {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Fold, Visit)]
 pub enum TypeName<I: Interner> {
-    /// a type like `Vec<T>`
-    Struct(StructId<I>),
+    /// Abstract data types, i.e., structs, unions, or enumerations.
+    /// For example, a type like `Vec<T>`.
+    Adt(AdtId<I>),
 
     /// an associated type like `Iterator::Item`; see `AssociatedType` for details
     AssociatedType(AssocTypeId<I>),
@@ -211,7 +212,7 @@ impl UniverseIndex {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct StructId<I: Interner>(pub I::DefId);
+pub struct AdtId<I: Interner>(pub I::InternedAdtId);
 
 /// The id of a trait definition; could be used to load the trait datum by
 /// invoking the [`trait_datum`] method.

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -7,8 +7,8 @@
 use crate::{
     AdtId, AssocTypeId, ClausePriority, DebruijnIndex, FloatTy, GenericArg, Goals, ImplId, IntTy,
     Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauseData,
-    ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution,
-    SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
+    ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution, SuperVisit,
+    TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
 };
 use chalk_engine::{context::Context, ExClause, FlounderedSubgoal, Literal};
 use std::{marker::PhantomData, sync::Arc};

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -5,9 +5,9 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::{
-    AssocTypeId, ClausePriority, DebruijnIndex, FloatTy, GenericArg, Goals, ImplId, IntTy,
+    AdtId, AssocTypeId, ClausePriority, DebruijnIndex, FloatTy, GenericArg, Goals, ImplId, IntTy,
     Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauseData,
-    ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, StructId, Substitution,
+    ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution,
     SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
 };
 use chalk_engine::{context::Context, ExClause, FlounderedSubgoal, Literal};
@@ -232,7 +232,7 @@ macro_rules! id_visit {
 }
 
 id_visit!(ImplId);
-id_visit!(StructId);
+id_visit!(AdtId);
 id_visit!(TraitId);
 id_visit!(OpaqueTyId);
 id_visit!(AssocTypeId);

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -195,7 +195,7 @@ macro_rules! eq_zip {
     };
 }
 
-eq_zip!(I => StructId<I>);
+eq_zip!(I => AdtId<I>);
 eq_zip!(I => TraitId<I>);
 eq_zip!(I => AssocTypeId<I>);
 eq_zip!(I => OpaqueTyId<I>);

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -10,8 +10,8 @@ use chalk_ir::fold::shift::Shift;
 use chalk_ir::interner::{Interner, TargetInterner};
 use chalk_ir::{
     AdtId, AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, GenericArg, ImplId, OpaqueTyId,
-    ProjectionTy, QuantifiedWhereClause, Substitution, ToGenericArg, TraitId, TraitRef,
-    Ty, TyData, TypeName, VariableKind, WhereClause, WithKind,
+    ProjectionTy, QuantifiedWhereClause, Substitution, ToGenericArg, TraitId, TraitRef, Ty, TyData,
+    TypeName, VariableKind, WhereClause, WithKind,
 };
 use std::iter;
 

--- a/chalk-rust-ir/src/lib.rs
+++ b/chalk-rust-ir/src/lib.rs
@@ -9,8 +9,8 @@ use chalk_ir::cast::Cast;
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::interner::{Interner, TargetInterner};
 use chalk_ir::{
-    AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, GenericArg, ImplId, OpaqueTyId,
-    ProjectionTy, QuantifiedWhereClause, StructId, Substitution, ToGenericArg, TraitId, TraitRef,
+    AdtId, AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, GenericArg, ImplId, OpaqueTyId,
+    ProjectionTy, QuantifiedWhereClause, Substitution, ToGenericArg, TraitId, TraitRef,
     Ty, TyData, TypeName, VariableKind, WhereClause, WithKind,
 };
 use std::iter;
@@ -38,7 +38,7 @@ impl<I: Interner> ImplDatum<I> {
         self.binders.skip_binders().trait_ref.trait_id
     }
 
-    pub fn self_type_struct_id(&self, interner: &I) -> Option<StructId<I>> {
+    pub fn self_type_adt_id(&self, interner: &I) -> Option<AdtId<I>> {
         match self
             .binders
             .skip_binders()
@@ -47,7 +47,7 @@ impl<I: Interner> ImplDatum<I> {
             .data(interner)
         {
             TyData::Apply(apply) => match apply.name {
-                TypeName::Struct(id) => Some(id),
+                TypeName::Adt(id) => Some(id),
                 _ => None,
             },
             _ => None,
@@ -79,26 +79,26 @@ pub struct DefaultImplDatumBound<I: Interner> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct StructDatum<I: Interner> {
-    pub binders: Binders<StructDatumBound<I>>,
-    pub id: StructId<I>,
-    pub flags: StructFlags,
+pub struct AdtDatum<I: Interner> {
+    pub binders: Binders<AdtDatumBound<I>>,
+    pub id: AdtId<I>,
+    pub flags: AdtFlags,
 }
 
-impl<I: Interner> StructDatum<I> {
+impl<I: Interner> AdtDatum<I> {
     pub fn name(&self, interner: &I) -> TypeName<I> {
         self.id.cast(interner)
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
-pub struct StructDatumBound<I: Interner> {
+pub struct AdtDatumBound<I: Interner> {
     pub fields: Vec<Ty<I>>,
     pub where_clauses: Vec<QuantifiedWhereClause<I>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct StructFlags {
+pub struct AdtFlags {
     pub upstream: bool,
     pub fundamental: bool,
 }

--- a/chalk-solve/src/clauses/builtin_traits/sized.rs
+++ b/chalk-solve/src/clauses/builtin_traits/sized.rs
@@ -3,28 +3,28 @@ use std::iter;
 use crate::clauses::builtin_traits::needs_impl_for_tys;
 use crate::clauses::ClauseBuilder;
 use crate::{Interner, RustIrDatabase, TraitRef};
-use chalk_ir::{ApplicationTy, StructId, Substitution, TyData, TypeName};
+use chalk_ir::{AdtId, ApplicationTy, Substitution, TyData, TypeName};
 
-fn push_struct_sized_conditions<I: Interner>(
+fn push_adt_sized_conditions<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,
     trait_ref: &TraitRef<I>,
-    struct_id: StructId<I>,
+    adt_id: AdtId<I>,
     substitution: &Substitution<I>,
 ) {
-    let struct_datum = db.struct_datum(struct_id);
+    let adt_datum = db.adt_datum(adt_id);
 
-    // Structs with no fields are always Sized
-    if struct_datum.binders.skip_binders().fields.is_empty() {
+    // ADTs with no fields are always Sized
+    if adt_datum.binders.skip_binders().fields.is_empty() {
         builder.push_fact(trait_ref.clone());
         return;
     }
 
     let interner = db.interner();
 
-    // To check if a struct type S<..> is Sized, we only have to look at its last field.
-    // This is because the WF checks for structs require that all the other fields must be Sized.
-    let last_field_ty = struct_datum
+    // To check if an ADT type S<..> is Sized, we only have to look at its last field.
+    // This is because the WF checks for ADTs require that all the other fields must be Sized.
+    let last_field_ty = adt_datum
         .binders
         .map_ref(|b| b.fields.last().unwrap())
         .substitute(interner, substitution);
@@ -68,8 +68,8 @@ pub fn add_sized_program_clauses<I: Interner>(
 ) {
     match ty {
         TyData::Apply(ApplicationTy { name, substitution }) => match name {
-            TypeName::Struct(struct_id) => {
-                push_struct_sized_conditions(db, builder, trait_ref, *struct_id, substitution)
+            TypeName::Adt(adt_id) => {
+                push_adt_sized_conditions(db, builder, trait_ref, *adt_id, substitution)
             }
             TypeName::Tuple(arity) => {
                 push_tuple_sized_conditions(db, builder, trait_ref, *arity, substitution)

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -180,7 +180,7 @@ impl<I: Interner> ToProgramClauses<I> for OpaqueTyDatum<I> {
     }
 }
 
-impl<I: Interner> ToProgramClauses<I> for StructDatum<I> {
+impl<I: Interner> ToProgramClauses<I> for AdtDatum<I> {
     /// Given the following type definition: `struct Foo<T: Eq> { }`, generate:
     ///
     /// ```notrust
@@ -230,7 +230,7 @@ impl<I: Interner> ToProgramClauses<I> for StructDatum<I> {
     /// ```
     ///
     fn to_program_clauses(&self, builder: &mut ClauseBuilder<'_, I>) {
-        debug_heading!("StructDatum::to_program_clauses(self={:?})", self);
+        debug_heading!("AdtDatum::to_program_clauses(self={:?})", self);
 
         let interner = builder.interner();
         let binders = self.binders.map_ref(|b| &b.where_clauses);

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -36,7 +36,7 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     fn trait_datum(&self, trait_id: TraitId<I>) -> Arc<TraitDatum<I>>;
 
     /// Returns the datum for the impl with the given id.
-    fn struct_datum(&self, struct_id: StructId<I>) -> Arc<StructDatum<I>>;
+    fn adt_datum(&self, adt_id: AdtId<I>) -> Arc<AdtDatum<I>>;
 
     /// Returns the datum for the impl with the given id.
     fn impl_datum(&self, impl_id: ImplId<I>) -> Arc<ImplDatum<I>>;
@@ -68,12 +68,12 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     fn local_impls_to_coherence_check(&self, trait_id: TraitId<I>) -> Vec<ImplId<I>>;
 
     /// Returns true if there is an explicit impl of the auto trait
-    /// `auto_trait_id` for the struct `struct_id`. This is part of
+    /// `auto_trait_id` for the ADT `adt_id`. This is part of
     /// the auto trait handling -- if there is no explicit impl given
     /// by the user for the struct, then we provide default impls
     /// based on the field types (otherwise, we rely on the impls the
     /// user gave).
-    fn impl_provided_for(&self, auto_trait_id: TraitId<I>, struct_id: StructId<I>) -> bool;
+    fn impl_provided_for(&self, auto_trait_id: TraitId<I>, adt_id: AdtId<I>) -> bool;
 
     /// A stop-gap solution to force an impl for a given well-known trait.
     /// Useful when the logic for a given trait is absent or incomplete.

--- a/chalk-solve/src/test_macros.rs
+++ b/chalk-solve/src/test_macros.rs
@@ -110,6 +110,6 @@ macro_rules! lifetime {
 
 macro_rules! ty_name {
     ((item $n:expr)) => {
-        chalk_ir::TypeName::Struct(StructId(chalk_integration::interner::RawId { index: $n }))
+        chalk_ir::TypeName::Adt(AdtId(chalk_integration::interner::RawId { index: $n }))
     };
 }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -14,7 +14,7 @@ use chalk_rust_ir::*;
 
 #[derive(Debug)]
 pub enum WfError<I: Interner> {
-    IllFormedTypeDecl(chalk_ir::StructId<I>),
+    IllFormedTypeDecl(chalk_ir::AdtId<I>),
     IllFormedTraitImpl(chalk_ir::TraitId<I>),
 }
 
@@ -144,7 +144,8 @@ where
         Self { db, solver_choice }
     }
 
-    pub fn verify_struct_decl(&self, struct_id: StructId<I>) -> Result<(), WfError<I>> {
+    /// TODO: Currently only handles structs, may need more work for enums & unions
+    pub fn verify_adt_decl(&self, adt_id: AdtId<I>) -> Result<(), WfError<I>> {
         let interner = self.db.interner();
 
         // Given a struct like
@@ -154,7 +155,7 @@ where
         //     data: Vec<T>
         // }
         // ```
-        let struct_datum = self.db.struct_datum(struct_id);
+        let struct_datum = self.db.adt_datum(adt_id);
 
         let mut gb = GoalBuilder::new(self.db);
         let struct_data = struct_datum
@@ -199,7 +200,7 @@ where
         };
 
         if !is_legal {
-            Err(WfError::IllFormedTypeDecl(struct_id))
+            Err(WfError::IllFormedTypeDecl(adt_id))
         } else {
             Ok(())
         }
@@ -534,11 +535,11 @@ impl WfWellKnownGoals {
         let ty = trait_ref.self_type_parameter(interner);
         let ty_data = ty.data(interner);
 
-        let (struct_id, substitution) = match ty_data {
+        let (adt_id, substitution) = match ty_data {
             TyData::Apply(ApplicationTy {
-                name: TypeName::Struct(struct_id),
+                name: TypeName::Adt(adt_id),
                 substitution,
-            }) => (*struct_id, substitution),
+            }) => (*adt_id, substitution),
             // TODO(areredify)
             // when #368 lands, extend this to handle everything accordingly
             _ => return None,
@@ -556,9 +557,9 @@ impl WfWellKnownGoals {
                     .negate(interner)
                 });
 
-        let struct_datum = db.struct_datum(struct_id);
+        let adt_datum = db.adt_datum(adt_id);
 
-        let goals = struct_datum
+        let goals = adt_datum
             .binders
             .map_ref(|b| &b.fields)
             .substitute(interner, substitution)
@@ -616,7 +617,7 @@ impl WfWellKnownGoals {
     ) -> Option<Goal<I>> {
         let interner = db.interner();
 
-        let struct_id = match impl_datum.self_type_struct_id(interner) {
+        let adt_id = match impl_datum.self_type_adt_id(interner) {
             Some(id) => id,
             // Drop can only be implemented on a nominal type
             None => return Some(GoalData::CannotProve(()).intern(interner)),
@@ -624,15 +625,15 @@ impl WfWellKnownGoals {
 
         let mut gb = GoalBuilder::new(db);
 
-        let struct_datum = db.struct_datum(struct_id);
-        let struct_name = struct_datum.name(interner);
+        let adt_datum = db.adt_datum(adt_id);
+        let adt_name = adt_datum.name(interner);
 
         let impl_fields = impl_datum
             .binders
             .map_ref(|v| (&v.trait_ref, &v.where_clauses));
 
         // forall<ImplP1...ImplPn> { .. }
-        let implied_by_struct_def_goal =
+        let implied_by_adt_def_goal =
             gb.forall(&impl_fields, (), |gb, _, (trait_ref, where_clauses), ()| {
                 let interner = gb.interner();
 
@@ -659,29 +660,26 @@ impl WfWellKnownGoals {
 
         // forall<StructP1..StructPN> {...}
         let eq_goal = gb.forall(
-            &struct_datum.binders,
-            (struct_name, impl_self_ty),
-            |gb, substitution, _, (struct_name, impl_self_ty)| {
+            &adt_datum.binders,
+            (adt_name, impl_self_ty),
+            |gb, substitution, _, (adt_name, impl_self_ty)| {
                 let interner = gb.interner();
 
-                let def_struct: Ty<I> = ApplicationTy {
-                    name: struct_name,
+                let def_adt: Ty<I> = ApplicationTy {
+                    name: adt_name,
                     substitution,
                 }
                 .cast(interner)
                 .intern(interner);
 
                 // exists<ImplP1...ImplPn> { .. }
-                gb.exists(
-                    &impl_self_ty,
-                    def_struct,
-                    |gb, _, impl_struct, def_struct| {
-                        let interner = gb.interner();
+                gb.exists(&impl_self_ty, def_adt, |gb, _, impl_adt, def_adt| {
+                    let interner = gb.interner();
 
                         // StructName<StructP1..StructPn> = ImplSelfType
                         GoalData::EqGoal(EqGoal {
-                            a: GenericArgData::Ty(def_struct).intern(interner),
-                            b: GenericArgData::Ty(impl_struct.clone()).intern(interner),
+                            a: GenericArgData::Ty(def_adt).intern(interner),
+                            b: GenericArgData::Ty(impl_adt.clone()).intern(interner),
                         })
                         .intern(interner)
                     },
@@ -689,6 +687,6 @@ impl WfWellKnownGoals {
             },
         );
 
-        Some(gb.all([implied_by_struct_def_goal, eq_goal].iter()))
+        Some(gb.all([implied_by_adt_def_goal, eq_goal].iter()))
     }
 }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -676,14 +676,13 @@ impl WfWellKnownGoals {
                 gb.exists(&impl_self_ty, def_adt, |gb, _, impl_adt, def_adt| {
                     let interner = gb.interner();
 
-                        // StructName<StructP1..StructPn> = ImplSelfType
-                        GoalData::EqGoal(EqGoal {
-                            a: GenericArgData::Ty(def_adt).intern(interner),
-                            b: GenericArgData::Ty(impl_adt.clone()).intern(interner),
-                        })
-                        .intern(interner)
-                    },
-                )
+                    // StructName<StructP1..StructPn> = ImplSelfType
+                    GoalData::EqGoal(EqGoal {
+                        a: GenericArgData::Ty(def_adt).intern(interner),
+                        b: GenericArgData::Ty(impl_adt.clone()).intern(interner),
+                    })
+                    .intern(interner)
+                })
             },
         );
 


### PR DESCRIPTION
Closes #453

The only functional changes are due to the introduction of the ADT ID, and they are minimal.