### PR TITLE
Added scheduled release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,16 @@ jobs:
         rust: [stable, nightly]
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
-      - name: Setup Rust ${{ matrix.rust }}
-        run: rustup set profile minimal && rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
 
       - name: Build chalk-engine without default features
         run: cd chalk-engine && cargo build --no-default-features
@@ -69,27 +73,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
-      - name: Setup Rust stable with rustfmt
-        run: |
-          rustup set profile minimal
-          rustup update stable --no-self-update
-          rustup default stable
-          rustup component add rustfmt
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: rustfmt
 
       - name: Check formatting of all crates in the workspace
         run: cargo fmt --all -- --check
-  
+
   mdbook-linkcheck:
     name: Book link check
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish
+on:
+  schedule:
+    - cron: "0 0 * * 0" # midnight UTC on Sunday
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.PUBLISH_DEPLOY_KEY }}
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Install cargo-workspaces
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-workspaces
+
+      - name: Release
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        shell: bash
+        run: |
+          git config --global user.name "Github Action"
+          cargo workspaces version -ay --force '*' --include-merged-tags --no-git-commit --exact patch
+          export VERSION=$(cargo pkgid | sed -E 's/.*#(.*)/\1/g')
+          sed -E -i '' $'s/(# Unreleased)/\\1\\\n\\\n# Release '"$VERSION/" RELEASES.md
+          git commit -am "Release $VERSION"
+          git tag "v$VERSION"
+          git push --tags
+          cargo publish --from-git
+          cargo workspaces version -ay --force '*' --include-merged-tags --no-git-tag --pre-id dev preminor

--- a/chalk-solve/Cargo.toml
+++ b/chalk-solve/Cargo.toml
@@ -21,7 +21,7 @@ chalk-engine = { version = "0.10.1-dev", path = "../chalk-engine", optional = tr
 chalk-ir = { version = "0.10.1-dev", path = "../chalk-ir", default-features = false }
 
 [dev-dependencies]
-chalk-integration = { version = "0.10.1-dev", path = "../chalk-integration" }
+chalk-integration = { path = "../chalk-integration" }
 
 [features]
 default = ["slg-solver", "recursive-solver"]


### PR DESCRIPTION
As per the discussion on Zulip, here's the action that schedules and releases chalk every Sunday.

I used [cargo-workspaces](https://github.com/pksunkara/cargo-workspaces) for this which means if there are no changes in a week, a version will not be released. It also intelligently releases only the changes instead of everything.

You need to add 2 secrets in github for this to work:
* PERSONAL_ACCESS_TOKEN: Github personal access token that has rights to push to the master branch of this repo
* CARGO_REGISTRY_TOKEN: Crates.io token of the user who has access to publishing all the chalk crates

You can see an example release commit [here](https://github.com/pksunkara/chalk/commit/d8fdc2348d2a3abe1a987cf031a98e01a1442d8d)

cc @jackh726 @flodiebold @nikomatsakis 

I saw your message about asking me to also integrate bors-ng. While I did do that for https://github.com/clap-rs/clap, I am not sure if I can do that here without having access to settings. I could just create/edit the related config for it but it would be hard for me to debug.

**EDIT**: I realized that I would need to update `Cargo.lock` as well. Can someone confirm? While I would like to just run `cargo build` to update the `Cargo.lock`, but I think it would also update other deps, right? Is there an option to update only the local crates? I am not sure how to proceed on this.

Does running `cargo update -p {crate_name}` for each crate in workspace fix it?