### PR TITLE
Handle bound vars in builtin trait impls

### DIFF
--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -225,13 +225,7 @@ fn program_clauses_that_could_match<I: Interner>(
             }
 
             if let Some(well_known) = trait_datum.well_known {
-                builtin_traits::add_builtin_program_clauses(
-                    db,
-                    builder,
-                    well_known,
-                    trait_ref,
-                    self_ty.data(interner),
-                );
+                builtin_traits::add_builtin_program_clauses(db, builder, well_known, trait_ref);
             }
         }
         DomainGoal::Holds(WhereClause::AliasEq(alias_eq)) => match &alias_eq.alias {

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -67,7 +67,7 @@ impl<'i, I: Interner> Folder<'i, I> for Generalize<'i, I> {
         let binder_vec = &mut self.binders;
         let new_index = self.mapping.entry(bound_var).or_insert_with(|| {
             let i = binder_vec.len();
-            binder_vec.push(VariableKind::Ty);
+            binder_vec.push(VariableKind::Lifetime);
             i
         });
         let new_var = BoundVar::new(outer_binder, *new_index);

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -515,3 +515,43 @@ fn non_enumerable_traits_reorder() {
         }
     }
 }
+
+#[test]
+fn builtin_impl_enumeration() {
+    test! {
+        program {
+            #[lang(copy)]
+            trait Copy { }
+
+            #[lang(sized)]
+            trait Sized { }
+
+            #[lang(clone)]
+            trait Clone { }
+
+            impl Copy for u8 {}
+            impl Clone for u8 {}
+        }
+
+        goal {
+            exists<T> { T: Copy }
+        } yields {
+            // FIXME: wrong, e.g. &u8 is also Copy
+            "Unique; substitution [?0 := Uint(U8)]"
+        }
+
+        goal {
+            exists<T> { T: Clone }
+        } yields {
+            // FIXME: wrong, e.g. &u8 is also Clone
+            "Unique; substitution [?0 := Uint(U8)]"
+        }
+
+        goal {
+            exists<T> { T: Sized }
+        } yields {
+            // FIXME: wrong, most of the built-in types are Sized
+            "No possible solution"
+        }
+    }
+}

--- a/tests/test/tuples.rs
+++ b/tests/test/tuples.rs
@@ -82,6 +82,30 @@ fn tuples_are_sized() {
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
+
+        goal {
+            exists<T> { (T, u8): Sized }
+        } yields {
+            "Unique; for<?U0> { substitution [?0 := ^0.0], lifetime constraints [] }"
+        }
+
+        goal {
+            forall<T> { (T, u8): Sized }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            forall<T> { (u8, T): Sized }
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            forall<T> { if (T: Sized) { (u8, T): Sized } }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
     }
 }
 
@@ -89,6 +113,10 @@ fn tuples_are_sized() {
 fn tuples_are_copy() {
     test! {
         program {
+            // FIXME: If we don't declare Copy non-enumerable, `exists<T> { T:
+            // Copy }` gives wrong results, because it doesn't consider the
+            // built-in impls.
+            #[non_enumerable]
             #[lang(copy)]
             trait Copy { }
 
@@ -132,6 +160,18 @@ fn tuples_are_copy() {
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
+
+        goal {
+            exists<T> { (T, u8): Copy }
+        } yields {
+            "Ambiguous"
+        }
+
+        goal {
+            forall<T> { if (T: Copy) { (T, u8): Copy } }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
     }
 }
 
@@ -139,6 +179,7 @@ fn tuples_are_copy() {
 fn tuples_are_clone() {
     test! {
         program {
+            #[non_enumerable] // see above
             #[lang(clone)]
             trait Clone { }
 
@@ -179,6 +220,18 @@ fn tuples_are_clone() {
 
         goal {
             (u8, u8): Clone
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            exists<T> { (T, u8): Clone }
+        } yields {
+            "Ambiguous"
+        }
+
+        goal {
+            forall<T> { if (T: Clone) { (T, u8): Clone } }
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }


### PR DESCRIPTION
The builtin impls have the same problem that the dyn trait impl did, which is
that they reuse the trait ref as given. The problem with that is that the
recursive solver calls `program_clauses` with trait refs that contain bound vars
from the original goal. So the builtin impls returned clauses with free bound
vars, which is a problem. The solution is the same as for the dyn trait impls:
Use the `Generalize` folder to collect those free bound vars and basically put a
`forall` around them. To give an example:

Looking for

```
Implemented((^0.0, ^0.1): Sized)
```

previously returned something like

```
if (Implemented(^0.1: Sized)) { Implemented((^0.0, ^0.1): Sized) }
```

as a clause; now it returns

```
forall<type, type> if (Implemented(^0.1: Sized)) { Implemented((^0.0, ^0.1): Sized) }
```

(The SLG solver instantiates goals before asking for program clauses, so it has
inference variables instead of bound vars in those places.)