### PR TITLE
Integer and float variable kinds

### DIFF
--- a/book/src/engine/logic.md
+++ b/book/src/engine/logic.md
@@ -34,7 +34,7 @@ As either `Answer`s are found for the selected `Table`, entries on the stack are
 
 As mentioned before, whenever a new `Goal` is encounted, a new [`Table`] is
 created to store current and future answers. First, the [`Goal`] is converted into
-an [`HhGoal`]. If it can be simplified, then a `Strand` with one or more
+an `HhGoal`. If it can be simplified, then a `Strand` with one or more
 subgoals will be generated and can be followed as above. Otherwise, if it is a
 `DomainGoal` (see above), then
 [`program_clauses`](https://rust-lang.github.io/chalk/chalk_engine/context/trait.ContextOps.html#tymethod.program_clauses)
@@ -123,7 +123,6 @@ For much more in-depth
 
 [`Strand`]: https://rust-lang.github.io/chalk/chalk_engine/strand/struct.Strand.html
 [`Context`]: https://rust-lang.github.io/chalk/chalk_engine/context/trait.Context.html
-[`HhGoal`]: https://rust-lang.github.io/chalk/chalk_engine/hh/enum.HhGoal.html
 [`Stack`]: https://rust-lang.github.io/chalk/chalk_engine/stack/struct.Stack.html
 [`StackEntry`]: https://rust-lang.github.io/chalk/chalk_engine/stack/struct.StackEntry.html
 [`Table`]: https://rust-lang.github.io/chalk/chalk_engine/table/struct.Table.html

--- a/book/src/engine/major_concepts.md
+++ b/book/src/engine/major_concepts.md
@@ -16,7 +16,7 @@ opaque to the engine internals. Functions in the trait are agnostic to specific
 program or environment details, since they lack a `&self` argument.
 
 To give an example, there is an associated [`Goal`] type. However, Chalk doesn't
-know how to solve this. Instead, it has to be converted an [`HhGoal`] via the
+know how to solve this. Instead, it has to be converted an `HhGoal` via the
 `Context::into_hh_goal` function. This will be coverted more in the `Goals`
 section.
 
@@ -38,7 +38,7 @@ change the state of the logic itself.
 ## Goals
 
 A "goal" in Chalk can be thought of as "something we want to prove". The engine
-itself understands [`HhGoal`]s. `HHGoal`s consist of the most basic logic,
+itself understands `HhGoal`s. `HHGoal`s consist of the most basic logic,
 such as introducing Binders (`Forall` or `Exists`) or combining goals (`All`).
 On the other hand, `Context::Goal` represents an opaque goal generated
 externally. As such, it may contain any extra information or may be interned.
@@ -111,7 +111,6 @@ stack).
 [`Context`]: https://rust-lang.github.io/chalk/chalk_engine/context/trait.Context.html
 [`ContextOps`]: https://rust-lang.github.io/chalk/chalk_engine/context/trait.ContextOps.html
 [`InferenceTable`]: https://rust-lang.github.io/chalk/chalk_engine/context/trait.InferenceTable.html
