### PR TITLE
refactor Parameter into GenericArg

### DIFF
--- a/book/src/types.md
+++ b/book/src/types.md
@@ -57,8 +57,6 @@ not been thoroughly discussed by the Rust compiler team as a whole.
 Here is a (partial) list of some things that have to be adapted in
 Chalk as of today to match this document:
 
-* `Parameter<I>` needs to be renamed to `GenericArgument`
-* `Vec<Parameter<I>>` needs to be replaced with `GenericArguments`
 * Extract `TypeName` into something opaque to chalk-ir.
 * Dyn type equality should probably be driven by entailment.
 * Projections need to be renamed to aliases.

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -103,7 +103,7 @@ pub trait Context: Clone + Debug {
 
     /// A term that can be quantified over and unified -- in current
     /// Chalk, either a type or lifetime.
-    type Parameter: Debug;
+    type GenericArg: Debug;
 
     /// A rule like `DomainGoal :- Goal`.
     ///
@@ -354,13 +354,13 @@ pub trait UnificationOps<C: Context> {
     ///
     /// If the parameters fail to unify, then `Error` is returned
     // Used by: simplify
-    fn unify_parameters_into_ex_clause(
+    fn unify_generic_args_into_ex_clause(
         &mut self,
         interner: &C::Interner,
         environment: &C::Environment,
         variance: C::Variance,
-        a: &C::Parameter,
-        b: &C::Parameter,
+        a: &C::GenericArg,
+        b: &C::GenericArg,
         ex_clause: &mut ExClause<C>,
     ) -> Fallible<()>;
 }

--- a/chalk-engine/src/hh.rs
+++ b/chalk-engine/src/hh.rs
@@ -10,7 +10,7 @@ pub enum HhGoal<C: Context> {
     Implies(C::ProgramClauses, C::Goal),
     All(Vec<C::Goal>),
     Not(C::Goal),
-    Unify(C::Variance, C::Parameter, C::Parameter),
+    Unify(C::Variance, C::GenericArg, C::GenericArg),
     DomainGoal(C::DomainGoal),
 
     /// Indicates something that cannot be proven to be true or false

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -57,7 +57,7 @@ impl<C: Context> Forest<C> {
                             subgoal,
                         )));
                 }
