### PR TITLE
Get ready for the first publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   schedule:
-    - cron: "0 0 * * 1" # midnight UTC on Monday
+    - cron: "0 0 * * 2" # midnight UTC on Tuesday
 
 jobs:
   publish:
@@ -38,6 +38,6 @@ jobs:
           sed -E -i '' $'s/(# Unreleased)/\\1\\\n\\\n# Release '"$VERSION/" RELEASES.md
           git commit -am "Release $VERSION"
           git tag "v$VERSION"
-          git push --tags
           cargo workspaces publish --from-git
+          git ps --tags
           cargo workspaces version -ay --force '*' --include-merged-tags --no-git-tag --pre-id dev preminor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,14 +142,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chalk"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 dependencies = [
- "chalk-derive 0.10.1-dev",
- "chalk-engine 0.10.1-dev",
- "chalk-integration 0.10.1-dev",
- "chalk-ir 0.10.1-dev",
- "chalk-parse 0.10.1-dev",
- "chalk-solve 0.10.1-dev",
+ "chalk-derive 0.11.0-dev.0",
+ "chalk-engine 0.11.0-dev.0",
+ "chalk-integration 0.11.0-dev.0",
+ "chalk-ir 0.11.0-dev.0",
+ "chalk-parse 0.11.0-dev.0",
+ "chalk-solve 0.11.0-dev.0",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 6.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-derive"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -170,37 +170,37 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 dependencies = [
- "chalk-derive 0.10.1-dev",
- "chalk-ir 0.10.1-dev",
+ "chalk-derive 0.11.0-dev.0",
+ "chalk-ir 0.11.0-dev.0",
  "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chalk-integration"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 dependencies = [
- "chalk-derive 0.10.1-dev",
- "chalk-engine 0.10.1-dev",
- "chalk-ir 0.10.1-dev",
- "chalk-parse 0.10.1-dev",
- "chalk-solve 0.10.1-dev",
+ "chalk-derive 0.11.0-dev.0",
+ "chalk-engine 0.11.0-dev.0",
+ "chalk-ir 0.11.0-dev.0",
+ "chalk-parse 0.11.0-dev.0",
+ "chalk-solve 0.11.0-dev.0",
  "salsa 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chalk-ir"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 dependencies = [
- "chalk-derive 0.10.1-dev",
+ "chalk-derive 0.11.0-dev.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chalk-parse"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 dependencies = [
  "lalrpop 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -210,12 +210,12 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 dependencies = [
- "chalk-derive 0.10.1-dev",
- "chalk-engine 0.10.1-dev",
- "chalk-integration 0.10.1-dev",
- "chalk-ir 0.10.1-dev",
+ "chalk-derive 0.11.0-dev.0",
+ "chalk-engine 0.11.0-dev.0",
+ "chalk-integration 0.11.0-dev.0",
+ "chalk-ir 0.11.0-dev.0",
  "ena 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 description = "Model of the Rust trait system"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -21,11 +21,11 @@ salsa = "0.10.0"
 serde = "1.0"
 serde_derive = "1.0"
 
-chalk-derive = { version = "0.10.1-dev", path = "chalk-derive" }
-chalk-engine = { version = "0.10.1-dev", path = "chalk-engine" }
-chalk-ir = { version = "0.10.1-dev", path = "chalk-ir" }
-chalk-solve = { version = "0.10.1-dev", path = "chalk-solve" }
-chalk-parse = { version = "0.10.1-dev", path = "chalk-parse" }
-chalk-integration = { version = "0.10.1-dev", path = "chalk-integration" }
+chalk-derive = { version = "0.11.0-dev.0", path = "chalk-derive" }
+chalk-engine = { version = "0.11.0-dev.0", path = "chalk-engine" }
+chalk-ir = { version = "0.11.0-dev.0", path = "chalk-ir" }
+chalk-solve = { version = "0.11.0-dev.0", path = "chalk-solve" }
+chalk-parse = { version = "0.11.0-dev.0", path = "chalk-parse" }
+chalk-integration = { version = "0.11.0-dev.0", path = "chalk-integration" }
 
 [workspace]

--- a/chalk-derive/Cargo.toml
+++ b/chalk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-derive"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 description = "A helper crate for use by chalk crates for `derive` macros."
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]

--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-engine"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 description = "Core trait engine from Chalk project"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -15,5 +15,5 @@ default = []
 [dependencies]
 rustc-hash = { version = "1.1.0" }
 
-chalk-derive = { version = "0.10.1-dev", path = "../chalk-derive" }
-chalk-ir = { version = "0.10.1-dev", path = "../chalk-ir" }
+chalk-derive = { version = "0.11.0-dev.0", path = "../chalk-derive" }
+chalk-ir = { version = "0.11.0-dev.0", path = "../chalk-ir" }

--- a/chalk-integration/Cargo.toml
+++ b/chalk-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-integration"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 license = "Apache-2.0/MIT"
 description = "Sample solver setup for Chalk"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -13,8 +13,8 @@ publish = false
 string_cache = "0.8.0"
 salsa = "0.10.0"
 
-chalk-derive = { version = "0.10.1-dev", path = "../chalk-derive" }
-chalk-engine = { version = "0.10.1-dev", path = "../chalk-engine" }
-chalk-ir = { version = "0.10.1-dev", path = "../chalk-ir" }
-chalk-solve = { version = "0.10.1-dev", path = "../chalk-solve" }
-chalk-parse = { version = "0.10.1-dev", path = "../chalk-parse" }
+chalk-derive = { version = "0.11.0-dev.0", path = "../chalk-derive" }
+chalk-engine = { version = "0.11.0-dev.0", path = "../chalk-engine" }
+chalk-ir = { version = "0.11.0-dev.0", path = "../chalk-ir" }
+chalk-solve = { version = "0.11.0-dev.0", path = "../chalk-solve" }
+chalk-parse = { version = "0.11.0-dev.0", path = "../chalk-parse" }

--- a/chalk-ir/Cargo.toml
+++ b/chalk-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-ir"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 description = "Chalk's internal representation of types, goals, and clauses"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -11,5 +11,5 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.4.0"
-chalk-derive = { version = "0.10.1-dev", path = "../chalk-derive" }
+chalk-derive = { version = "0.11.0-dev.0", path = "../chalk-derive" }
 

--- a/chalk-parse/Cargo.toml
+++ b/chalk-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-parse"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 description = "Parser for the Chalk project"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]

--- a/chalk-solve/Cargo.toml
+++ b/chalk-solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-solve"
-version = "0.10.1-dev"
+version = "0.11.0-dev.0"
 description = "Combines the chalk-engine with chalk-ir"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -15,9 +15,9 @@ itertools = "0.9.0"
 petgraph = "0.5.0"
 rustc-hash = { version = "1.0.0" }
 
-chalk-derive = { version = "0.10.1-dev", path = "../chalk-derive" }
-chalk-engine = { version = "0.10.1-dev", path = "../chalk-engine", optional = true }
-chalk-ir = { version = "0.10.1-dev", path = "../chalk-ir" }
+chalk-derive = { version = "0.11.0-dev.0", path = "../chalk-derive" }
+chalk-engine = { version = "0.11.0-dev.0", path = "../chalk-engine", optional = true }
+chalk-ir = { version = "0.11.0-dev.0", path = "../chalk-ir" }
 
 [dev-dependencies]
 chalk-integration = { path = "../chalk-integration" }


### PR DESCRIPTION
Since the current tag is `v0.10.1-dev`, the action is trying to publish `v0.10.1` which we don't want. Luckily the action failed because of other reasons. So, we had the change to correct the first publish to be `v0.11.0`

https://github.com/rust-lang/chalk/releases/tag/v0.10.1 existed because of a failed publish earlier. So, the next publish had issues. Moving the pushing of tags to run after publishing makes sure the action is a bit more fault tolerant.