-[`HhGoal`]: https://rust-lang.github.io/chalk/chalk_engine/hh/enum.HhGoal.html
 [`Solution`]: https://rust-lang.github.io/chalk/chalk_engine/context/trait.Context.html#associatedtype.Solution
 [`ExClause`]: https://rust-lang.github.io/chalk/chalk_engine/struct.ExClause.html
 [`Strand`]: https://rust-lang.github.io/chalk/chalk_engine/strand/struct.Strand.html

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -3,7 +3,7 @@ use chalk_ir::cast::{Cast, Caster};
 use chalk_ir::interner::HasInterner;
 use chalk_ir::{
     self, AdtId, AssocTypeId, BoundVar, ClausePriority, DebruijnIndex, FnDefId, ImplId, OpaqueTyId,
-    QuantifiedWhereClauses, Substitution, ToGenericArg, TraitId,
+    QuantifiedWhereClauses, Substitution, ToGenericArg, TraitId, TyKind,
 };
 use chalk_parse::ast::*;
 use chalk_solve::rust_ir::{
@@ -90,7 +90,7 @@ impl<'k> Env<'k> {
         if let Some(p) = self.parameter_map.get(&name.str) {
             let b = p.skip_kind();
             return match &p.kind {
-                chalk_ir::VariableKind::Ty => Ok(chalk_ir::TyData::BoundVar(*b)
+                chalk_ir::VariableKind::Ty(_) => Ok(chalk_ir::TyData::BoundVar(*b)
                     .intern(interner)
                     .cast(interner)),
                 chalk_ir::VariableKind::Lifetime => Ok(chalk_ir::LifetimeData::BoundVar(*b)
@@ -506,7 +506,7 @@ impl LowerProgram for Program {
                             let bounds: chalk_ir::Binders<Vec<chalk_ir::Binders<_>>> = env
                                 .in_binders(
                                     Some(chalk_ir::WithKind::new(
-                                        chalk_ir::VariableKind::Ty,
+                                        chalk_ir::VariableKind::Ty(TyKind::General),
                                         Atom::from(FIXME_SELF),
                                     )),
                                     |env1| {
@@ -681,7 +681,7 @@ impl LowerParameterMap for AssocTyValue {
 impl LowerParameterMap for TraitDefn {
     fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
         Some(chalk_ir::WithKind::new(
-            chalk_ir::VariableKind::Ty,
+            chalk_ir::VariableKind::Ty(TyKind::General),
             Atom::from(SELF),
         ))
     }
@@ -717,9 +717,14 @@ trait LowerVariableKind {
 impl LowerVariableKind for VariableKind {
     fn lower(&self) -> chalk_ir::WithKind<ChalkIr, Ident> {
         match self {
-            VariableKind::Ty(n) => {
-                chalk_ir::WithKind::new(chalk_ir::VariableKind::Ty, n.str.clone())
-            }
+            VariableKind::Ty(n) => chalk_ir::WithKind::new(
+                chalk_ir::VariableKind::Ty(chalk_ir::TyKind::General),
+                n.str.clone(),
+            ),
+            VariableKind::IntegerTy(n) => chalk_ir::WithKind::new(
+                chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Integer),
+                n.str.clone(),
+            ),
             VariableKind::Lifetime(n) => {
                 chalk_ir::WithKind::new(chalk_ir::VariableKind::Lifetime, n.str.clone())
             }
@@ -1290,7 +1295,7 @@ impl LowerTy for Ty {
                 bounds: env.in_binders(
                     // FIXME: Figure out a proper name for this type parameter
                     Some(chalk_ir::WithKind::new(
-                        chalk_ir::VariableKind::Ty,
+                        chalk_ir::VariableKind::Ty(TyKind::General),
                         Atom::from(FIXME_SELF),
                     )),
                     |env| {
@@ -1820,6 +1825,7 @@ impl Kinded for VariableKind {
     fn kind(&self) -> Kind {
         match *self {
             VariableKind::Ty(_) => Kind::Ty,
+            VariableKind::IntegerTy(_) => Kind::Ty,
             VariableKind::Lifetime(_) => Kind::Lifetime,
             VariableKind::Const(_) => Kind::Const,
         }
@@ -1829,7 +1835,7 @@ impl Kinded for VariableKind {
 impl Kinded for chalk_ir::VariableKind<ChalkIr> {
     fn kind(&self) -> Kind {
         match self {
-            chalk_ir::VariableKind::Ty => Kind::Ty,
+            chalk_ir::VariableKind::Ty(_) => Kind::Ty,
             chalk_ir::VariableKind::Lifetime => Kind::Lifetime,
             chalk_ir::VariableKind::Const(_) => Kind::Const,
         }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -725,6 +725,10 @@ impl LowerVariableKind for VariableKind {
                 chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Integer),
                 n.str.clone(),
             ),
+            VariableKind::FloatTy(n) => chalk_ir::WithKind::new(
+                chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Float),
+                n.str.clone(),
+            ),
             VariableKind::Lifetime(n) => {
                 chalk_ir::WithKind::new(chalk_ir::VariableKind::Lifetime, n.str.clone())
             }
@@ -1826,6 +1830,7 @@ impl Kinded for VariableKind {
         match *self {
             VariableKind::Ty(_) => Kind::Ty,
             VariableKind::IntegerTy(_) => Kind::Ty,
+            VariableKind::FloatTy(_) => Kind::Ty,
             VariableKind::Lifetime(_) => Kind::Lifetime,
             VariableKind::Const(_) => Kind::Const,
         }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -179,7 +179,8 @@ impl<I: Interner> Debug for TyData<I> {
         match self {
             TyData::BoundVar(db) => write!(fmt, "{:?}", db),
             TyData::Dyn(clauses) => write!(fmt, "{:?}", clauses),
-            TyData::InferenceVar(var) => write!(fmt, "{:?}", var),
+            TyData::InferenceVar(var, TyKind::General) => write!(fmt, "{:?}", var),
+            TyData::InferenceVar(var, TyKind::Integer) => write!(fmt, "{:?}i", var),
             TyData::Apply(apply) => write!(fmt, "{:?}", apply),
             TyData::Alias(alias) => write!(fmt, "{:?}", alias),
             TyData::Placeholder(index) => write!(fmt, "{:?}", index),
@@ -276,7 +277,8 @@ impl<'a, I: Interner> Debug for VariableKindsInnerDebug<'a, I> {
                 write!(fmt, ", ")?;
             }
             match binder {
-                VariableKind::Ty => write!(fmt, "type")?,
+                VariableKind::Ty(TyKind::General) => write!(fmt, "type")?,
+                VariableKind::Ty(TyKind::Integer) => write!(fmt, "integer type")?,
                 VariableKind::Lifetime => write!(fmt, "lifetime")?,
                 VariableKind::Const(ty) => write!(fmt, "const: {:?}", ty)?,
             }
@@ -765,7 +767,8 @@ impl<I: Interner> Debug for GenericArgData<I> {
 impl<I: Interner> Debug for VariableKind<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
-            VariableKind::Ty => write!(fmt, "type"),
+            VariableKind::Ty(TyKind::General) => write!(fmt, "type"),
+            VariableKind::Ty(TyKind::Integer) => write!(fmt, "integer type"),
             VariableKind::Lifetime => write!(fmt, "lifetime"),
             VariableKind::Const(ty) => write!(fmt, "const: {:?}", ty),
         }
@@ -776,7 +779,8 @@ impl<I: Interner, T: Debug> Debug for WithKind<I, T> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         let value = self.skip_kind();
         match &self.kind {
-            VariableKind::Ty => write!(fmt, "{:?} with kind type", value),
+            VariableKind::Ty(TyKind::General) => write!(fmt, "{:?} with kind type", value),
+            VariableKind::Ty(TyKind::Integer) => write!(fmt, "{:?} with kind integer type", value),
             VariableKind::Lifetime => write!(fmt, "{:?} with kind lifetime", value),
             VariableKind::Const(ty) => write!(fmt, "{:?} with kind {:?}", value, ty),
         }

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -181,6 +181,7 @@ impl<I: Interner> Debug for TyData<I> {
             TyData::Dyn(clauses) => write!(fmt, "{:?}", clauses),
             TyData::InferenceVar(var, TyKind::General) => write!(fmt, "{:?}", var),
             TyData::InferenceVar(var, TyKind::Integer) => write!(fmt, "{:?}i", var),
+            TyData::InferenceVar(var, TyKind::Float) => write!(fmt, "{:?}f", var),
             TyData::Apply(apply) => write!(fmt, "{:?}", apply),
             TyData::Alias(alias) => write!(fmt, "{:?}", alias),
             TyData::Placeholder(index) => write!(fmt, "{:?}", index),
@@ -279,6 +280,7 @@ impl<'a, I: Interner> Debug for VariableKindsInnerDebug<'a, I> {
             match binder {
                 VariableKind::Ty(TyKind::General) => write!(fmt, "type")?,
                 VariableKind::Ty(TyKind::Integer) => write!(fmt, "integer type")?,
+                VariableKind::Ty(TyKind::Float) => write!(fmt, "float type")?,
                 VariableKind::Lifetime => write!(fmt, "lifetime")?,
                 VariableKind::Const(ty) => write!(fmt, "const: {:?}", ty)?,
             }
@@ -769,6 +771,7 @@ impl<I: Interner> Debug for VariableKind<I> {
         match self {
             VariableKind::Ty(TyKind::General) => write!(fmt, "type"),
             VariableKind::Ty(TyKind::Integer) => write!(fmt, "integer type"),
+            VariableKind::Ty(TyKind::Float) => write!(fmt, "float type"),
             VariableKind::Lifetime => write!(fmt, "lifetime"),
             VariableKind::Const(ty) => write!(fmt, "const: {:?}", ty),
         }
@@ -781,6 +784,7 @@ impl<I: Interner, T: Debug> Debug for WithKind<I, T> {
         match &self.kind {
             VariableKind::Ty(TyKind::General) => write!(fmt, "{:?} with kind type", value),
             VariableKind::Ty(TyKind::Integer) => write!(fmt, "{:?} with kind integer type", value),
+            VariableKind::Ty(TyKind::Float) => write!(fmt, "{:?} with kind float type", value),
             VariableKind::Lifetime => write!(fmt, "{:?} with kind lifetime", value),
             VariableKind::Const(ty) => write!(fmt, "{:?} with kind {:?}", value, ty),
         }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -267,12 +267,13 @@ where
     fn fold_inference_ty(
         &mut self,
         var: InferenceVar,
+        kind: TyKind,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Ty<TI>> {
         if self.forbid_inference_vars() {
             panic!("unexpected inference type `{:?}`", var)
         } else {
-            Ok(var.to_ty(self.target_interner()))
+            Ok(var.to_ty(self.target_interner(), kind))
         }
     }
 
@@ -416,7 +417,7 @@ where
             }
             TyData::Dyn(clauses) => Ok(TyData::Dyn(clauses.fold_with(folder, outer_binder)?)
                 .intern(folder.target_interner())),
-            TyData::InferenceVar(var) => folder.fold_inference_ty(*var, outer_binder),
+            TyData::InferenceVar(var, kind) => folder.fold_inference_ty(*var, *kind, outer_binder),
             TyData::Apply(apply) => Ok(TyData::Apply(apply.fold_with(folder, outer_binder)?)
                 .intern(folder.target_interner())),
             TyData::Placeholder(ui) => Ok(folder.fold_free_placeholder_ty(*ui, outer_binder)?),

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -357,6 +357,17 @@ impl<I: Interner> Ty<I> {
         }
     }
 
+    /// Returns true if this is a `FloatTy`
+    pub fn is_float(&self, interner: &I) -> bool {
+        match self.data(interner) {
+            TyData::Apply(ApplicationTy {
+                name: TypeName::Scalar(Scalar::Float(_)),
+                ..
+            }) => true,
+            _ => false,
+        }
+    }
+
     /// True if this type contains "bound" types/lifetimes, and hence
     /// needs to be shifted across binders. This is a very inefficient
     /// check, intended only for debug assertions, because I am lazy.
@@ -925,7 +936,7 @@ impl<I: Interner> ApplicationTy<I> {
     }
 }
 
-/// Represents some extra knowledge we may have about the variable.
+/// Represents some extra knowledge we may have about the type variable.
 /// ```ignore
 /// let x: &[u32];
 /// let i = 1;
@@ -939,6 +950,7 @@ impl<I: Interner> ApplicationTy<I> {
 pub enum TyKind {
     General,
     Integer,
+    Float,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -320,7 +320,7 @@ impl<I: Interner> Ty<I> {
 
     /// If this is a `TyData::InferenceVar(d)`, returns `Some(d)` else `None`.
     pub fn inference_var(&self, interner: &I) -> Option<InferenceVar> {
-        if let TyData::InferenceVar(depth) = self.data(interner) {
+        if let TyData::InferenceVar(depth, _) = self.data(interner) {
             Some(*depth)
         } else {
             None
@@ -330,7 +330,7 @@ impl<I: Interner> Ty<I> {
     /// Returns true if this is a `BoundVar` or `InferenceVar`.
     pub fn is_var(&self, interner: &I) -> bool {
         match self.data(interner) {
-            TyData::BoundVar(_) | TyData::InferenceVar(_) => true,
+            TyData::BoundVar(_) | TyData::InferenceVar(_, _) => true,
             _ => false,
         }
     }
@@ -338,6 +338,21 @@ impl<I: Interner> Ty<I> {
     pub fn is_alias(&self, interner: &I) -> bool {
         match self.data(interner) {
             TyData::Alias(..) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if this is an `IntTy` or `UintTy`
+    pub fn is_integer(&self, interner: &I) -> bool {
+        match self.data(interner) {
+            TyData::Apply(ApplicationTy {
+                name: TypeName::Scalar(Scalar::Int(_)),
+                ..
+            })
+            | TyData::Apply(ApplicationTy {
+                name: TypeName::Scalar(Scalar::Uint(_)),
+                ..
+            }) => true,
             _ => false,
         }
     }
@@ -390,7 +405,7 @@ pub enum TyData<I: Interner> {
     BoundVar(BoundVar),
 
     /// Inference variable defined in the current inference context.
-    InferenceVar(InferenceVar),
+    InferenceVar(InferenceVar, TyKind),
 }
 
 impl<I: Interner> TyData<I> {
@@ -682,8 +697,8 @@ impl InferenceVar {
         self.index
     }
 
-    pub fn to_ty<I: Interner>(self, interner: &I) -> Ty<I> {
-        TyData::<I>::InferenceVar(self).intern(interner)
+    pub fn to_ty<I: Interner>(self, interner: &I, kind: TyKind) -> Ty<I> {
+        TyData::<I>::InferenceVar(self, kind).intern(interner)
     }
 
     pub fn to_lifetime<I: Interner>(self, interner: &I) -> Lifetime<I> {
@@ -910,9 +925,25 @@ impl<I: Interner> ApplicationTy<I> {
     }
 }
 
+/// Represents some extra knowledge we may have about the variable.
+/// ```ignore
+/// let x: &[u32];
+/// let i = 1;
+/// x[i]
+/// ```
+/// In this example, `i` is known to be some type of integer. We can infer that
+/// it is `usize` because that is the only integer type that slices have an
+/// `Index` impl for. `i` would have a `TyKind` of `Integer` to guide the
+/// inference process.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TyKind {
+    General,
+    Integer,
+}
+
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum VariableKind<I: Interner> {
-    Ty,
+    Ty(TyKind),
     Lifetime,
     Const(Ty<I>),
 }
@@ -920,7 +951,7 @@ pub enum VariableKind<I: Interner> {
 impl<I: Interner> VariableKind<I> {
     fn to_bound_variable(&self, interner: &I, bound_var: BoundVar) -> GenericArg<I> {
         match self {
-            VariableKind::Ty => {
+            VariableKind::Ty(_) => {
                 GenericArgData::Ty(TyData::BoundVar(bound_var).intern(interner)).intern(interner)
             }
             VariableKind::Lifetime => {
@@ -1524,7 +1555,7 @@ impl<T: HasInterner> Binders<T> {
         // The new variable is at the front and everything afterwards is shifted up by 1
         let new_var = TyData::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, 0)).intern(interner);
         let value = op(new_var);
-        let binders = VariableKinds::from(interner, iter::once(VariableKind::Ty));
+        let binders = VariableKinds::from(interner, iter::once(VariableKind::Ty(TyKind::General)));
         Binders { binders, value }
     }
 
@@ -1940,7 +1971,7 @@ impl<T: HasInterner> UCanonical<T> {
                 .map(|(index, pk)| {
                     let bound_var = BoundVar::new(DebruijnIndex::INNERMOST, index);
                     match &pk.kind {
-                        VariableKind::Ty => {
+                        VariableKind::Ty(_) => {
                             GenericArgData::Ty(TyData::BoundVar(bound_var).intern(interner))
                                 .intern(interner)
                         }

--- a/chalk-ir/src/visit.rs
+++ b/chalk-ir/src/visit.rs
@@ -273,7 +273,7 @@ where
                 }
             }
             TyData::Dyn(clauses) => clauses.visit_with(visitor, outer_binder),
-            TyData::InferenceVar(var) => visitor.visit_inference_var(*var, outer_binder),
+            TyData::InferenceVar(var, _) => visitor.visit_inference_var(*var, outer_binder),
             TyData::Apply(apply) => apply.visit_with(visitor, outer_binder),
             TyData::Placeholder(ui) => visitor.visit_free_placeholder(*ui, outer_binder),
             TyData::Alias(proj) => proj.visit_with(visitor, outer_binder),

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -308,14 +308,14 @@ impl<I: Interner> Zip<I> for VariableKind<I> {
         I: 'i,
     {
         match (a, b) {
-            (VariableKind::Ty, VariableKind::Ty) => Ok(()),
+            (VariableKind::Ty(a), VariableKind::Ty(b)) if a == b => Ok(()),
             (VariableKind::Lifetime, VariableKind::Lifetime) => Ok(()),
             (VariableKind::Const(ty_a), VariableKind::Const(ty_b)) => {
                 Zip::zip_with(zipper, ty_a, ty_b)
             }
-            (VariableKind::Ty, _) | (VariableKind::Lifetime, _) | (VariableKind::Const(_), _) => {
-                panic!("zipping things of mixed kind")
-            }
+            (VariableKind::Ty(_), _)
+            | (VariableKind::Lifetime, _)
+            | (VariableKind::Const(_), _) => panic!("zipping things of mixed kind"),
         }
     }
 }

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -100,6 +100,7 @@ pub struct OpaqueTyDefn {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum VariableKind {
     Ty(Identifier),
+    IntegerTy(Identifier),
     Lifetime(Identifier),
     Const(Identifier),
 }

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -101,6 +101,7 @@ pub struct OpaqueTyDefn {
 pub enum VariableKind {
     Ty(Identifier),
     IntegerTy(Identifier),
+    FloatTy(Identifier),
     Lifetime(Identifier),
     Const(Identifier),
 }

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -201,6 +201,7 @@ VariableKind: VariableKind = {
     Id => VariableKind::Ty(<>),
     LifetimeId => VariableKind::Lifetime(<>),
     "const" <id:Id> => VariableKind::Const(id),
+    "int" <id:Id> => VariableKind::IntegerTy(id),
 };
 
 AssocTyValue: AssocTyValue = {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -202,6 +202,7 @@ VariableKind: VariableKind = {
     LifetimeId => VariableKind::Lifetime(<>),
     "const" <id:Id> => VariableKind::Const(id),
     "int" <id:Id> => VariableKind::IntegerTy(id),
+    "float" <id:Id> => VariableKind::FloatTy(id),
 };
 
 AssocTyValue: AssocTyValue = {

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -260,7 +260,7 @@ fn program_clauses_that_could_match<I: Interner>(
                         }
                         _ => {}
                     },
-                    TyData::InferenceVar(_) | TyData::BoundVar(_) => {
+                    TyData::InferenceVar(_, _) | TyData::BoundVar(_) => {
                         return Err(Floundered);
                     }
                     _ => {}
@@ -459,7 +459,7 @@ fn match_ty<I: Interner>(
                 .map(|ty| match_ty(builder, environment, &ty))
                 .collect::<Result<_, Floundered>>()?;
         }
-        TyData::BoundVar(_) | TyData::InferenceVar(_) => return Err(Floundered),
+        TyData::BoundVar(_) | TyData::InferenceVar(_, _) => return Err(Floundered),
         TyData::Dyn(_) => {}
     })
 }

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -149,7 +149,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
     pub fn push_bound_ty(&mut self, op: impl FnOnce(&mut Self, Ty<I>)) {
         let interner = self.interner();
         let binders = Binders::new(
-            VariableKinds::from(interner, iter::once(VariableKind::Ty)),
+            VariableKinds::from(interner, iter::once(VariableKind::Ty(TyKind::General))),
             PhantomData::<I>,
         );
         self.push_binders(&binders, |this, PhantomData| {

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -70,7 +70,7 @@ impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
             // bounds story around `dyn Trait` types.
             TyData::Dyn(_) => (),
 
-            TyData::Function(_) | TyData::BoundVar(_) | TyData::InferenceVar(_) => (),
+            TyData::Function(_) | TyData::BoundVar(_) | TyData::InferenceVar(_, _) => (),
         }
     }
 

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -10,7 +10,7 @@ use chalk_base::results::Fallible;
 use chalk_ir::{
     fold::{Fold, Folder},
     interner::{HasInterner, Interner},
-    Binders, BoundVar, DebruijnIndex, Lifetime, LifetimeData, Ty, TyData, VariableKind,
+    Binders, BoundVar, DebruijnIndex, Lifetime, LifetimeData, Ty, TyData, TyKind, VariableKind,
     VariableKinds,
 };
 use rustc_hash::FxHashMap;
@@ -52,7 +52,7 @@ impl<'i, I: Interner> Folder<'i, I> for Generalize<'i, I> {
         let binder_vec = &mut self.binders;
         let new_index = self.mapping.entry(bound_var).or_insert_with(|| {
             let i = binder_vec.len();
-            binder_vec.push(VariableKind::Ty);
+            binder_vec.push(VariableKind::Ty(TyKind::General));
             i
         });
         let new_var = BoundVar::new(outer_binder, *new_index);

--- a/chalk-solve/src/infer.rs
+++ b/chalk-solve/src/infer.rs
@@ -218,7 +218,7 @@ impl<I: Interner> ParameterEnaVariableExt<I> for ParameterEnaVariable<I> {
         // we are matching on kind, so skipping it is fine
         let ena_variable = self.skip_kind();
         match &self.kind {
-            VariableKind::Ty(kind) => ena_variable.to_ty(interner, *kind).cast(interner),
+            VariableKind::Ty(kind) => ena_variable.to_ty_with_kind(interner, *kind).cast(interner),
             VariableKind::Lifetime => ena_variable.to_lifetime(interner).cast(interner),
             VariableKind::Const(ty) => ena_variable.to_const(interner, ty.clone()).cast(interner),
         }

--- a/chalk-solve/src/infer.rs
+++ b/chalk-solve/src/infer.rs
@@ -218,7 +218,7 @@ impl<I: Interner> ParameterEnaVariableExt<I> for ParameterEnaVariable<I> {
         // we are matching on kind, so skipping it is fine
         let ena_variable = self.skip_kind();
         match &self.kind {
-            VariableKind::Ty => ena_variable.to_ty(interner).cast(interner),
+            VariableKind::Ty(kind) => ena_variable.to_ty(interner, *kind).cast(interner),
             VariableKind::Lifetime => ena_variable.to_lifetime(interner).cast(interner),
             VariableKind::Const(ty) => ena_variable.to_const(interner, ty.clone()).cast(interner),
         }

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -147,11 +147,13 @@ where
     fn fold_inference_ty(
         &mut self,
         var: InferenceVar,
+        kind: TyKind,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Ty<I>> {
         debug_heading!(
-            "fold_inference_ty(depth={:?}, binders={:?})",
+            "fold_inference_ty(depth={:?}, kind={:?}, binders={:?})",
             var,
+            kind,
             outer_binder
         );
         let interner = self.interner;
@@ -169,7 +171,7 @@ where
                 // and then map `root_var` to a fresh index that is
                 // unique to this quantification.
                 let free_var =
-                    ParameterEnaVariable::new(VariableKind::Ty, self.table.unify.find(var));
+                    ParameterEnaVariable::new(VariableKind::Ty(kind), self.table.unify.find(var));
 
                 let bound_var = BoundVar::new(DebruijnIndex::INNERMOST, self.add(free_var));
                 debug!("not yet unified: position={:?}", bound_var);

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -95,7 +95,7 @@ impl<I: Interner> InferenceTable<I> {
                         let lt = placeholder_idx.to_lifetime(interner);
                         lt.cast(interner)
                     }
-                    VariableKind::Ty => placeholder_idx.to_ty(interner).cast(interner),
+                    VariableKind::Ty(_) => placeholder_idx.to_ty(interner).cast(interner),
                     VariableKind::Const(ty) => {
                         placeholder_idx.to_const(interner, ty).cast(interner)
                     }

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -150,7 +150,7 @@ where
             .inverted_ty
             .entry(universe)
             .or_insert_with(|| table.new_variable(universe.ui))
-            .to_ty(self.interner(), TyKind::General)
+            .to_ty(self.interner())
             .shifted_in(self.interner()))
     }
 

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -150,7 +150,7 @@ where
             .inverted_ty
             .entry(universe)
             .or_insert_with(|| table.new_variable(universe.ui))
-            .to_ty(self.interner())
+            .to_ty(self.interner(), TyKind::General)
             .shifted_in(self.interner()))
     }
 

--- a/chalk-solve/src/infer/normalize_deep.rs
+++ b/chalk-solve/src/infer/normalize_deep.rs
@@ -47,6 +47,7 @@ where
     fn fold_inference_ty(
         &mut self,
         var: InferenceVar,
+        kind: TyKind,
         _outer_binder: DebruijnIndex,
     ) -> Fallible<Ty<I>> {
         let interner = self.interner;
@@ -55,7 +56,7 @@ where
                 .assert_ty_ref(interner)
                 .fold_with(self, DebruijnIndex::INNERMOST)?
                 .shifted_in(interner)), // FIXME shift
-            None => Ok(var.to_ty(interner)),
+            None => Ok(var.to_ty(interner, kind)),
         }
     }
 

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -9,8 +9,8 @@ fn infer() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner);
-    let b = table.new_variable(U0).to_ty(interner);
+    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let b = table.new_variable(U0).to_ty(interner, TyKind::General);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
@@ -33,7 +33,7 @@ fn universe_error() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner);
+    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
     table
         .unify(interner, &environment0, &a, &ty!(placeholder 1))
         .unwrap_err();
@@ -45,7 +45,7 @@ fn cycle_error() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner);
+    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr a)))
         .unwrap_err();
@@ -62,8 +62,8 @@ fn cycle_indirect() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner);
-    let b = table.new_variable(U0).to_ty(interner);
+    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let b = table.new_variable(U0).to_ty(interner, TyKind::General);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
@@ -76,8 +76,8 @@ fn universe_error_indirect_1() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner);
-    let b = table.new_variable(U1).to_ty(interner);
+    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let b = table.new_variable(U1).to_ty(interner, TyKind::General);
     table
         .unify(interner, &environment0, &b, &ty!(placeholder 1))
         .unwrap();
@@ -90,8 +90,8 @@ fn universe_error_indirect_2() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner);
-    let b = table.new_variable(U1).to_ty(interner);
+    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let b = table.new_variable(U1).to_ty(interner, TyKind::General);
     table.unify(interner, &environment0, &a, &b).unwrap();
     table
         .unify(interner, &environment0, &b, &ty!(placeholder 1))
@@ -104,8 +104,8 @@ fn universe_promote() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner);
-    let b = table.new_variable(U1).to_ty(interner);
+    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let b = table.new_variable(U1).to_ty(interner, TyKind::General);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
@@ -125,8 +125,8 @@ fn universe_promote_bad() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner);
-    let b = table.new_variable(U1).to_ty(interner);
+    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let b = table.new_variable(U1).to_ty(interner, TyKind::General);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
@@ -143,7 +143,7 @@ fn projection_eq() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner);
+    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
 
     // expect an error ("cycle during unification")
     table
@@ -184,9 +184,9 @@ fn quantify_simple() {
             binders: CanonicalVarKinds::from(
                 interner,
                 vec![
-                    CanonicalVarKind::new(VariableKind::Ty, U2),
-                    CanonicalVarKind::new(VariableKind::Ty, U1),
-                    CanonicalVarKind::new(VariableKind::Ty, U0),
+                    CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U2),
+                    CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U1),
+                    CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U0),
                 ]
             ),
         }
@@ -199,10 +199,10 @@ fn quantify_bound() {
     let mut table = make_table();
     let environment0 = Environment::new(interner);
 
-    let v0 = table.new_variable(U0).to_ty(interner);
-    let v1 = table.new_variable(U1).to_ty(interner);
-    let v2a = table.new_variable(U2).to_ty(interner);
-    let v2b = table.new_variable(U2).to_ty(interner);
+    let v0 = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let v1 = table.new_variable(U1).to_ty(interner, TyKind::General);
+    let v2a = table.new_variable(U2).to_ty(interner, TyKind::General);
+    let v2b = table.new_variable(U2).to_ty(interner, TyKind::General);
 
     table
         .unify(
@@ -225,9 +225,9 @@ fn quantify_bound() {
             binders: CanonicalVarKinds::from(
                 interner,
                 vec![
-                    CanonicalVarKind::new(VariableKind::Ty, U1),
-                    CanonicalVarKind::new(VariableKind::Ty, U0),
-                    CanonicalVarKind::new(VariableKind::Ty, U2),
+                    CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U1),
+                    CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U0),
+                    CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U2),
                 ]
             ),
         }
@@ -248,8 +248,8 @@ fn quantify_ty_under_binder() {
         .unify(
             interner,
             &environment0,
-            &v0.to_ty(interner),
-            &v1.to_ty(interner),
+            &v0.to_ty(interner, TyKind::General),
+            &v1.to_ty(interner, TyKind::General),
         )
         .unwrap();
 
@@ -269,7 +269,7 @@ fn quantify_ty_under_binder() {
             binders: CanonicalVarKinds::from(
                 interner,
                 vec![
-                    CanonicalVarKind::new(VariableKind::Ty, U0),
+                    CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U0),
                     CanonicalVarKind::new(VariableKind::Lifetime, U0)
                 ]
             ),

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -9,8 +9,8 @@ fn infer() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
-    let b = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let a = table.new_variable(U0).to_ty(interner);
+    let b = table.new_variable(U0).to_ty(interner);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
@@ -33,7 +33,7 @@ fn universe_error() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let a = table.new_variable(U0).to_ty(interner);
     table
         .unify(interner, &environment0, &a, &ty!(placeholder 1))
         .unwrap_err();
@@ -45,7 +45,7 @@ fn cycle_error() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let a = table.new_variable(U0).to_ty(interner);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr a)))
         .unwrap_err();
@@ -62,8 +62,8 @@ fn cycle_indirect() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
-    let b = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let a = table.new_variable(U0).to_ty(interner);
+    let b = table.new_variable(U0).to_ty(interner);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
@@ -76,8 +76,8 @@ fn universe_error_indirect_1() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
-    let b = table.new_variable(U1).to_ty(interner, TyKind::General);
+    let a = table.new_variable(U0).to_ty(interner);
+    let b = table.new_variable(U1).to_ty(interner);
     table
         .unify(interner, &environment0, &b, &ty!(placeholder 1))
         .unwrap();
@@ -90,8 +90,8 @@ fn universe_error_indirect_2() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
-    let b = table.new_variable(U1).to_ty(interner, TyKind::General);
+    let a = table.new_variable(U0).to_ty(interner);
+    let b = table.new_variable(U1).to_ty(interner);
     table.unify(interner, &environment0, &a, &b).unwrap();
     table
         .unify(interner, &environment0, &b, &ty!(placeholder 1))
@@ -104,8 +104,8 @@ fn universe_promote() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
-    let b = table.new_variable(U1).to_ty(interner, TyKind::General);
+    let a = table.new_variable(U0).to_ty(interner);
+    let b = table.new_variable(U1).to_ty(interner);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
@@ -125,8 +125,8 @@ fn universe_promote_bad() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
-    let b = table.new_variable(U1).to_ty(interner, TyKind::General);
+    let a = table.new_variable(U0).to_ty(interner);
+    let b = table.new_variable(U1).to_ty(interner);
     table
         .unify(interner, &environment0, &a, &ty!(apply (item 0) (expr b)))
         .unwrap();
@@ -143,7 +143,7 @@ fn projection_eq() {
     let interner = &ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
-    let a = table.new_variable(U0).to_ty(interner, TyKind::General);
+    let a = table.new_variable(U0).to_ty(interner);
 
     // expect an error ("cycle during unification")
     table
@@ -199,10 +199,10 @@ fn quantify_bound() {
     let mut table = make_table();
     let environment0 = Environment::new(interner);
 
-    let v0 = table.new_variable(U0).to_ty(interner, TyKind::General);
-    let v1 = table.new_variable(U1).to_ty(interner, TyKind::General);
-    let v2a = table.new_variable(U2).to_ty(interner, TyKind::General);
-    let v2b = table.new_variable(U2).to_ty(interner, TyKind::General);
+    let v0 = table.new_variable(U0).to_ty(interner);
+    let v1 = table.new_variable(U1).to_ty(interner);
+    let v2a = table.new_variable(U2).to_ty(interner);
+    let v2b = table.new_variable(U2).to_ty(interner);
 
     table
         .unify(
@@ -248,8 +248,8 @@ fn quantify_ty_under_binder() {
         .unify(
             interner,
             &environment0,
-            &v0.to_ty(interner, TyKind::General),
-            &v1.to_ty(interner, TyKind::General),
+            &v0.to_ty(interner),
+            &v1.to_ty(interner),
         )
         .unwrap();
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -630,7 +630,7 @@ where
                         .unwrap();
                 }
 
-                Ok(var.to_ty(interner, kind))
+                Ok(var.to_ty_with_kind(interner, kind))
             }
         }
     }

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -140,10 +140,13 @@ impl<'t, I: Interner> Unifier<'t, I> {
             => {
                 let ty = ty_data.clone().intern(interner);
 
-                match (kind, ty.is_integer(interner)) {
-                    (TyKind::General, _)
+                match (kind, ty.is_integer(interner), ty.is_float(interner)) {
+                    // General inference variables can unify with any type
+                    (TyKind::General, _, _)
                     // Integer inference variables can only unify with integer types
-                    | (TyKind::Integer, true) => self.unify_var_ty(var, &ty),
+                    | (TyKind::Integer, true, _)
+                    // Float inference variables can only unify with float types
+                    | (TyKind::Float, _, true) => self.unify_var_ty(var, &ty),
                     _ => Err(NoSolution),
                 }
             }

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -101,7 +101,10 @@ impl<'t, I: Interner> Unifier<'t, I> {
         match (a.data(interner), b.data(interner)) {
             // Unifying two inference variables: unify them in the underlying
             // ena table.
-            (&TyData::InferenceVar(var1), &TyData::InferenceVar(var2)) => {
+            (
+                &TyData::InferenceVar(var1, kind1),
+                &TyData::InferenceVar(var2, kind2),
+            ) if kind1 == kind2 => {
                 debug!("unify_ty_ty: unify_var_var({:?}, {:?})", var1, var2);
                 let var1 = EnaVariable::from(var1);
                 let var2 = EnaVariable::from(var2);
@@ -112,16 +115,38 @@ impl<'t, I: Interner> Unifier<'t, I> {
                     .expect("unification of two unbound variables cannot fail"))
             }
 
-            // Unifying an inference variables with a non-inference variable.
-            (&TyData::InferenceVar(var), &TyData::Apply(_))
-            | (&TyData::InferenceVar(var), &TyData::Placeholder(_))
-            | (&TyData::InferenceVar(var), &TyData::Dyn(_))
-            | (&TyData::InferenceVar(var), &TyData::Function(_)) => self.unify_var_ty(var, b),
+            // Tried to unify mis-matching inference variables (not caught by prior match arm)
+            (
+                &TyData::InferenceVar(_, kind1),
+                &TyData::InferenceVar(_, kind2),
+            ) => {
+                debug!(
+                    "Tried to unify mis-matching inference variables: {:?} and {:?}",
+                    kind1, kind2
+                );
+                Err(NoSolution)
+            }
 
-            (&TyData::Apply(_), &TyData::InferenceVar(var))
-            | (&TyData::Placeholder(_), &TyData::InferenceVar(var))
-            | (&TyData::Dyn(_), &TyData::InferenceVar(var))
-            | (&TyData::Function(_), &TyData::InferenceVar(var)) => self.unify_var_ty(var, a),
+            // Unifying an inference variable with a non-inference variable.
+            (&TyData::InferenceVar(var, kind), ty_data @ &TyData::Apply(_))
+            | (&TyData::InferenceVar(var, kind), ty_data @ &TyData::Placeholder(_))
+            | (&TyData::InferenceVar(var, kind), ty_data @ &TyData::Dyn(_))
+            | (&TyData::InferenceVar(var, kind), ty_data @ &TyData::Function(_))
+            // The reflexive matches
+            | (ty_data @ &TyData::Apply(_), &TyData::InferenceVar(var, kind))
+            | (ty_data @ &TyData::Placeholder(_), &TyData::InferenceVar(var, kind))
+            | (ty_data @ &TyData::Dyn(_), &TyData::InferenceVar(var, kind))
+            | (ty_data @ &TyData::Function(_), &TyData::InferenceVar(var, kind))
+            => {
+                let ty = ty_data.clone().intern(interner);
+
+                match (kind, ty.is_integer(interner)) {
+                    (TyKind::General, _)
+                    // Integer inference variables can only unify with integer types
+                    | (TyKind::Integer, true) => self.unify_var_ty(var, &ty),
+                    _ => Err(NoSolution),
+                }
+            }
 
             // Unifying `forall<X> { T }` with some other forall type `forall<X> { U }`
             (&TyData::Function(ref fn1), &TyData::Function(ref fn2)) => {
@@ -135,9 +160,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
             | (&TyData::Function(_), &TyData::Placeholder(_))
             | (&TyData::Apply(_), &TyData::Function(_))
             | (&TyData::Placeholder(_), &TyData::Function(_))
-            | (&TyData::Dyn(_), &TyData::Function(_)) => {
-                return Err(NoSolution);
-            }
+            | (&TyData::Dyn(_), &TyData::Function(_)) => Err(NoSolution),
 
             (&TyData::Placeholder(ref p1), &TyData::Placeholder(ref p2)) => {
                 Zip::zip_with(self, p1, p2)
@@ -149,17 +172,13 @@ impl<'t, I: Interner> Unifier<'t, I> {
 
             // Cannot unify (e.g.) some struct type `Foo` and a placeholder like `T`
             (&TyData::Apply(_), &TyData::Placeholder(_))
-            | (&TyData::Placeholder(_), &TyData::Apply(_)) => {
-                return Err(NoSolution);
-            }
+            | (&TyData::Placeholder(_), &TyData::Apply(_)) => Err(NoSolution),
 
             // Cannot unify `dyn Trait` with things like structs or placeholders
             (&TyData::Placeholder(_), &TyData::Dyn(_))
             | (&TyData::Dyn(_), &TyData::Placeholder(_))
             | (&TyData::Apply(_), &TyData::Dyn(_))
-            | (&TyData::Dyn(_), &TyData::Apply(_)) => {
-                return Err(NoSolution);
-            }
+            | (&TyData::Dyn(_), &TyData::Apply(_)) => Err(NoSolution),
 
             // Unifying two dyn is possible if they have the same bounds.
             (&TyData::Dyn(ref qwc1), &TyData::Dyn(ref qwc2)) => Zip::zip_with(self, qwc1, qwc2),
@@ -168,14 +187,14 @@ impl<'t, I: Interner> Unifier<'t, I> {
             (&TyData::Apply(_), &TyData::Alias(ref alias))
             | (&TyData::Placeholder(_), &TyData::Alias(ref alias))
             | (&TyData::Function(_), &TyData::Alias(ref alias))
-            | (&TyData::InferenceVar(_), &TyData::Alias(ref alias))
+            | (&TyData::InferenceVar(_, _), &TyData::Alias(ref alias))
             | (&TyData::Dyn(_), &TyData::Alias(ref alias)) => self.unify_alias_ty(alias, a),
 
             (&TyData::Alias(ref alias), &TyData::Alias(_))
             | (&TyData::Alias(ref alias), &TyData::Apply(_))
             | (&TyData::Alias(ref alias), &TyData::Placeholder(_))
             | (&TyData::Alias(ref alias), &TyData::Function(_))
-            | (&TyData::Alias(ref alias), &TyData::InferenceVar(_))
+            | (&TyData::Alias(ref alias), &TyData::InferenceVar(_, _))
             | (&TyData::Alias(ref alias), &TyData::Dyn(_)) => self.unify_alias_ty(alias, b),
 
             (TyData::BoundVar(_), _) | (_, TyData::BoundVar(_)) => panic!(
@@ -549,6 +568,7 @@ where
     fn fold_inference_ty(
         &mut self,
         var: InferenceVar,
+        kind: TyKind,
         _outer_binder: DebruijnIndex,
     ) -> Fallible<Ty<I>> {
         let interner = self.interner();
@@ -584,7 +604,7 @@ where
                         .unwrap();
                 }
 
-                Ok(var.to_ty(interner))
+                Ok(var.to_ty(interner, kind))
             }
         }
     }

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -54,8 +54,15 @@ impl<I: Interner> EnaVariable<I> {
     /// Convert this inference variable into a type. When using this
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a type (we can't check it).
-    pub(crate) fn to_ty(self, interner: &I, kind: TyKind) -> Ty<I> {
+    pub(crate) fn to_ty_with_kind(self, interner: &I, kind: TyKind) -> Ty<I> {
         self.var.to_ty(interner, kind)
+    }
+
+    /// Same as `to_ty_with_kind`, but the kind is set to `TyKind::General`.
+    /// This should be used instead of `to_ty_with_kind` when creating a new
+    /// inference variable (when the kind is not known).
+    pub(crate) fn to_ty(self, interner: &I) -> Ty<I> {
+        self.var.to_ty(interner, TyKind::General)
     }
 
     /// Convert this inference variable into a lifetime. When using this

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -54,8 +54,8 @@ impl<I: Interner> EnaVariable<I> {
     /// Convert this inference variable into a type. When using this
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a type (we can't check it).
-    pub(crate) fn to_ty(self, interner: &I) -> Ty<I> {
-        self.var.to_ty(interner)
+    pub(crate) fn to_ty(self, interner: &I, kind: TyKind) -> Ty<I> {
+        self.var.to_ty(interner, kind)
     }
 
     /// Convert this inference variable into a lifetime. When using this

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -388,7 +388,7 @@ impl<I: Interner> MayInvalidate<'_, I> {
                 true
             }
 
-            (TyData::InferenceVar(_), _) | (_, TyData::InferenceVar(_)) => {
+            (TyData::InferenceVar(_, _), _) | (_, TyData::InferenceVar(_, _)) => {
                 panic!(
                     "unexpected free inference variable in may-invalidate: {:?} vs {:?}",
                     new, current,

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -478,9 +478,7 @@ impl<I: Interner> AntiUnifier<'_, '_, I> {
 
     fn new_ty_variable(&mut self) -> Ty<I> {
         let interner = self.interner;
-        self.infer
-            .new_variable(self.universe)
-            .to_ty(interner, TyKind::General)
+        self.infer.new_variable(self.universe).to_ty(interner)
     }
 
     fn new_lifetime_variable(&mut self) -> Lifetime<I> {

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -224,7 +224,7 @@ impl<I: Interner> AntiUnifier<'_, '_, I> {
             // overgeneralize.  So for example if we have two
             // solutions that are both `(X, X)`, we just produce `(Y,
             // Z)` in all cases.
-            (TyData::InferenceVar(_), TyData::InferenceVar(_)) => self.new_ty_variable(),
+            (TyData::InferenceVar(_, _), TyData::InferenceVar(_, _)) => self.new_ty_variable(),
 
             // Ugh. Aggregating two types like `for<'a> fn(&'a u32,
             // &'a u32)` and `for<'a, 'b> fn(&'a u32, &'b u32)` seems
@@ -253,7 +253,7 @@ impl<I: Interner> AntiUnifier<'_, '_, I> {
             }
 
             // Mismatched base kinds.
-            (TyData::InferenceVar(_), _)
+            (TyData::InferenceVar(_, _), _)
             | (TyData::BoundVar(_), _)
             | (TyData::Dyn(_), _)
             | (TyData::Function(_), _)
@@ -478,7 +478,9 @@ impl<I: Interner> AntiUnifier<'_, '_, I> {
 
     fn new_ty_variable(&mut self) -> Ty<I> {
         let interner = self.interner;
-        self.infer.new_variable(self.universe).to_ty(interner)
+        self.infer
+            .new_variable(self.universe)
+            .to_ty(interner, TyKind::General)
     }
 
     fn new_lifetime_variable(&mut self) -> Lifetime<I> {

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -415,7 +415,7 @@ impl<'i, I: Interner> Zipper<'i, I> for AnswerSubstitutor<'i, I> {
                 Ok(())
             }
 
-            (TyData::InferenceVar(_), _) | (_, TyData::InferenceVar(_)) => panic!(
+            (TyData::InferenceVar(_, _), _) | (_, TyData::InferenceVar(_, _)) => panic!(
                 "unexpected inference var in answer `{:?}` or pending goal `{:?}`",
                 answer, pending,
             ),

--- a/chalk-solve/src/test_macros.rs
+++ b/chalk-solve/src/test_macros.rs
@@ -39,7 +39,7 @@ macro_rules! ty {
     };
 
     (infer $b:expr) => {
-        chalk_ir::TyData::InferenceVar(chalk_ir::InferenceVar::from($b))
+        chalk_ir::TyData::InferenceVar(chalk_ir::InferenceVar::from($b), chalk_ir::TyKind::General)
             .intern(&chalk_integration::interner::ChalkIr)
     };
 

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -309,6 +309,7 @@ mod impls;
 mod misc;
 mod negation;
 mod never;
+mod numerics;
 mod object_safe;
 mod opaque_types;
 mod projection;

--- a/tests/test/numerics.rs
+++ b/tests/test/numerics.rs
@@ -169,3 +169,19 @@ fn general_ty_kind_becomes_specific() {
         }
     }
 }
+
+/// Integer and float type kinds can not be equated
+#[test]
+fn integers_are_not_floats() {
+    test! {
+        program {}
+
+        goal {
+            exists<int I, float F> {
+                I = F
+            }
+        } yields {
+            "No possible solution"
+        }
+    }
+}

--- a/tests/test/numerics.rs
+++ b/tests/test/numerics.rs
@@ -119,3 +119,53 @@ fn float_ambiguity() {
         }
     }
 }
+
+/// Integer/float type kinds are just specialized type kinds, so they can unify
+/// with general type kinds.
+#[test]
+fn integer_and_float_are_specialized_ty_kinds() {
+    test! {
+        program {}
+
+        goal {
+            exists<T, int N> {
+                T = N, N = usize
+            }
+        } yields {
+            "Unique; substitution [?0 := Uint(Usize), ?1 := Uint(Usize)], lifetime constraints []"
+        }
+
+        goal {
+            exists<T, float N> {
+                T = N, N = f32
+            }
+        } yields {
+            "Unique; substitution [?0 := Float(F32), ?1 := Float(F32)], lifetime constraints []"
+        }
+    }
+}
+
+/// Once a general type kind is unified with a specific type kind, it cannot be
+/// unified with an incompatible type (ex. integer type kind with char)
+#[test]
+fn general_ty_kind_becomes_specific() {
+    test! {
+        program {}
+
+        goal {
+            exists<T, int N> {
+                T = N, T = char
+            }
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            exists<T, float N> {
+                T = N, T = char
+            }
+        } yields {
+            "No possible solution"
+        }
+    }
+}

--- a/tests/test/numerics.rs
+++ b/tests/test/numerics.rs
@@ -77,3 +77,45 @@ fn float_kind_trait() {
         }
     }
 }
+
+/// You can still get ambiguous results with integer variables
+#[test]
+fn integer_ambiguity() {
+    test! {
+        program {
+            trait Foo {}
+
+            impl Foo for usize {}
+            impl Foo for isize {}
+        }
+
+        goal {
+            exists<int N> {
+                N: Foo
+            }
+        } yields {
+            "Ambiguous; no inference guidance"
+        }
+    }
+}
+
+/// You can still get ambiguous results with float variables
+#[test]
+fn float_ambiguity() {
+    test! {
+        program {
+            trait Foo {}
+
+            impl Foo for f32 {}
+            impl Foo for f64 {}
+        }
+
+        goal {
+            exists<float N> {
+                N: Foo
+            }
+        } yields {
+            "Ambiguous; no inference guidance"
+        }
+    }
+}

--- a/tests/test/numerics.rs
+++ b/tests/test/numerics.rs
@@ -1,0 +1,57 @@
+//! Tests related to integer/float variable kinds
+
+use super::*;
+
+/// If we know that the type is an integer, we can narrow down the possible
+/// types. This test is based on the following example:
+/// ```ignore
+/// let x: &[u32];
+/// let i = 1;
+/// x[i]
+/// ```
+/// `i` must be `usize` because that is the only integer type used in `Index`
+/// impls for slices.
+#[test]
+fn integer_index() {
+    test! {
+        program {
+            trait Index<T> {}
+            struct Slice {}
+            struct Foo {}
+
+            impl Index<usize> for Slice {}
+            impl Index<Foo> for Slice {}
+        }
+
+        goal {
+            exists<int N> {
+                Slice: Index<N>
+            }
+        } yields {
+            "Unique; substitution [?0 := Uint(Usize)]"
+        }
+    }
+}
+
+/// A more straightforward version of the `integer_index` test where the
+/// variable is on the impl side of the trait ref.
+#[test]
+fn integer_kind_trait() {
+    test! {
+        program {
+            trait Foo {}
+            struct Bar {}
+
+            impl Foo for usize {}
+            impl Foo for Bar {}
+        }
+
+        goal {
+            exists<int N> {
+                N: Foo
+            }
+        } yields {
+            "Unique; substitution [?0 := Uint(Usize)]"
+        }
+    }
+}

--- a/tests/test/numerics.rs
+++ b/tests/test/numerics.rs
@@ -55,3 +55,25 @@ fn integer_kind_trait() {
         }
     }
 }
+
+/// The `integer_kind_trait` test, but for floats
+#[test]
+fn float_kind_trait() {
+    test! {
+        program {
+            trait Foo {}
+            struct Bar {}
+
+            impl Foo for f32 {}
+            impl Foo for Bar {}
+        }
+
+        goal {
+            exists<float N> {
+                N: Foo
+            }
+        } yields {
+            "Unique; substitution [?0 := Float(F32)]"
+        }
+    }
+}


### PR DESCRIPTION
Closes #327 

This adds support for integer and float variable kinds. Example usage:
```rust
test! {
    program {
        trait Foo {}
        struct Bar {}

        impl Foo for usize {}
        impl Foo for Bar {}
    }

    goal {
        exists<int N> {
            N: Foo
        }
    } yields {
        "Unique; substitution [?0 := Uint(Usize)]"
    }
}
```