### PR TITLE
Add built-in support for Fn* traits

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1757,6 +1757,9 @@ impl LowerWellKnownTrait for WellKnownTrait {
             Self::CopyTrait => rust_ir::WellKnownTrait::CopyTrait,
             Self::CloneTrait => rust_ir::WellKnownTrait::CloneTrait,
             Self::DropTrait => rust_ir::WellKnownTrait::DropTrait,
+            Self::FnTrait => rust_ir::WellKnownTrait::FnTrait,
+            Self::FnMutTrait => rust_ir::WellKnownTrait::FnMutTrait,
+            Self::FnOnceTrait => rust_ir::WellKnownTrait::FnOnceTrait,
         }
     }
 }

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -68,6 +68,9 @@ pub enum WellKnownTrait {
     CopyTrait,
     CloneTrait,
     DropTrait,
+    FnTrait,
+    FnMutTrait,
+    FnOnceTrait,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -51,6 +51,9 @@ WellKnownTrait: WellKnownTrait = {
      "#" "[" "lang" "(" "copy" ")" "]" => WellKnownTrait::CopyTrait,
      "#" "[" "lang" "(" "clone" ")" "]" => WellKnownTrait::CloneTrait,
      "#" "[" "lang" "(" "drop" ")" "]" => WellKnownTrait::DropTrait,
+     "#" "[" "lang" "(" "fn" ")" "]" => WellKnownTrait::FnTrait,
+     "#" "[" "lang" "(" "fnmut" ")" "]" => WellKnownTrait::FnMutTrait,
+     "#" "[" "lang" "(" "fnonce" ")" "]" => WellKnownTrait::FnOnceTrait,
 };
 
 StructDefn: StructDefn = {

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -4,6 +4,7 @@ use chalk_ir::{Substitution, Ty};
 
 mod clone;
 mod copy;
+mod fn_family;
 mod sized;
 
 /// For well known traits we have special hard-coded impls, either as an
@@ -37,6 +38,9 @@ pub fn add_builtin_program_clauses<I: Interner>(
             }
             WellKnownTrait::CloneTrait => {
                 clone::add_clone_program_clauses(db, builder, &trait_ref, ty)
+            }
+            WellKnownTrait::FnTrait | WellKnownTrait::FnMutTrait | WellKnownTrait::FnOnceTrait => {
+                fn_family::add_fn_family_program_clauses(db, builder, &trait_ref, ty)
             }
             // Drop impls are provided explicitly
             WellKnownTrait::DropTrait => (),

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -1,0 +1,47 @@
+#![allow(unused)]
+use crate::clauses::ClauseBuilder;
+use crate::{Interner, RustIrDatabase, TraitRef};
+use chalk_ir::cast::Cast;
+use chalk_ir::{ApplicationTy, Ty, TyData, TypeName};
+use std::iter;
+
+pub fn argument_types_match<I: Interner>(
+    db: &dyn RustIrDatabase<I>,
+    trait_ref: &TraitRef<I>,
+    fn_ptr: &chalk_ir::Fn<I>,
+) -> bool {
+    let interner = db.interner();
+    let trait_args: Vec<_> = trait_ref.type_parameters(interner).skip(1).collect();
+    let fn_args: Vec<_> = fn_ptr
+        .substitution
+        .parameters(interner)
+        .iter()
+        .filter_map(|p| p.ty(interner))
+        .collect();
+    if trait_args.len() != fn_args.len() {
+        return false;
+    }
+    for (arg, &param) in trait_args.iter().zip(fn_args.iter()) {
+        if arg != param {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn add_fn_family_program_clauses<I: Interner>(
+    db: &dyn RustIrDatabase<I>,
+    builder: &mut ClauseBuilder<'_, I>,
+    trait_ref: &TraitRef<I>,
+    ty: &TyData<I>,
+) {
+    match ty {
+        TyData::Function(f) => {
+            if argument_types_match(db, trait_ref, f) {
+                builder.push_fact(trait_ref.clone());
+            }
+        }
+        // TODO: handle closures once implemented
+        _ => return,
+    };
+}

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -196,6 +196,9 @@ pub enum WellKnownTrait {
     CopyTrait,
     CloneTrait,
     DropTrait,
+    FnTrait,
+    FnMutTrait,
+    FnOnceTrait,
 }
 
 impl<I: Interner> TraitDatum<I> {

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -470,9 +470,12 @@ impl WfWellKnownGoals {
     ) -> Option<Goal<I>> {
         match db.trait_datum(trait_ref.trait_id).well_known? {
             WellKnownTrait::CopyTrait => Self::copy_impl_constraint(db, trait_ref),
-            WellKnownTrait::DropTrait | WellKnownTrait::CloneTrait | WellKnownTrait::SizedTrait => {
-                None
-            }
+            WellKnownTrait::DropTrait
+            | WellKnownTrait::CloneTrait
+            | WellKnownTrait::SizedTrait
+            | WellKnownTrait::FnTrait
+            | WellKnownTrait::FnMutTrait
+            | WellKnownTrait::FnOnceTrait => None,
         }
     }
 
@@ -489,7 +492,11 @@ impl WfWellKnownGoals {
             // You can't add a manual implementation of Sized
             WellKnownTrait::SizedTrait => Some(GoalData::CannotProve(()).intern(interner)),
             WellKnownTrait::DropTrait => Self::drop_impl_constraint(db, impl_datum),
-            WellKnownTrait::CopyTrait | WellKnownTrait::CloneTrait => None,
+            WellKnownTrait::CopyTrait
+            | WellKnownTrait::CloneTrait
+            | WellKnownTrait::FnTrait
+            | WellKnownTrait::FnMutTrait
+            | WellKnownTrait::FnOnceTrait => None,
         }
     }
 

--- a/tests/test/functions.rs
+++ b/tests/test/functions.rs
@@ -82,3 +82,81 @@ fn fn_def_implied_bounds_from_env() {
         }
     }
 }
+
+#[test]
+fn fn_ptr_implements_fn_traits() {
+    test! {
+        program {
+            #[lang(fn)]
+            trait Fn<Args> { }
+
+            #[lang(fnmut)]
+            trait FnMut<Args> { }
+
+            #[lang(fnonce)]
+            trait FnOnce<Args> { }
+
+            struct Foo { }
+        }
+
+        goal {
+            fn(i32): Fn<(i32)>
+        } yields {
+            "Unique"
+        }
+        goal {
+            fn(()): FnMut<(())>
+        } yields {
+            "Unique"
+        }
+        goal {
+            fn(()): FnOnce<(())>
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            fn(()): Fn<(i32)>
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            fn(()): FnMut<(i32)>
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            fn(()): FnOnce<(i32)>
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            fn((i32, i32)): Fn<((i32, i32))>
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            fn((i32, i32, (u32, u32))): Fn<(i32, i32, (u32, u32))>
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            fn((i32, i32, (u32, u32))): Fn<(i32, i32, (u32, u32, u32))>
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            exists<Args> {
+                Foo: Fn<Args>
+            }
+        } yields {
+            "No possible solution"
+        }
+    }
+}


### PR DESCRIPTION
This is an attempt at adding support for `Fn`, `FnMut`, and `FnOnce`. 

There isn't anything too interesting at the moment because closures are not implemented yet, but with this PR function pointers will now implement the `Fn` traits if the function pointer's argument types match the type parameters on the trait-ref.

I'm not very confident about the (lack of) well-formedness constraints, so some confirmation on that would be helpful.