### PR TITLE
Improve coinduction handling in recursive solver

### DIFF
--- a/chalk-solve/src/recursive/search_graph.rs
+++ b/chalk-solve/src/recursive/search_graph.rs
@@ -4,8 +4,7 @@ use std::ops::IndexMut;
 use std::usize;
 
 use super::stack::StackDepth;
-use super::{Minimums, UCanonicalGoal};
-use crate::Solution;
+use super::{Answer, Minimums, UCanonicalGoal};
 use chalk_engine::fallible::{Fallible, NoSolution};
 use chalk_ir::{interner::Interner, ClausePriority};
 use rustc_hash::FxHashMap;
@@ -23,7 +22,7 @@ pub(super) struct DepthFirstNumber {
 pub(super) struct Node<I: Interner> {
     pub(crate) goal: UCanonicalGoal<I>,
 
-    pub(crate) solution: Fallible<Solution<I>>,
+    pub(crate) solution: Fallible<Answer<I>>,
     pub(crate) solution_priority: ClausePriority,
 
     /// This is `Some(X)` if we are actively exploring this node, or
@@ -88,7 +87,7 @@ impl<I: Interner> SearchGraph<I> {
     pub(crate) fn move_to_cache(
         &mut self,
         dfn: DepthFirstNumber,
-        cache: &mut FxHashMap<UCanonicalGoal<I>, Fallible<Solution<I>>>,
+        cache: &mut FxHashMap<UCanonicalGoal<I>, Fallible<Answer<I>>>,
     ) {
         debug!("move_to_cache(dfn={:?})", dfn);
         self.indices.retain(|_key, value| *value < dfn);

--- a/tests/test/coinduction.rs
+++ b/tests/test/coinduction.rs
@@ -210,15 +210,8 @@ fn coinductive_unsound1() {
 
         goal {
             forall<X> { X: C1orC2 }
-        } yields[SolverChoice::slg(3, None)] {
+        } yields {
             "No possible solution"
-        }
-
-        goal {
-            forall<X> { X: C1orC2 }
-        } yields[SolverChoice::recursive()] {
-            // FIXME(chalk#399) recursive solver doesn't handle coinduction correctly
-            "Unique; substitution [], lifetime constraints []"
         }
     }
 }
@@ -447,14 +440,8 @@ fn coinductive_multicycle4() {
 
         goal {
             forall<X> { X: Any }
-        } yields_all[SolverChoice::slg(3, None)] {
-        }
-
-        goal {
-            forall<X> { X: Any }
-        } yields[SolverChoice::recursive()] {
-            // FIXME(chalk#399) recursive solver doesn't handle coinduction correctly
-            "Unique; substitution [], lifetime constraints []"
+        } yields {
+            "No possible solution"
         }
     }
 }


### PR DESCRIPTION
This change is an attempt to handle coinduction semantics better when solving with the recursive solver. The main idea is that we introduce the concept of solutions with delayed goals that can be refined later. The main concepts behind the approach are borrowed from: https://rust-lang.github.io/chalk/book/engine/logic/coinduction.html Would love to know if I missed something obvious. 

Fix: #399

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>