### PR TITLE
Check for trivial cycles in persue_answer

### DIFF
--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -1314,9 +1314,9 @@ impl<'forest, C: Context + 'forest, CO: ContextOps<C> + 'forest> SolveState<'for
             return None;
         }
 
-        let table = self.stack.top().table;
         let table_goal = &self.forest.tables[table].table_goal;
 
+        //FIXME: Avoid double canonicalization
         let filtered_delayed_subgoals = delayed_subgoals
             .into_iter()
             .filter(|delayed_subgoal| {

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -236,10 +236,6 @@ impl<I: Interner> context::ResolventOps<SlgContext<I>> for TruncatingInferenceTa
             .infer
             .instantiate_canonical(interner, &canonical_answer_subst);
 
-        let table_goal = self
-            .infer
-            .instantiate_canonical(interner, &answer_table_goal);
-
         AnswerSubstitutor::substitute(
             interner,
             &mut self.infer,
@@ -250,18 +246,9 @@ impl<I: Interner> context::ResolventOps<SlgContext<I>> for TruncatingInferenceTa
             selected_goal,
         )?;
         ex_clause.constraints.extend(answer_constraints);
-
-        for delayed_subgoal in delayed_subgoals {
-            // FIXME: is this always valid or would we ever run
-            // into an issue with normalization? (Would this even
-            // be a "trivial self-cycle"?)
-            // Only add the delayed_subgoals to the ex-clause if
-            // it isn't a trivial self-cycle
-            if delayed_subgoal.goal != table_goal.goal {
-                ex_clause.delayed_subgoals.push(delayed_subgoal);
-            }
-        }
-
+        // at that point we should only have goals that stemmed
+        // from non trivial self cycles
+        ex_clause.delayed_subgoals.extend(delayed_subgoals);
         Ok(())
     }
 }


### PR DESCRIPTION
This change ensures that we do not add trivial coinductive goals to the answer at all and filter them in `pursue_answer`. This allows us to have this check performed in a single place as @jackh726 was suggesting. 

Fix #313

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>