### PR TITLE
Fix solving <impl Trait as Trait>::AssocType

### DIFF
--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -234,12 +234,15 @@ fn program_clauses_that_could_match<I: Interner>(
                     .trait_ref_from_projection(proj)
                     .self_type_parameter(interner);
 
-                if let TyData::Apply(ApplicationTy {
-                    name: TypeName::OpaqueType(opaque_ty_id),
-                    ..
-                }) = trait_self_ty.data(interner)
-                {
-                    db.opaque_ty_data(*opaque_ty_id).to_program_clauses(builder)
+                match trait_self_ty.data(interner) {
+                    TyData::Apply(ApplicationTy {
+                        name: TypeName::OpaqueType(opaque_ty_id),
+                        ..
+                    })
+                    | TyData::Alias(AliasTy::Opaque(OpaqueTy { opaque_ty_id, .. })) => {
+                        db.opaque_ty_data(*opaque_ty_id).to_program_clauses(builder);
+                    }
+                    _ => {}
                 }
 
                 db.associated_ty_data(proj.associated_ty_id)

--- a/tests/test/opaque_types.rs
+++ b/tests/test/opaque_types.rs
@@ -96,5 +96,14 @@ fn opaque_generics() {
             "Unique; substitution []"
         }
 
+        goal {
+            exists<T> {
+                <Foo<Bar> as Iterator>::Item = T
+            }
+        } yields[SolverChoice::slg_default()] {
+            "Ambiguous" // #234
+        } yields[SolverChoice::recursive()] {
+            "Unique; substitution [?0 := Bar], lifetime constraints []"
+        }
     }
 }


### PR DESCRIPTION
... if the `impl Trait` is represented as an `AliasTy` itself, instead of a placeholder.

I couldn't actually write a test for this that fails here, because chalk-integration represents opaque types as placeholders (i.e. application types with `TypeName::OpaqueTy`) immediately, instead of using `AliasTy`. I'm not sure that's correct?