### PR TITLE
Remove unused StackIndex from chalk-engine.

### DIFF
--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -77,16 +77,6 @@ index_struct! {
     }
 }
 
-index_struct! {
-    /// The StackIndex identifies the position of a table's goal in the
-    /// stack of goals that are actively being processed. Note that once a
-    /// table is completely evaluated, it may be popped from the stack,
-    /// and hence no longer have a stack index.
-    struct StackIndex {
-        value: usize,
-    }
-}
-
 /// The paper describes these as `A :- D | G`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ExClause<C: Context> {


### PR DESCRIPTION
It seems this a leftover when moved.