### PR TITLE
Generate auto trait clauses for opaque type goals

### DIFF
--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -319,6 +319,15 @@ where
     }
 }
 
+impl<I> CastTo<TypeName<I>> for OpaqueTyId<I>
+where
+    I: Interner,
+{
+    fn cast_to(self, _interner: &I) -> TypeName<I> {
+        TypeName::OpaqueType(self)
+    }
+}
+
 impl<T> CastTo<T> for &T
 where
     T: Clone + HasInterner,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -226,7 +226,9 @@ fn program_clauses_that_could_match<I: Interner>(
                 let self_ty = trait_ref.self_type_parameter(interner);
 
                 if let TyData::Alias(AliasTy::Opaque(opaque_ty)) = self_ty.data(interner) {
-                    push_auto_trait_impls_opaque(builder, trait_id, opaque_ty.opaque_ty_id)
+                    if trait_datum.is_auto_trait() {
+                        push_auto_trait_impls_opaque(builder, trait_id, opaque_ty.opaque_ty_id)
+                    }
                 } else if self_ty.bound_var(interner).is_some()
                     || self_ty.inference_var(interner).is_some()
                 {

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -126,7 +126,6 @@ impl<I: Interner> ToProgramClauses<I> for OpaqueTyDatum<I> {
     /// AliasEq(T<..> = !T<..>).
     /// Implemented(!T<..>: A).
     /// Implemented(!T<..>: B).
-    /// Implemented(!T<..>: Send) :- Implemented(HiddenTy: Send). // For all auto traits
     /// ```
     /// where `!T<..>` is the placeholder for the unnormalized type `T<..>`.
     fn to_program_clauses(&self, builder: &mut ClauseBuilder<'_, I>) {
@@ -142,7 +141,7 @@ impl<I: Interner> ToProgramClauses<I> for OpaqueTyDatum<I> {
             let alias_placeholder_ty = Ty::new(
                 interner,
                 ApplicationTy {
-                    name: TypeName::OpaqueType(self.opaque_ty_id),
+                    name: self.opaque_ty_id.cast(interner),
                     substitution,
                 },
             );

--- a/tests/test/opaque_types.rs
+++ b/tests/test/opaque_types.rs
@@ -98,3 +98,34 @@ fn opaque_generics() {
 
     }
 }
+
+#[test]
+fn opaque_auto_traits() {
+    test! {
+        program {
+            struct Bar { }
+            struct Baz { }
+            trait Trait { }
+
+            #[auto]
+            trait Send { }
+
+            impl !Send for Baz { }
+
+            opaque type Opaque1: Trait = Bar;
+            opaque type Opaque2: Trait = Baz;
+        }
+
+        goal {
+            Opaque1: Send
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            Opaque2: Send
+        } yields {
+            "No possible solution"
+        }
+    }
+}


### PR DESCRIPTION
When you have `opaque type Foo: Trait = Bar`,
solving the goal `Foo: Send`
will generate `Foo: Send :- Bar: Send`