-                HhGoal::Unify(variance, a, b) => infer.unify_parameters_into_ex_clause(
+                HhGoal::Unify(variance, a, b) => infer.unify_generic_args_into_ex_clause(
                     context.interner(),
                     &environment,
                     variance,

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -9,11 +9,11 @@ use chalk_ir::AssocTypeId;
 use chalk_ir::Canonical;
 use chalk_ir::ConstrainedSubst;
 use chalk_ir::Environment;
+use chalk_ir::GenericArg;
 use chalk_ir::Goal;
 use chalk_ir::ImplId;
 use chalk_ir::InEnvironment;
 use chalk_ir::OpaqueTyId;
-use chalk_ir::Parameter;
 use chalk_ir::ProgramClause;
 use chalk_ir::StructId;
 use chalk_ir::TraitId;
@@ -117,11 +117,11 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
     fn impls_for_trait(
         &self,
         trait_id: TraitId<ChalkIr>,
-        parameters: &[Parameter<ChalkIr>],
+        generic_args: &[GenericArg<ChalkIr>],
     ) -> Vec<ImplId<ChalkIr>> {
         self.program_ir()
             .unwrap()
-            .impls_for_trait(trait_id, parameters)
+            .impls_for_trait(trait_id, generic_args)
     }
 
     fn local_impls_to_coherence_check(&self, trait_id: TraitId<ChalkIr>) -> Vec<ImplId<ChalkIr>> {

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -3,8 +3,8 @@ use crate::{tls, Identifier, TypeKind};
 use chalk_ir::could_match::CouldMatch;
 use chalk_ir::debug::Angle;
 use chalk_ir::{
-    debug::SeparatorTraitRef, AliasTy, ApplicationTy, AssocTypeId, Goal, Goals, ImplId, Lifetime,
-    OpaqueTy, OpaqueTyId, Parameter, ProgramClause, ProgramClauseImplication, ProgramClauses,
+    debug::SeparatorTraitRef, AliasTy, ApplicationTy, AssocTypeId, GenericArg, Goal, Goals, ImplId,
+    Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication, ProgramClauses,
     ProjectionTy, StructId, Substitution, TraitId, Ty,
 };
 use chalk_rust_ir::{
@@ -184,40 +184,40 @@ impl tls::DebugContext for Program {
         write!(fmt, "{:?}", lifetime.data(interner))
     }
 
-    fn debug_parameter(
+    fn debug_generic_arg(
         &self,
-        parameter: &Parameter<ChalkIr>,
+        generic_arg: &GenericArg<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error> {
         let interner = self.interner();
-        write!(fmt, "{:?}", parameter.data(interner).inner_debug())
+        write!(fmt, "{:?}", generic_arg.data(interner).inner_debug())
     }
 
-    fn debug_parameter_kinds(
+    fn debug_variable_kinds(
         &self,
-        parameter_kinds: &chalk_ir::ParameterKinds<ChalkIr>,
+        variable_kinds: &chalk_ir::VariableKinds<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error> {
         let interner = self.interner();
-        write!(fmt, "{:?}", parameter_kinds.as_slice(interner))
+        write!(fmt, "{:?}", variable_kinds.as_slice(interner))
     }
 
-    fn debug_parameter_kinds_with_angles(
+    fn debug_variable_kinds_with_angles(
         &self,
-        parameter_kinds: &chalk_ir::ParameterKinds<ChalkIr>,
+        variable_kinds: &chalk_ir::VariableKinds<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error> {
         let interner = self.interner();
-        write!(fmt, "{:?}", parameter_kinds.inner_debug(interner))
+        write!(fmt, "{:?}", variable_kinds.inner_debug(interner))
     }
 
     fn debug_canonical_var_kinds(
         &self,
-        parameter_kinds: &chalk_ir::CanonicalVarKinds<ChalkIr>,
+        variable_kinds: &chalk_ir::CanonicalVarKinds<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error> {
         let interner = self.interner();
-        write!(fmt, "{:?}", parameter_kinds.as_slice(interner))
+        write!(fmt, "{:?}", variable_kinds.as_slice(interner))
     }
 
     fn debug_goal(
@@ -337,7 +337,7 @@ impl RustIrDatabase<ChalkIr> for Program {
     fn impls_for_trait(
         &self,
         trait_id: TraitId<ChalkIr>,
-        parameters: &[Parameter<ChalkIr>],
+        parameters: &[GenericArg<ChalkIr>],
     ) -> Vec<ImplId<ChalkIr>> {
         let interner = self.interner();
         self.impl_data

--- a/chalk-integration/src/tls.rs
+++ b/chalk-integration/src/tls.rs
@@ -1,9 +1,9 @@
 use crate::interner::ChalkIr;
 use chalk_ir::{
-    debug::SeparatorTraitRef, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKinds, Goal, Goals,
-    Lifetime, OpaqueTy, OpaqueTyId, Parameter, ParameterKinds, ProgramClause,
-    ProgramClauseImplication, ProgramClauses, ProjectionTy, QuantifiedWhereClauses, StructId,
-    Substitution, TraitId, Ty,
+    debug::SeparatorTraitRef, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKinds, GenericArg,
+    Goal, Goals, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication,
+    ProgramClauses, ProjectionTy, QuantifiedWhereClauses, StructId, Substitution, TraitId, Ty,
+    VariableKinds,
 };
 use std::cell::RefCell;
 use std::fmt;
@@ -64,27 +64,27 @@ pub trait DebugContext {
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 
-    fn debug_parameter(
+    fn debug_generic_arg(
         &self,
-        parameter: &Parameter<ChalkIr>,
+        generic_arg: &GenericArg<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 
-    fn debug_parameter_kinds(
+    fn debug_variable_kinds(
         &self,
-        parameter_kinds: &ParameterKinds<ChalkIr>,
+        variable_kinds: &VariableKinds<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 
-    fn debug_parameter_kinds_with_angles(
+    fn debug_variable_kinds_with_angles(
         &self,
-        parameter_kinds: &ParameterKinds<ChalkIr>,
+        variable_kinds: &VariableKinds<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 
     fn debug_canonical_var_kinds(
         &self,
-        parameter_kinds: &CanonicalVarKinds<ChalkIr>,
+        variable_kinds: &CanonicalVarKinds<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -82,7 +82,7 @@ reflexive_impl!(for(I: Interner) Goal<I>);
 reflexive_impl!(for(I: Interner) WhereClause<I>);
 reflexive_impl!(for(I: Interner) ProgramClause<I>);
 reflexive_impl!(for(I: Interner) QuantifiedWhereClause<I>);
-reflexive_impl!(for(I: Interner) ParameterKinds<I>);
+reflexive_impl!(for(I: Interner) VariableKinds<I>);
 reflexive_impl!(for(I: Interner) CanonicalVarKinds<I>);
 
 impl<I: Interner> CastTo<WhereClause<I>> for TraitRef<I> {
@@ -162,20 +162,20 @@ impl<I: Interner> CastTo<TyData<I>> for AliasTy<I> {
     }
 }
 
-impl<I: Interner> CastTo<Parameter<I>> for Ty<I> {
-    fn cast_to(self, interner: &I) -> Parameter<I> {
-        Parameter::new(interner, ParameterKind::Ty(self))
+impl<I: Interner> CastTo<GenericArg<I>> for Ty<I> {
+    fn cast_to(self, interner: &I) -> GenericArg<I> {
+        GenericArg::new(interner, GenericArgData::Ty(self))
     }
 }
 
-impl<I: Interner> CastTo<Parameter<I>> for Lifetime<I> {
-    fn cast_to(self, interner: &I) -> Parameter<I> {
-        Parameter::new(interner, ParameterKind::Lifetime(self))
+impl<I: Interner> CastTo<GenericArg<I>> for Lifetime<I> {
+    fn cast_to(self, interner: &I) -> GenericArg<I> {
+        GenericArg::new(interner, GenericArgData::Lifetime(self))
     }
 }
 
-impl<I: Interner> CastTo<Parameter<I>> for Parameter<I> {
-    fn cast_to(self, _interner: &I) -> Parameter<I> {
+impl<I: Interner> CastTo<GenericArg<I>> for GenericArg<I> {
+    fn cast_to(self, _interner: &I) -> GenericArg<I> {
         self
     }
 }

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -49,8 +49,8 @@ where
             value: self_value,
         } = self;
         let value = self_value.fold_with(folder, outer_binder.shifted_in())?;
-        let binders = ParameterKinds {
-            interned: TI::transfer_parameter_kinds(self_binders.interned().clone()),
+        let binders = VariableKinds {
+            interned: TI::transfer_variable_kinds(self_binders.interned().clone()),
         };
         Ok(Binders::new(binders, value))
     }

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -113,8 +113,8 @@ impl<T: Fold<I, TI>, I: Interner, TI: TargetInterner<I>> Fold<I, TI> for Option<
     }
 }
 
-impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for Parameter<I> {
-    type Result = Parameter<TI>;
+impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for GenericArg<I> {
+    type Result = GenericArg<TI>;
     fn fold_with<'i>(
         &self,
         folder: &mut dyn Folder<'i, I, TI>,
@@ -128,7 +128,7 @@ impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for Parameter<I> {
         let target_interner = folder.target_interner();
 
         let data = self.data(interner).fold_with(folder, outer_binder)?;
-        Ok(Parameter::new(target_interner, data))
+        Ok(GenericArg::new(target_interner, data))
     }
 }
 
@@ -329,31 +329,6 @@ impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for PhantomData<I> {
         TI: 'i,
     {
         Ok(PhantomData)
-    }
-}
-
-impl<I: Interner, TI: TargetInterner<I>, T, L> Fold<I, TI> for ParameterKind<T, L>
-where
-    T: Fold<I, TI>,
-    L: Fold<I, TI>,
-{
-    type Result = ParameterKind<T::Result, L::Result>;
-
-    fn fold_with<'i>(
-        &self,
-        folder: &mut dyn Folder<'i, I, TI>,
-        outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
-    where
-        I: 'i,
-        TI: 'i,
-    {
-        match self {
-            ParameterKind::Ty(a) => Ok(ParameterKind::Ty(a.fold_with(folder, outer_binder)?)),
-            ParameterKind::Lifetime(a) => {
-                Ok(ParameterKind::Lifetime(a.fold_with(folder, outer_binder)?))
-            }
-        }
     }
 }
 

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -5,10 +5,10 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::{
-    AssocTypeId, ClausePriority, DebruijnIndex, FloatTy, Goals, ImplId, IntTy, Interner,
-    Mutability, OpaqueTyId, Parameter, ParameterKind, PlaceholderIndex, ProgramClause,
-    ProgramClauseData, ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, StructId,
-    Substitution, SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
+    AssocTypeId, ClausePriority, DebruijnIndex, FloatTy, GenericArg, Goals, ImplId, IntTy,
+    Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauseData,
+    ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, StructId, Substitution,
+    SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
 };
 use chalk_engine::{context::Context, ExClause, FlounderedSubgoal, Literal};
 use std::{marker::PhantomData, sync::Arc};
@@ -138,7 +138,7 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Option<T> {
     }
 }
 
-impl<I: Interner> Visit<I> for Parameter<I> {
+impl<I: Interner> Visit<I> for GenericArg<I> {
     fn visit_with<'i, R: VisitResult>(
         &self,
         visitor: &mut dyn Visitor<'i, I, Result = R>,
@@ -295,26 +295,6 @@ impl<I: Interner> Visit<I> for PhantomData<I> {
         I: 'i,
     {
         R::new()
-    }
-}
-
-impl<I: Interner, T, L> Visit<I> for ParameterKind<T, L>
-where
-    T: Visit<I>,
-    L: Visit<I>,
-{
-    fn visit_with<'i, R: VisitResult>(
-        &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
-        outer_binder: DebruijnIndex,
-    ) -> R
-    where
-        I: 'i,
-    {
-        match self {
-            ParameterKind::Ty(a) => a.visit_with(visitor, outer_binder),
-            ParameterKind::Lifetime(a) => a.visit_with(visitor, outer_binder),
-        }
     }
 }
 

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -289,23 +289,23 @@ impl<I: Interner> Zip<I> for Goal<I> {
 }
 
 // I'm too lazy to make `enum_zip` support type parameters.
-impl<T: Zip<I>, L: Zip<I>, I: Interner> Zip<I> for ParameterKind<T, L> {
-    fn zip_with<'i, Z: Zipper<'i, I>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()>
+impl<I: Interner> Zip<I> for VariableKind<I> {
+    fn zip_with<'i, Z: Zipper<'i, I>>(_zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()>
     where
         I: 'i,
     {
         match (a, b) {
-            (ParameterKind::Ty(a), ParameterKind::Ty(b)) => Zip::zip_with(zipper, a, b),
-            (ParameterKind::Lifetime(a), ParameterKind::Lifetime(b)) => Zip::zip_with(zipper, a, b),
-            (ParameterKind::Ty(_), _) | (ParameterKind::Lifetime(_), _) => {
+            (VariableKind::Ty, VariableKind::Ty) => Ok(()),
+            (VariableKind::Lifetime, VariableKind::Lifetime) => Ok(()),
+            (VariableKind::Phantom(..), _) | (_, VariableKind::Phantom(..)) => unreachable!(),
+            (VariableKind::Ty, _) | (VariableKind::Lifetime, _) => {
                 panic!("zipping things of mixed kind")
             }
         }
     }
 }
 
-#[allow(unreachable_code, unused_variables)]
-impl<I: Interner> Zip<I> for Parameter<I> {
+impl<I: Interner> Zip<I> for GenericArg<I> {
     fn zip_with<'i, Z: Zipper<'i, I>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()>
     where
         I: 'i,

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -30,7 +30,7 @@ pub enum Item {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StructDefn {
     pub name: Identifier,
-    pub parameter_kinds: Vec<ParameterKind>,
+    pub variable_kinds: Vec<VariableKind>,
     pub where_clauses: Vec<QuantifiedWhereClause>,
     pub fields: Vec<Field>,
     pub flags: StructFlags,
@@ -45,7 +45,7 @@ pub struct StructFlags {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TraitDefn {
     pub name: Identifier,
-    pub parameter_kinds: Vec<ParameterKind>,
+    pub variable_kinds: Vec<VariableKind>,
     pub where_clauses: Vec<QuantifiedWhereClause>,
     pub assoc_ty_defns: Vec<AssocTyDefn>,
     pub flags: TraitFlags,
@@ -74,7 +74,7 @@ pub struct TraitFlags {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct AssocTyDefn {
     pub name: Identifier,
-    pub parameter_kinds: Vec<ParameterKind>,
+    pub variable_kinds: Vec<VariableKind>,
     pub bounds: Vec<QuantifiedInlineBound>,
     pub where_clauses: Vec<QuantifiedWhereClause>,
 }
@@ -82,19 +82,19 @@ pub struct AssocTyDefn {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct OpaqueTyDefn {
     pub ty: Ty,
-    pub parameter_kinds: Vec<ParameterKind>,
+    pub variable_kinds: Vec<VariableKind>,
     pub identifier: Identifier,
     pub bounds: Vec<QuantifiedInlineBound>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum ParameterKind {
+pub enum VariableKind {
     Ty(Identifier),
     Lifetime(Identifier),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum Parameter {
+pub enum GenericArg {
     Ty(Ty),
     Lifetime(Lifetime),
 }
@@ -108,7 +108,7 @@ pub enum InlineBound {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct QuantifiedInlineBound {
-    pub parameter_kinds: Vec<ParameterKind>,
+    pub variable_kinds: Vec<VariableKind>,
     pub bound: InlineBound,
 }
 
@@ -117,7 +117,7 @@ pub struct QuantifiedInlineBound {
 /// Does not know anything about what it's binding.
 pub struct TraitBound {
     pub trait_name: Identifier,
-    pub args_no_self: Vec<Parameter>,
+    pub args_no_self: Vec<GenericArg>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -126,7 +126,7 @@ pub struct TraitBound {
 pub struct AliasEqBound {
     pub trait_bound: TraitBound,
     pub name: Identifier,
-    pub args: Vec<Parameter>,
+    pub args: Vec<GenericArg>,
     pub value: Ty,
 }
 
@@ -147,7 +147,7 @@ impl fmt::Display for Kind {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Impl {
-    pub parameter_kinds: Vec<ParameterKind>,
+    pub variable_kinds: Vec<VariableKind>,
     pub trait_ref: TraitRef,
     pub polarity: Polarity,
     pub where_clauses: Vec<QuantifiedWhereClause>,
@@ -164,7 +164,7 @@ pub enum ImplType {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct AssocTyValue {
     pub name: Identifier,
-    pub parameter_kinds: Vec<ParameterKind>,
+    pub variable_kinds: Vec<VariableKind>,
     pub value: Ty,
     pub default: bool,
 }
@@ -179,7 +179,7 @@ pub enum Ty {
     },
     Apply {
         name: Identifier,
-        args: Vec<Parameter>,
+        args: Vec<GenericArg>,
     },
     Projection {
         proj: ProjectionTy,
@@ -259,13 +259,13 @@ pub enum Lifetime {
 pub struct ProjectionTy {
     pub trait_ref: TraitRef,
     pub name: Identifier,
-    pub args: Vec<Parameter>,
+    pub args: Vec<GenericArg>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TraitRef {
     pub trait_name: Identifier,
-    pub args: Vec<Parameter>,
+    pub args: Vec<GenericArg>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -332,7 +332,7 @@ pub enum LeafGoal {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct QuantifiedWhereClause {
-    pub parameter_kinds: Vec<ParameterKind>,
+    pub variable_kinds: Vec<VariableKind>,
     pub where_clause: WhereClause,
 }
 
@@ -346,15 +346,15 @@ pub struct Field {
 /// This allows users to add arbitrary `A :- B` clauses into the
 /// logic; it has no equivalent in Rust, but it's useful for testing.
 pub struct Clause {
-    pub parameter_kinds: Vec<ParameterKind>,
+    pub variable_kinds: Vec<VariableKind>,
     pub consequence: DomainGoal,
     pub conditions: Vec<Box<Goal>>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Goal {
-    ForAll(Vec<ParameterKind>, Box<Goal>),
-    Exists(Vec<ParameterKind>, Box<Goal>),
+    ForAll(Vec<VariableKind>, Box<Goal>),
+    Exists(Vec<VariableKind>, Box<Goal>),
     Implies(Vec<Clause>, Box<Goal>),
     And(Box<Goal>, Vec<Box<Goal>>),
     Not(Box<Goal>),

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -28,8 +28,8 @@ pub Goal: Box<Goal> = {
 };
 
 Goal1: Box<Goal> = {
-    "forall" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::ForAll(p, g)),
-    "exists" "<" <p:Comma<ParameterKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::Exists(p, g)),
+    "forall" "<" <p:Comma<VariableKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::ForAll(p, g)),
+    "exists" "<" <p:Comma<VariableKind>> ">" "{" <g:Goal> "}" => Box::new(Goal::Exists(p, g)),
     "if" "(" <h:SemiColon<InlineClause>> ")" "{" <g:Goal> "}" => Box::new(Goal::Implies(h, g)),
     "not" "{" <g:Goal> "}" => Box::new(Goal::Not(g)),
     "compatible" "{" <g:Goal> "}" => Box::new(Goal::Compatible(g)),
@@ -53,11 +53,11 @@ WellKnownTrait: WellKnownTrait = {
 };
 
 StructDefn: StructDefn = {
-    <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> "struct" <n:Id><p:Angle<ParameterKind>>
+    <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> "struct" <n:Id><p:Angle<VariableKind>>
         <w:QuantifiedWhereClauses> "{" <f:Fields> "}" => StructDefn
     {
         name: n,
-        parameter_kinds: p,
+        variable_kinds: p,
         where_clauses: w,
         fields: f,
         flags: StructFlags {
@@ -68,11 +68,11 @@ StructDefn: StructDefn = {
 };
 
 TraitDefn: TraitDefn = {
-    <auto:AutoKeyword?> <marker:MarkerKeyword?> <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> <non_enumerable:NonEnumerableKeyword?> <coinductive:CoinductiveKeyword?> <object_safe:ObjectSafeKeyword?> <well_known:WellKnownTrait?> "trait" <n:Id><p:Angle<ParameterKind>>
+    <auto:AutoKeyword?> <marker:MarkerKeyword?> <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> <non_enumerable:NonEnumerableKeyword?> <coinductive:CoinductiveKeyword?> <object_safe:ObjectSafeKeyword?> <well_known:WellKnownTrait?> "trait" <n:Id><p:Angle<VariableKind>>
         <w:QuantifiedWhereClauses> "{" <a:AssocTyDefn*> "}" => TraitDefn
     {
         name: n,
-        parameter_kinds: p,
+        variable_kinds: p,
         where_clauses: w,
         assoc_ty_defns: a,
         well_known,
@@ -89,12 +89,12 @@ TraitDefn: TraitDefn = {
 };
 
 AssocTyDefn: AssocTyDefn = {
-    "type" <name:Id> <p:Angle<ParameterKind>> <b:(":" <Plus<QuantifiedInlineBound>>)?>
+    "type" <name:Id> <p:Angle<VariableKind>> <b:(":" <Plus<QuantifiedInlineBound>>)?>
         <w:QuantifiedWhereClauses> ";" =>
     {
         AssocTyDefn {
             name: name,
-            parameter_kinds: p,
+            variable_kinds: p,
             where_clauses: w,
             bounds: b.unwrap_or(vec![]),
         }
@@ -102,10 +102,10 @@ AssocTyDefn: AssocTyDefn = {
 };
 
 OpaqueTyDefn: OpaqueTyDefn = {
-    "opaque" "type" <identifier:Id> <p:Angle<ParameterKind>> ":" <b:Plus<QuantifiedInlineBound>> "=" <ty:Ty> ";" => {
+    "opaque" "type" <identifier:Id> <p:Angle<VariableKind>> ":" <b:Plus<QuantifiedInlineBound>> "=" <ty:Ty> ";" => {
         OpaqueTyDefn {
             ty,
-            parameter_kinds: p,
+            variable_kinds: p,
             identifier,
             bounds: b,
         }
@@ -118,7 +118,7 @@ InlineBound: InlineBound = {
 };
 
 TraitBound: TraitBound = {
-    <t:Id> <a:Angle<Parameter>> => {
+    <t:Id> <a:Angle<GenericArg>> => {
         TraitBound {
             trait_name: t,
             args_no_self: a,
@@ -127,7 +127,7 @@ TraitBound: TraitBound = {
 };
 
 AliasEqBound: AliasEqBound = {
-    <t:Id> "<" <a:(<Comma<Parameter>> ",")?> <name:Id> <a2:Angle<Parameter>>
+    <t:Id> "<" <a:(<Comma<GenericArg>> ",")?> <name:Id> <a2:Angle<GenericArg>>
         "=" <ty:Ty> ">" => AliasEqBound
     {
         trait_bound: TraitBound {
@@ -142,24 +142,24 @@ AliasEqBound: AliasEqBound = {
 
 QuantifiedInlineBound: QuantifiedInlineBound = {
     <b:InlineBound> => QuantifiedInlineBound {
-        parameter_kinds: vec![],
+        variable_kinds: vec![],
         bound: b,
     },
 
-    "forall" "<" <pk:Comma<ParameterKind>> ">" <b:InlineBound> => QuantifiedInlineBound {
-        parameter_kinds: pk,
+    "forall" "<" <pk:Comma<VariableKind>> ">" <b:InlineBound> => QuantifiedInlineBound {
+        variable_kinds: pk,
         bound: b,
     },
 };
 
 Impl: Impl = {
-    <external:UpstreamKeyword?> "impl" <p:Angle<ParameterKind>> <mark:"!"?> <t:Id> <a:Angle<Parameter>> "for" <s:Ty>
+    <external:UpstreamKeyword?> "impl" <p:Angle<VariableKind>> <mark:"!"?> <t:Id> <a:Angle<GenericArg>> "for" <s:Ty>
         <w:QuantifiedWhereClauses> "{" <assoc:AssocTyValue*> "}" =>
     {
-        let mut args = vec![Parameter::Ty(s)];
+        let mut args = vec![GenericArg::Ty(s)];
         args.extend(a);
         Impl {
-            parameter_kinds: p,
+            variable_kinds: p,
             polarity: Polarity::from_bool(mark.is_none()),
             trait_ref: TraitRef {
                 trait_name: t,
@@ -172,15 +172,15 @@ Impl: Impl = {
     },
 };
 
-ParameterKind: ParameterKind = {
-    Id => ParameterKind::Ty(<>),
-    LifetimeId => ParameterKind::Lifetime(<>),
+VariableKind: VariableKind = {
+    Id => VariableKind::Ty(<>),
+    LifetimeId => VariableKind::Lifetime(<>),
 };
 
 AssocTyValue: AssocTyValue = {
-    <default:"default"?> "type" <n:Id> <a:Angle<ParameterKind>> "=" <v:Ty> ";" => AssocTyValue {
+    <default:"default"?> "type" <n:Id> <a:Angle<VariableKind>> "=" <v:Ty> ";" => AssocTyValue {
         name: n,
-        parameter_kinds: a,
+        variable_kinds: a,
         value: v,
         default: default.is_some(),
     },
@@ -205,7 +205,7 @@ TyWithoutFor: Ty = {
     "dyn" <b:Plus<QuantifiedInlineBound>> => Ty::Dyn {
         bounds: b,
     },
-    <n:Id> "<" <a:Comma<Parameter>> ">" => Ty::Apply { name: n, args: a },
+    <n:Id> "<" <a:Comma<GenericArg>> ">" => Ty::Apply { name: n, args: a },
     <p:ProjectionTy> => Ty::Projection { proj: p },
     "(" <t:TupleOrParensInner> ")" => t,
     "*" <m: RawMutability> <t:Ty> => Ty::Raw{ mutability: m, ty: Box::new(t) },
@@ -253,13 +253,13 @@ Lifetime: Lifetime = {
     <n:LifetimeId> => Lifetime::Id { name: n },
 };
 
-Parameter: Parameter = {
-    Ty => Parameter::Ty(<>),
-    Lifetime => Parameter::Lifetime(<>),
+GenericArg: GenericArg = {
+    Ty => GenericArg::Ty(<>),
+    Lifetime => GenericArg::Lifetime(<>),
 };
 
 ProjectionTy: ProjectionTy = {
-    "<" <t:TraitRef<"as">> ">" "::" <n:Id> <a:Angle<Parameter>> => ProjectionTy {
+    "<" <t:TraitRef<"as">> ">" "::" <n:Id> <a:Angle<GenericArg>> => ProjectionTy {
         trait_ref: t, name: n, args: a
     },
 };
@@ -276,14 +276,14 @@ Field: Field = {
 };
 
 Clause: Clause = {
-    "forall" <pk:Angle<ParameterKind>> "{" <dg:DomainGoal> "if" <g:Comma<Goal1>> "}" => Clause {
-        parameter_kinds: pk,
+    "forall" <pk:Angle<VariableKind>> "{" <dg:DomainGoal> "if" <g:Comma<Goal1>> "}" => Clause {
+        variable_kinds: pk,
         consequence: dg,
         conditions: g,
     },
 
-    "forall" <pk:Angle<ParameterKind>> "{" <dg:DomainGoal> "}" => Clause {
-        parameter_kinds: pk,
+    "forall" <pk:Angle<VariableKind>> "{" <dg:DomainGoal> "}" => Clause {
+        variable_kinds: pk,
         consequence: dg,
         conditions: vec![],
     },
@@ -291,13 +291,13 @@ Clause: Clause = {
 
 InlineClause1: Clause = {
     <dg:DomainGoal> => Clause {
-        parameter_kinds: vec![],
+        variable_kinds: vec![],
         consequence: dg,
         conditions: vec![],
     },
 
     <dg:DomainGoal> ":" "-" <g:Comma<Goal1>> => Clause {
-        parameter_kinds: vec![],
+        variable_kinds: vec![],
         consequence: dg,
         conditions: g,
     },
@@ -306,8 +306,8 @@ InlineClause1: Clause = {
 InlineClause: Clause = {
     <InlineClause1>,
 
-    "forall" "<" <pk:Comma<ParameterKind>> ">" "{" <c:InlineClause1> "}" => Clause {
-        parameter_kinds: pk,
+    "forall" "<" <pk:Comma<VariableKind>> ">" "{" <c:InlineClause1> "}" => Clause {
+        variable_kinds: pk,
         consequence: c.consequence,
         conditions: c.conditions,
     }
@@ -317,10 +317,10 @@ WhereClause: WhereClause = {
     <t:TraitRef<":">> => WhereClause::Implemented { trait_ref: t },
 
     // `T: Foo<U = Bar>` -- projection equality
-    <s:Ty> ":" <t:Id> "<" <a:(<Comma<Parameter>> ",")?> <name:Id> <a2:Angle<Parameter>>
+    <s:Ty> ":" <t:Id> "<" <a:(<Comma<GenericArg>> ",")?> <name:Id> <a2:Angle<GenericArg>>
         "=" <ty:Ty> ">" =>
     {
-        let mut args = vec![Parameter::Ty(s)];
+        let mut args = vec![GenericArg::Ty(s)];
         if let Some(a) = a { args.extend(a); }
         let trait_ref = TraitRef { trait_name: t, args: args };
         let projection = ProjectionTy { trait_ref, name, args: a2 };
@@ -330,12 +330,12 @@ WhereClause: WhereClause = {
 
 QuantifiedWhereClause: QuantifiedWhereClause = {
     <wc:WhereClause> => QuantifiedWhereClause {
-        parameter_kinds: vec![],
+        variable_kinds: vec![],
         where_clause: wc,
     },
 
-    "forall" "<" <pk:Comma<ParameterKind>> ">" <wc:WhereClause> => QuantifiedWhereClause {
-        parameter_kinds: pk,
+    "forall" "<" <pk:Comma<VariableKind>> ">" <wc:WhereClause> => QuantifiedWhereClause {
+        variable_kinds: pk,
         where_clause: wc,
     },
 };
@@ -382,8 +382,8 @@ LeafGoal: LeafGoal = {
 };
 
 TraitRef<S>: TraitRef = {
-    <s:Ty> S <t:Id> <a:Angle<Parameter>> => {
-        let mut args = vec![Parameter::Ty(s)];
+    <s:Ty> S <t:Id> <a:Angle<GenericArg>> => {
+        let mut args = vec![GenericArg::Ty(s)];
         args.extend(a);
         TraitRef {
             trait_name: t,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -319,7 +319,7 @@ fn program_clauses_that_could_match<I: Interner>(
 fn push_program_clauses_for_associated_type_values_in_impls_of<I: Interner>(
     builder: &mut ClauseBuilder<'_, I>,
     trait_id: TraitId<I>,
-    trait_parameters: &[Parameter<I>],
+    trait_parameters: &[GenericArg<I>],
 ) {
     debug_heading!(
         "push_program_clauses_for_associated_type_values_in_impls_of(\

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -1,9 +1,11 @@
+use std::iter;
+use std::marker::PhantomData;
+
 use crate::cast::{Cast, CastTo};
 use crate::RustIrDatabase;
 use chalk_ir::fold::Fold;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
-use std::marker::PhantomData;
 
 /// The "clause builder" is a useful tool for building up sets of
 /// program clauses. It takes ownership of the output vector while it
@@ -12,8 +14,8 @@ use std::marker::PhantomData;
 pub struct ClauseBuilder<'me, I: Interner> {
     pub db: &'me dyn RustIrDatabase<I>,
     clauses: &'me mut Vec<ProgramClause<I>>,
-    binders: Vec<ParameterKind<()>>,
-    parameters: Vec<Parameter<I>>,
+    binders: Vec<VariableKind<I>>,
+    parameters: Vec<GenericArg<I>>,
 }
 
 impl<'me, I: Interner> ClauseBuilder<'me, I> {
@@ -81,7 +83,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
         } else {
             self.clauses.push(
                 ProgramClauseData::ForAll(Binders::new(
-                    ParameterKinds::from(interner, self.binders.clone()),
+                    VariableKinds::from(interner, self.binders.clone()),
                     clause,
                 ))
                 .intern(interner),
@@ -92,7 +94,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
     }
 
     /// Accesses the placeholders for the current list of parameters in scope.
-    pub fn placeholders_in_scope(&self) -> &[Parameter<I>] {
+    pub fn placeholders_in_scope(&self) -> &[GenericArg<I>] {
         &self.parameters
     }
 
@@ -127,7 +129,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
                 .binders
                 .iter(interner)
                 .zip(old_len..)
-                .map(|p| p.to_parameter(interner)),
+                .map(|p| p.to_generic_arg(interner)),
         );
 
         let value = binders.substitute(self.interner(), &self.parameters[old_len..]);
@@ -147,7 +149,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
     pub fn push_bound_ty(&mut self, op: impl FnOnce(&mut Self, Ty<I>)) {
         let interner = self.interner();
         let binders = Binders::new(
-            ParameterKinds::from(interner, vec![ParameterKind::Ty(())]),
+            VariableKinds::from(interner, iter::once(VariableKind::Ty)),
             PhantomData::<I>,
         );
         self.push_binders(&binders, |this, PhantomData| {

--- a/chalk-solve/src/clauses/builtin_traits/copy.rs
+++ b/chalk-solve/src/clauses/builtin_traits/copy.rs
@@ -24,7 +24,7 @@ fn push_tuple_copy_conditions<I: Interner>(
         trait_ref,
         substitution
             .iter(interner)
-            .map(|param| param.ty(interner).unwrap().clone()),
+            .map(|param| param.assert_ty_ref(interner).clone()),
     );
 }
 

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -10,13 +10,13 @@ use chalk_engine::fallible::Fallible;
 use chalk_ir::{
     fold::{Fold, Folder},
     interner::{HasInterner, Interner},
-    Binders, BoundVar, DebruijnIndex, Lifetime, LifetimeData, ParameterKind, ParameterKinds, Ty,
-    TyData,
+    Binders, BoundVar, DebruijnIndex, Lifetime, LifetimeData, Ty, TyData, VariableKind,
+    VariableKinds,
 };
 use rustc_hash::FxHashMap;
 
 pub struct Generalize<'i, I: Interner> {
-    binders: Vec<ParameterKind<()>>,
+    binders: Vec<VariableKind<I>>,
     mapping: FxHashMap<BoundVar, usize>,
     interner: &'i I,
 }
@@ -35,7 +35,7 @@ impl<I: Interner> Generalize<'_, I> {
         let value = value
             .fold_with(&mut generalize, DebruijnIndex::INNERMOST)
             .unwrap();
-        Binders::new(ParameterKinds::from(interner, generalize.binders), value)
+        Binders::new(VariableKinds::from(interner, generalize.binders), value)
     }
 }
 
@@ -52,7 +52,7 @@ impl<'i, I: Interner> Folder<'i, I> for Generalize<'i, I> {
         let binder_vec = &mut self.binders;
         let new_index = self.mapping.entry(bound_var).or_insert_with(|| {
             let i = binder_vec.len();
-            binder_vec.push(ParameterKind::Ty(()));
+            binder_vec.push(VariableKind::Ty);
             i
         });
         let new_var = BoundVar::new(outer_binder, *new_index);
@@ -67,7 +67,7 @@ impl<'i, I: Interner> Folder<'i, I> for Generalize<'i, I> {
         let binder_vec = &mut self.binders;
         let new_index = self.mapping.entry(bound_var).or_insert_with(|| {
             let i = binder_vec.len();
-            binder_vec.push(ParameterKind::Ty(()));
+            binder_vec.push(VariableKind::Ty);
             i
         });
         let new_var = BoundVar::new(outer_binder, *new_index);

--- a/chalk-solve/src/goal_builder.rs
+++ b/chalk-solve/src/goal_builder.rs
@@ -138,7 +138,7 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
                 .binders
                 .iter(interner)
                 .zip(0..)
-                .map(|p| p.to_parameter(interner)),
+                .map(|p| p.to_generic_arg(interner)),
         );
 
         // Shift passthru into one level of binder, to account for the `forall<P0..Pn>`

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -184,9 +184,9 @@ fn quantify_simple() {
             binders: CanonicalVarKinds::from(
                 interner,
                 vec![
-                    ParameterKind::Ty(U2),
-                    ParameterKind::Ty(U1),
-                    ParameterKind::Ty(U0),
+                    CanonicalVarKind::new(VariableKind::Ty, U2),
+                    CanonicalVarKind::new(VariableKind::Ty, U1),
+                    CanonicalVarKind::new(VariableKind::Ty, U0),
                 ]
             ),
         }
@@ -225,9 +225,9 @@ fn quantify_bound() {
             binders: CanonicalVarKinds::from(
                 interner,
                 vec![
-                    ParameterKind::Ty(U1),
-                    ParameterKind::Ty(U0),
-                    ParameterKind::Ty(U2),
+                    CanonicalVarKind::new(VariableKind::Ty, U1),
+                    CanonicalVarKind::new(VariableKind::Ty, U0),
+                    CanonicalVarKind::new(VariableKind::Ty, U2),
                 ]
             ),
         }
@@ -268,7 +268,10 @@ fn quantify_ty_under_binder() {
             value: ty!(function 3 (apply (item 0) (bound 1) (bound 1 0) (bound 1 0) (lifetime (bound 1 1)))),
             binders: CanonicalVarKinds::from(
                 interner,
-                vec![ParameterKind::Ty(U0), ParameterKind::Lifetime(U0)]
+                vec![
+                    CanonicalVarKind::new(VariableKind::Ty, U0),
+                    CanonicalVarKind::new(VariableKind::Lifetime, U0)
+                ]
             ),
         }
     );

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -46,7 +46,7 @@ impl<I: Interner> InferenceTable<I> {
             value0
                 .binders
                 .iter(interner)
-                .map(|pk| pk.map(|ui| universes.map_universe_to_canonical(ui))),
+                .map(|pk| pk.map_ref(|&ui| universes.map_universe_to_canonical(ui))),
         );
 
         UCanonicalized {

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -462,7 +462,7 @@ where
         match self.unifier.table.unify.probe_value(var) {
             // If this variable already has a value, fold over that value instead.
             InferenceValue::Bound(normalized_ty) => {
-                let normalized_ty = normalized_ty.ty(interner).unwrap();
+                let normalized_ty = normalized_ty.assert_ty_ref(interner);
                 let normalized_ty = normalized_ty.fold_with(self, DebruijnIndex::INNERMOST)?;
                 assert!(!normalized_ty.needs_shift(interner));
                 Ok(normalized_ty)
@@ -523,10 +523,10 @@ where
             }
 
             InferenceValue::Bound(l) => {
-                let l = l.lifetime(interner).unwrap();
+                let l = l.assert_lifetime_ref(interner);
                 let l = l.fold_with(self, outer_binder)?;
                 assert!(!l.needs_shift(interner));
-                Ok(l.clone())
+                Ok(l)
             }
         }
     }

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -30,7 +30,7 @@ use std::u32;
 ///   reject illegal values. Once the value of a variable is known, it
 ///   can never change.
 ///   - The value we actually store for variables is a
-///     `ir::Parameter`, and hence it does carry along the kind of the
+///     `ir::GenericArg`, and hence it does carry along the kind of the
 ///     variable via the enum variant. However, we should always know
 ///     the kind of the variable from context, and hence we typically
 ///     "downcast" the resulting variable using
@@ -88,7 +88,7 @@ impl<I: Interner> UnifyKey for EnaVariable<I> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum InferenceValue<I: Interner> {
     Unbound(UniverseIndex),
-    Bound(Parameter<I>),
+    Bound(GenericArg<I>),
 }
 
 impl<I: Interner> InferenceValue<I> {

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -56,7 +56,8 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// apply. The parameters are provided as a "hint" to help the
     /// implementor do less work, but can be completely ignored if
     /// desired.
-    fn impls_for_trait(&self, trait_id: TraitId<I>, parameters: &[Parameter<I>]) -> Vec<ImplId<I>>;
+    fn impls_for_trait(&self, trait_id: TraitId<I>, parameters: &[GenericArg<I>])
+        -> Vec<ImplId<I>>;
 
     /// Returns the impls that require coherence checking. This is not the
     /// full set of impls that exist:

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -372,7 +372,7 @@ impl<'me, I: Interner> Solver<'me, I> {
                     let res = self.solve_via_implication(
                         canonical_goal,
                         &Binders::new(
-                            ParameterKinds::from(self.program.interner(), vec![]),
+                            VariableKinds::from(self.program.interner(), vec![]),
                             implication.clone(),
                         ),
                         minimums,
@@ -473,7 +473,7 @@ fn calculate_inputs<I: Interner>(
     interner: &I,
     domain_goal: &DomainGoal<I>,
     solution: &Solution<I>,
-) -> Vec<Parameter<I>> {
+) -> Vec<GenericArg<I>> {
     if let Some(subst) = solution.constrained_subst() {
         let subst_goal = subst.value.subst.apply(&domain_goal, interner);
         subst_goal.inputs(interner)

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -307,7 +307,7 @@ impl<'s, 'db, I: Interner> Fulfill<'s, 'db, I> {
 
         for (i, free_var) in free_vars.into_iter().enumerate() {
             let subst_value = subst.at(self.interner(), i);
-            let free_value = free_var.to_parameter(self.interner());
+            let free_value = free_var.to_generic_arg(self.interner());
             self.unify(empty_env, &free_value, subst_value)
                 .unwrap_or_else(|err| {
                     panic!(

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -137,7 +137,7 @@ fn merge_into_guidance<I: Interner>(
 
     // Collect the types that the two substitutions have in
     // common.
-    let aggr_parameters: Vec<_> = guidance
+    let aggr_generic_args: Vec<_> = guidance
         .value
         .iter(interner)
         .zip(subst1.iter(interner))
@@ -146,11 +146,11 @@ fn merge_into_guidance<I: Interner>(
             // We have two values for some variable X that
             // appears in the root goal. Find out the universe
             // of X.
-            let universe = root_goal.binders.as_slice(interner)[index].into_inner();
+            let universe = *root_goal.binders.as_slice(interner)[index].skip_kind();
 
             let ty = match value.data(interner) {
-                ParameterKind::Ty(ty) => ty,
-                ParameterKind::Lifetime(_) => {
+                GenericArgData::Ty(ty) => ty,
+                GenericArgData::Lifetime(_) => {
                     // Ignore the lifetimes from the substitution: we're just
                     // creating guidance here anyway.
                     return infer
@@ -172,7 +172,7 @@ fn merge_into_guidance<I: Interner>(
         })
         .collect();
 
-    let aggr_subst = Substitution::from(interner, aggr_parameters);
+    let aggr_subst = Substitution::from(interner, aggr_generic_args);
 
     infer.canonicalize(interner, &aggr_subst).quantified
 }
@@ -183,11 +183,11 @@ fn is_trivial<I: Interner>(interner: &I, subst: &Canonical<Substitution<I>>) -> 
         .value
         .iter(interner)
         .enumerate()
-        .all(|(index, parameter)| match parameter.data(interner) {
+        .all(|(index, generic_arg)| match generic_arg.data(interner) {
             // All types are mapped to distinct variables.  Since this
             // has been canonicalized, those will also be the first N
             // variables.
-            ParameterKind::Ty(t) => match t.bound(interner) {
+            GenericArgData::Ty(t) => match t.bound(interner) {
                 None => false,
                 Some(bound_var) => {
                     if let Some(index1) = bound_var.index_if_innermost() {
@@ -200,7 +200,7 @@ fn is_trivial<I: Interner>(interner: &I, subst: &Canonical<Substitution<I>>) -> 
 
             // And no lifetime mappings. (This is too strict, but we never
             // product substs with lifetimes.)
-            ParameterKind::Lifetime(_) => false,
+            GenericArgData::Lifetime(_) => false,
         })
 }
 
@@ -381,22 +381,22 @@ impl<I: Interner> AntiUnifier<'_, '_, I> {
             substitution1
                 .iter(interner)
                 .zip(substitution2.iter(interner))
-                .map(|(p1, p2)| self.aggregate_parameters(p1, p2)),
+                .map(|(p1, p2)| self.aggregate_generic_args(p1, p2)),
         );
 
         Some((name, substitution))
     }
 
-    fn aggregate_parameters(&mut self, p1: &Parameter<I>, p2: &Parameter<I>) -> Parameter<I> {
+    fn aggregate_generic_args(&mut self, p1: &GenericArg<I>, p2: &GenericArg<I>) -> GenericArg<I> {
         let interner = self.interner;
         match (p1.data(interner), p2.data(interner)) {
-            (ParameterKind::Ty(ty1), ParameterKind::Ty(ty2)) => {
+            (GenericArgData::Ty(ty1), GenericArgData::Ty(ty2)) => {
                 self.aggregate_tys(ty1, ty2).cast(interner)
             }
-            (ParameterKind::Lifetime(l1), ParameterKind::Lifetime(l2)) => {
+            (GenericArgData::Lifetime(l1), GenericArgData::Lifetime(l2)) => {
                 self.aggregate_lifetimes(l1, l2).cast(interner)
             }
-            (ParameterKind::Ty(_), _) | (ParameterKind::Lifetime(_), _) => {
+            (GenericArgData::Ty(_), _) | (GenericArgData::Lifetime(_), _) => {
                 panic!("mismatched parameter kinds: p1={:?} p2={:?}", p1, p2)
             }
         }

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -314,7 +314,7 @@ impl<I: Interner> AnswerSubstitutor<'_, I> {
         &mut self,
         interner: &I,
         answer_var: BoundVar,
-        pending: ParameterKind<&Ty<I>, &Lifetime<I>>,
+        pending: GenericArgData<I>,
     ) -> Fallible<bool> {
         let answer_index = match answer_var.index_if_bound_at(self.outer_binder) {
             Some(index) => index,
@@ -341,7 +341,7 @@ impl<I: Interner> AnswerSubstitutor<'_, I> {
                 interner,
                 &self.environment,
                 answer_param,
-                &Parameter::new(interner, pending_shifted),
+                &GenericArg::new(interner, pending_shifted),
             )?,
             self.ex_clause,
         );
@@ -395,7 +395,11 @@ impl<'i, I: Interner> Zipper<'i, I> for AnswerSubstitutor<'i, I> {
         // resulting answer that the subgoal found and unify it with
         // the value from our "pending subgoal".
         if let TyData::BoundVar(answer_depth) = answer.data(interner) {
-            if self.unify_free_answer_var(interner, *answer_depth, ParameterKind::Ty(pending))? {
+            if self.unify_free_answer_var(
+                interner,
+                *answer_depth,
+                GenericArgData::Ty(pending.clone()),
+            )? {
                 return Ok(());
             }
         }
@@ -451,7 +455,7 @@ impl<'i, I: Interner> Zipper<'i, I> for AnswerSubstitutor<'i, I> {
             if self.unify_free_answer_var(
                 interner,
                 *answer_depth,
-                ParameterKind::Lifetime(pending),
+                GenericArgData::Lifetime(pending.clone()),
             )? {
                 return Ok(());
             }

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -18,8 +18,8 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
         projection: &'p ProjectionTy<I>,
     ) -> (
         Arc<AssociatedTyDatum<I>>,
-        &'p [Parameter<I>],
-        &'p [Parameter<I>],
+        &'p [GenericArg<I>],
+        &'p [GenericArg<I>],
     ) {
         let interner = self.interner();
         let ProjectionTy {
@@ -41,7 +41,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
     fn trait_parameters_from_projection<'p>(
         &self,
         projection: &'p ProjectionTy<I>,
-    ) -> &'p [Parameter<I>] {
+    ) -> &'p [GenericArg<I>] {
         let (_, trait_params, _) = self.split_projection(projection);
         trait_params
     }
@@ -122,9 +122,9 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
     /// * the projection `<Vec<Y> as Iterable>::Iter<'x>`
     fn impl_parameters_and_projection_from_associated_ty_value<'p>(
         &self,
-        parameters: &'p [Parameter<I>],
+        parameters: &'p [GenericArg<I>],
         associated_ty_value: &AssociatedTyValue<I>,
-    ) -> (&'p [Parameter<I>], ProjectionTy<I>) {
+    ) -> (&'p [GenericArg<I>], ProjectionTy<I>) {
         let interner = self.interner();
         debug_heading!(
             "impl_parameters_and_projection_from_associated_ty_value(parameters={:?})",

--- a/chalk-solve/src/test_macros.rs
+++ b/chalk-solve/src/test_macros.rs
@@ -6,7 +6,7 @@ macro_rules! ty {
             name: ty_name!($n),
             substitution: chalk_ir::Substitution::from(
                 &chalk_integration::interner::ChalkIr,
-                vec![$(arg!($arg)),*] as Vec<chalk_ir::Parameter<_>>
+                vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             ),
         }).intern(&chalk_integration::interner::ChalkIr)
     };
@@ -16,7 +16,7 @@ macro_rules! ty {
             num_binders: $n,
             substitution: chalk_ir::Substitution::from(
                 &chalk_integration::interner::ChalkIr,
-                vec![$(arg!($arg)),*] as Vec<chalk_ir::Parameter<_>>
+                vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             ),
         }).intern(&chalk_integration::interner::ChalkIr)
     };
@@ -33,7 +33,7 @@ macro_rules! ty {
             associated_ty_id: AssocTypeId(chalk_integration::interner::RawId { index: $n }),
             substitution: chalk_ir::Substitution::from(
                 &chalk_integration::interner::ChalkIr,
-                vec![$(arg!($arg)),*] as Vec<chalk_ir::Parameter<_>>
+                vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             ),
         }).intern(&chalk_integration::interner::ChalkIr)
     };
@@ -64,16 +64,16 @@ macro_rules! ty {
 
 macro_rules! arg {
     ((lifetime $b:tt)) => {
-        chalk_ir::Parameter::new(
+        chalk_ir::GenericArg::new(
             &chalk_integration::interner::ChalkIr,
-            chalk_ir::ParameterKind::Lifetime(lifetime!($b)),
+            chalk_ir::GenericArgData::Lifetime(lifetime!($b)),
         )
     };
 
     ($arg:tt) => {
-        chalk_ir::Parameter::new(
+        chalk_ir::GenericArg::new(
             &chalk_integration::interner::ChalkIr,
-            chalk_ir::ParameterKind::Ty(ty!($arg)),
+            chalk_ir::GenericArgData::Ty(ty!($arg)),
         )
     };
 }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -680,8 +680,8 @@ impl WfWellKnownGoals {
 
                         // StructName<StructP1..StructPn> = ImplSelfType
                         GoalData::EqGoal(EqGoal {
-                            a: ParameterData::Ty(def_struct).intern(interner),
-                            b: ParameterData::Ty(impl_struct.clone()).intern(interner),
+                            a: GenericArgData::Ty(def_struct).intern(interner),
+                            b: GenericArgData::Ty(impl_struct.clone()).intern(interner),
                         })
                         .intern(interner)
                     },

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -221,7 +221,7 @@ fn atc_accounting() {
 }
 
 #[test]
-fn check_parameter_kinds() {
+fn check_variable_kinds() {
     lowering_error! {
         program {
             struct Foo<'a> { }


### PR DESCRIPTION
Some notes: 
1. I decided to leave most of the entries for `*parameters*` functions and variables, because it flows better, while `parameter` was refactored into `generic_arg` where applicable. 
2. I am not sure about `ParameterEnaVariable` ( = `WithKind<I, EnaVariable<I>>`), but `GenericArgEnaVariable` is too much. All other names are open to bikeshedding; speak now, or forever hold your peace.
3. there is a suspicious place that I marked with a `FIXME(areredify)`, which I will deal with in the const generic pr  
closes #452 
