### PR TITLE
Refactor the recursive solver a bit

### DIFF
--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -34,11 +34,6 @@ use std::fmt::Debug;
 /// FIXME: Clone and Debug bounds are just for easy derive, they are
 /// not actually necessary. But dang are they convenient.
 pub trait Context<I: Interner>: Clone + Debug {
-    /// A final solution that is passed back to the user. This is
-    /// completely opaque to the SLG solver; it is produced by
-    /// `make_solution`.
-    type Solution;
-
     /// Represents an inference table.
     type InferenceTable: InferenceTable<I, Self> + Clone;
 
@@ -47,9 +42,7 @@ pub trait Context<I: Interner>: Clone + Debug {
     fn next_subgoal_index(ex_clause: &ExClause<I>) -> usize;
 }
 
-pub trait ContextOps<I: Interner, C: Context<I>>:
-    Sized + Clone + Debug + AggregateOps<I, C>
-{
+pub trait ContextOps<I: Interner, C: Context<I>>: Sized + Clone + Debug {
     /// True if this is a coinductive goal -- e.g., proving an auto trait.
     fn is_coinductive(&self, goal: &UCanonical<InEnvironment<Goal<I>>>) -> bool;
 
@@ -145,16 +138,6 @@ pub trait ContextOps<I: Interner, C: Context<I>>:
         u_canon: &UCanonical<InEnvironment<Goal<I>>>,
         canonical_subst: &Canonical<AnswerSubst<I>>,
     ) -> bool;
-}
-
-/// Methods for combining solutions to yield an aggregate solution.
-pub trait AggregateOps<I: Interner, C: Context<I>> {
-    fn make_solution(
-        &self,
-        root_goal: &UCanonical<InEnvironment<Goal<I>>>,
-        answers: impl AnswerStream<I>,
-        should_continue: impl Fn() -> bool,
-    ) -> Option<C::Solution>;
 }
 
 /// An "inference table" contains the state to support unification and

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -6,7 +6,6 @@ use crate::{
     query::{Lowering, LoweringDatabase},
     tls,
 };
-use chalk_engine::forest::SubstitutionResult;
 use chalk_ir::{
     AdtId, AssocTypeId, Canonical, ConstrainedSubst, Environment, FnDefId, GenericArg, Goal,
     ImplId, InEnvironment, OpaqueTyId, ProgramClause, ProgramClauses, TraitId, Ty, UCanonical,
@@ -15,7 +14,7 @@ use chalk_solve::rust_ir::{
     AdtDatum, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, FnDefDatum, ImplDatum,
     OpaqueTyDatum, TraitDatum, WellKnownTrait,
 };
-use chalk_solve::{RustIrDatabase, Solution, SolverChoice};
+use chalk_solve::{RustIrDatabase, Solution, SolverChoice, SubstitutionResult};
 use salsa::Database;
 use std::sync::Arc;
 
@@ -58,6 +57,10 @@ impl ChalkDatabase {
         solution
     }
 
+    /// Solves a given goal, producing the solution. This will do only
+    /// as much work towards `goal` as it has to (and that works is
+    /// cached for future attempts). Calls provided function `f` to
+    /// iterate over multiple solutions until the function return `false`.
     pub fn solve_multiple(
         &self,
         goal: &UCanonical<InEnvironment<Goal<ChalkIr>>>,

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -109,3 +109,4 @@ pub use solve::Guidance;
 pub use solve::Solution;
 pub use solve::Solver;
 pub use solve::SolverChoice;
+pub use solve::SubstitutionResult;

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -351,11 +351,11 @@ impl<'me, I: Interner> Solver<'me, I> {
         minimums: &mut Minimums,
     ) -> (Fallible<Solution<I>>, ClausePriority) {
         debug_heading!("solve_via_simplification({:?})", canonical_goal);
-        let (fulfill, subst) = match Fulfill::new_with_simplification(self, canonical_goal) {
+        let fulfill = match Fulfill::new_with_simplification(self, canonical_goal) {
             Ok(r) => r,
             Err(e) => return (Err(e), ClausePriority::High),
         };
-        (fulfill.solve(subst, minimums), ClausePriority::High)
+        (fulfill.solve(minimums), ClausePriority::High)
     }
 
     /// See whether we can solve a goal by implication on any of the given
@@ -426,15 +426,12 @@ impl<'me, I: Interner> Solver<'me, I> {
             canonical_goal,
             clause
         );
-        let (fulfill, subst) = match Fulfill::new_with_clause(self, canonical_goal, clause) {
+        let fulfill = match Fulfill::new_with_clause(self, canonical_goal, clause) {
             Ok(r) => r,
             Err(e) => return (Err(e), ClausePriority::High),
         };
 
-        (
-            fulfill.solve(subst, minimums),
-            clause.skip_binders().priority,
-        )
+        (fulfill.solve(minimums), clause.skip_binders().priority)
     }
 
     fn program_clauses_for_goal(

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -1,14 +1,16 @@
 mod fulfill;
+pub mod lib;
 mod search_graph;
 mod stack;
 
 use self::fulfill::{Fulfill, RecursiveInferenceTable, RecursiveSolver};
+use self::lib::{Guidance, Minimums, Solution, UCanonicalGoal};
 use self::search_graph::{DepthFirstNumber, SearchGraph};
 use self::stack::{Stack, StackDepth};
 use crate::clauses::program_clauses_for_goal;
 use crate::infer::{InferenceTable, ParameterEnaVariableExt};
 use crate::solve::truncate;
-use crate::{Guidance, RustIrDatabase, Solution};
+use crate::RustIrDatabase;
 use chalk_ir::fold::Fold;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::Visit;
@@ -22,8 +24,6 @@ use chalk_ir::{
 };
 use rustc_hash::FxHashMap;
 use std::fmt::Debug;
-
-type UCanonicalGoal<I> = UCanonical<InEnvironment<Goal<I>>>;
 
 pub(crate) struct RecursiveContext<I: Interner> {
     stack: Stack,
@@ -139,13 +139,6 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
 pub(crate) struct Solver<'me, I: Interner> {
     program: &'me dyn RustIrDatabase<I>,
     context: &'me mut RecursiveContext<I>,
-}
-
-/// The `minimums` struct is used while solving to track whether we encountered
-/// any cycles in the process.
-#[derive(Copy, Clone, Debug)]
-pub struct Minimums {
-    positive: DepthFirstNumber,
 }
 
 /// An extension trait for merging `Result`s
@@ -633,17 +626,5 @@ fn combine_with_priorities<I: Interner>(
             }
         }
         (_, _, a, b) => (a.combine(b, interner), prio_a),
-    }
-}
-
-impl Minimums {
-    fn new() -> Self {
-        Minimums {
-            positive: DepthFirstNumber::MAX,
-        }
-    }
-
-    fn update_from(&mut self, minimums: Minimums) {
-        self.positive = ::std::cmp::min(self.positive, minimums.positive);
     }
 }

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -10,7 +10,7 @@ use self::stack::{Stack, StackDepth};
 use crate::clauses::program_clauses_for_goal;
 use crate::infer::{InferenceTable, ParameterEnaVariableExt};
 use crate::solve::truncate;
-use crate::RustIrDatabase;
+use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
 use chalk_ir::fold::Fold;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::Visit;
@@ -516,7 +516,8 @@ impl<'me, I: Interner> RecursiveSolver<I> for Solver<'me, I> {
         } else {
             // Otherwise, push the goal onto the stack and create a table.
             // The initial result for this table is error.
-            let depth = self.context.stack.push(self.program, &goal);
+            let coinductive_goal = goal.is_coinductive(self.program);
+            let depth = self.context.stack.push(coinductive_goal);
             let dfn = self.context.search_graph.insert(&goal, depth);
             let subgoal_minimums = self.solve_new_subgoal(goal, depth, dfn);
             self.context.search_graph[dfn].links = subgoal_minimums;

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -1,5 +1,4 @@
-use super::lib::{Guidance, Solution};
-use crate::recursive::Minimums;
+use super::lib::{Guidance, Minimums, Solution};
 use chalk_ir::cast::Cast;
 use chalk_ir::fold::Fold;
 use chalk_ir::interner::{HasInterner, Interner};

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -1,5 +1,5 @@
+use super::lib::{Guidance, Solution};
 use crate::recursive::Minimums;
-use crate::solve::{Guidance, Solution};
 use chalk_ir::cast::Cast;
 use chalk_ir::fold::Fold;
 use chalk_ir::interner::{HasInterner, Interner};

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -140,7 +140,12 @@ pub trait RecursiveSolver<I: Interner> {
 /// of type inference in general. But when solving trait constraints, *fresh*
 /// `Fulfill` instances will be created to solve canonicalized, free-standing
 /// goals, and transport what was learned back to the outer context.
-pub(crate) struct Fulfill<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: RecursiveInferenceTable<I>> {
+pub(crate) struct Fulfill<
+    's,
+    I: Interner,
+    Solver: RecursiveSolver<I>,
+    Infer: RecursiveInferenceTable<I>,
+> {
     solver: &'s mut Solver,
     subst: Substitution<I>,
     infer: Infer,
@@ -158,7 +163,9 @@ pub(crate) struct Fulfill<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: Re
     cannot_prove: bool,
 }
 
-impl<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: RecursiveInferenceTable<I>> Fulfill<'s, I, Solver, Infer> {
+impl<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: RecursiveInferenceTable<I>>
+    Fulfill<'s, I, Solver, Infer>
+{
     pub(crate) fn new_with_clause(
         solver: &'s mut Solver,
         infer: Infer,
@@ -261,9 +268,9 @@ impl<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: RecursiveInferenceTable
     where
         T: ?Sized + Zip<I> + Debug,
     {
-        let (goals, constraints) =
-            self.infer
-                .unify(self.solver.interner(), environment, a, b)?;
+        let (goals, constraints) = self
+            .infer
+            .unify(self.solver.interner(), environment, a, b)?;
         debug!("unify({:?}, {:?}) succeeded", a, b);
         debug!("unify: goals={:?}", goals);
         debug!("unify: constraints={:?}", constraints);

--- a/chalk-solve/src/recursive/lib.rs
+++ b/chalk-solve/src/recursive/lib.rs
@@ -1,7 +1,8 @@
-use chalk_ir::{
-    Goal, InEnvironment, UCanonical
-};
 use super::search_graph::DepthFirstNumber;
+use chalk_ir::debug;
+use chalk_ir::interner::Interner;
+use chalk_ir::{Canonical, ConstrainedSubst, Goal, InEnvironment, Substitution, UCanonical};
+use std::fmt;
 
 pub type UCanonicalGoal<I> = UCanonical<InEnvironment<Goal<I>>>;
 
@@ -21,5 +22,173 @@ impl Minimums {
 
     pub fn update_from(&mut self, minimums: Minimums) {
         self.positive = ::std::cmp::min(self.positive, minimums.positive);
+    }
+}
+
+/// A (possible) solution for a proposed goal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Solution<I: Interner> {
+    /// The goal indeed holds, and there is a unique value for all existential
+    /// variables. In this case, we also record a set of lifetime constraints
+    /// which must also hold for the goal to be valid.
+    Unique(Canonical<ConstrainedSubst<I>>),
+
+    /// The goal may be provable in multiple ways, but regardless we may have some guidance
+    /// for type inference. In this case, we don't return any lifetime
+    /// constraints, since we have not "committed" to any particular solution
+    /// yet.
+    Ambig(Guidance<I>),
+}
+
+/// When a goal holds ambiguously (e.g., because there are multiple possible
+/// solutions), we issue a set of *guidance* back to type inference.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Guidance<I: Interner> {
+    /// The existential variables *must* have the given values if the goal is
+    /// ever to hold, but that alone isn't enough to guarantee the goal will
+    /// actually hold.
+    Definite(Canonical<Substitution<I>>),
+
+    /// There are multiple plausible values for the existentials, but the ones
+    /// here are suggested as the preferred choice heuristically. These should
+    /// be used for inference fallback only.
+    Suggested(Canonical<Substitution<I>>),
+
+    /// There's no useful information to feed back to type inference
+    Unknown,
+}
+
+impl<I: Interner> Solution<I> {
+    /// There are multiple candidate solutions, which may or may not agree on
+    /// the values for existential variables; attempt to combine them. This
+    /// operation does not depend on the order of its arguments.
+    //
+    // This actually isn't as precise as it could be, in two ways:
+    //
+    // a. It might be that while there are multiple distinct candidates, they
+    //    all agree about *some things*. To be maximally precise, we would
+    //    compute the intersection of what they agree on. It's not clear though
+    //    that this is actually what we want Rust's inference to do, and it's
+    //    certainly not what it does today.
+    //
+    // b. There might also be an ambiguous candidate and a successful candidate,
+    //    both with the same refined-goal. In that case, we could probably claim
+    //    success, since if the conditions of the ambiguous candidate were met,
+    //    we know the success would apply.  Example: `?0: Clone` yields ambiguous
+    //    candidate `Option<?0>: Clone` and successful candidate `Option<?0>:
+    //    Clone`.
+    //
+    // But you get the idea.
+    pub(crate) fn combine(self, other: Solution<I>, interner: &I) -> Solution<I> {
+        use self::Guidance::*;
+
+        if self == other {
+            return self;
+        }
+
+        debug!(
+            "combine {} with {}",
+            self.display(interner),
+            other.display(interner)
+        );
+
+        // Otherwise, always downgrade to Ambig:
+
+        let guidance = match (self.into_guidance(), other.into_guidance()) {
+            (Definite(ref subst1), Definite(ref subst2)) if subst1 == subst2 => {
+                Definite(subst1.clone())
+            }
+            (Suggested(ref subst1), Suggested(ref subst2)) if subst1 == subst2 => {
+                Suggested(subst1.clone())
+            }
+            _ => Unknown,
+        };
+        Solution::Ambig(guidance)
+    }
+
+    /// View this solution purely in terms of type inference guidance
+    pub(crate) fn into_guidance(self) -> Guidance<I> {
+        match self {
+            Solution::Unique(constrained) => Guidance::Definite(Canonical {
+                value: constrained.value.subst,
+                binders: constrained.binders,
+            }),
+            Solution::Ambig(guidance) => guidance,
+        }
+    }
+
+    /// Extract a constrained substitution from this solution, even if ambiguous.
+    pub(crate) fn constrained_subst(&self) -> Option<Canonical<ConstrainedSubst<I>>> {
+        match *self {
+            Solution::Unique(ref constrained) => Some(constrained.clone()),
+            Solution::Ambig(Guidance::Definite(ref canonical))
+            | Solution::Ambig(Guidance::Suggested(ref canonical)) => {
+                let value = ConstrainedSubst {
+                    subst: canonical.value.clone(),
+                    constraints: vec![],
+                };
+                Some(Canonical {
+                    value,
+                    binders: canonical.binders.clone(),
+                })
+            }
+            Solution::Ambig(_) => None,
+        }
+    }
+
+    /// Determine whether this solution contains type information that *must*
+    /// hold.
+    pub(crate) fn has_definite(&self) -> bool {
+        match *self {
+            Solution::Unique(_) => true,
+            Solution::Ambig(Guidance::Definite(_)) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_unique(&self) -> bool {
+        match *self {
+            Solution::Unique(..) => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn is_ambig(&self) -> bool {
+        match *self {
+            Solution::Ambig(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn display<'a>(&'a self, interner: &'a I) -> SolutionDisplay<'a, I> {
+        SolutionDisplay {
+            solution: self,
+            interner,
+        }
+    }
+}
+
+pub struct SolutionDisplay<'a, I: Interner> {
+    solution: &'a Solution<I>,
+    interner: &'a I,
+}
+
+impl<'a, I: Interner> fmt::Display for SolutionDisplay<'a, I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let SolutionDisplay { solution, interner } = self;
+        match solution {
+            Solution::Unique(constrained) => write!(f, "Unique; {}", constrained.display(interner)),
+            Solution::Ambig(Guidance::Definite(subst)) => write!(
+                f,
+                "Ambiguous; definite substitution {}",
+                subst.display(interner)
+            ),
+            Solution::Ambig(Guidance::Suggested(subst)) => write!(
+                f,
+                "Ambiguous; suggested substitution {}",
+                subst.display(interner)
+            ),
+            Solution::Ambig(Guidance::Unknown) => write!(f, "Ambiguous; no inference guidance"),
+        }
     }
 }

--- a/chalk-solve/src/recursive/lib.rs
+++ b/chalk-solve/src/recursive/lib.rs
@@ -1,0 +1,25 @@
+use chalk_ir::{
+    Goal, InEnvironment, UCanonical
+};
+use super::search_graph::DepthFirstNumber;
+
+pub type UCanonicalGoal<I> = UCanonical<InEnvironment<Goal<I>>>;
+
+/// The `minimums` struct is used while solving to track whether we encountered
+/// any cycles in the process.
+#[derive(Copy, Clone, Debug)]
+pub struct Minimums {
+    pub positive: DepthFirstNumber,
+}
+
+impl Minimums {
+    pub fn new() -> Self {
+        Minimums {
+            positive: DepthFirstNumber::MAX,
+        }
+    }
+
+    pub fn update_from(&mut self, minimums: Minimums) {
+        self.positive = ::std::cmp::min(self.positive, minimums.positive);
+    }
+}

--- a/chalk-solve/src/recursive/search_graph.rs
+++ b/chalk-solve/src/recursive/search_graph.rs
@@ -4,8 +4,7 @@ use std::ops::IndexMut;
 use std::usize;
 
 use super::stack::StackDepth;
-use super::{Minimums, UCanonicalGoal};
-use crate::Solution;
+use super::{Minimums, UCanonicalGoal, Solution};
 use chalk_ir::debug;
 use chalk_ir::{interner::Interner, ClausePriority, Fallible, NoSolution};
 use rustc_hash::FxHashMap;
@@ -16,7 +15,7 @@ pub(super) struct SearchGraph<I: Interner> {
 }
 
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub(super) struct DepthFirstNumber {
+pub struct DepthFirstNumber {
     index: usize,
 }
 

--- a/chalk-solve/src/recursive/search_graph.rs
+++ b/chalk-solve/src/recursive/search_graph.rs
@@ -3,8 +3,8 @@ use std::ops::Index;
 use std::ops::IndexMut;
 use std::usize;
 
+use super::lib::{Minimums, Solution, UCanonicalGoal};
 use super::stack::StackDepth;
-use super::{Minimums, UCanonicalGoal, Solution};
 use chalk_ir::debug;
 use chalk_ir::{interner::Interner, ClausePriority, Fallible, NoSolution};
 use rustc_hash::FxHashMap;

--- a/chalk-solve/src/recursive/stack.rs
+++ b/chalk-solve/src/recursive/stack.rs
@@ -1,6 +1,3 @@
-use super::UCanonicalGoal;
-use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
-use chalk_ir::interner::Interner;
 use std::mem;
 use std::ops::Index;
 use std::ops::IndexMut;
@@ -42,11 +39,7 @@ impl Stack {
         self.entries.is_empty()
     }
 
-    pub(crate) fn push<I: Interner>(
-        &mut self,
-        program: &dyn RustIrDatabase<I>,
-        goal: &UCanonicalGoal<I>,
-    ) -> StackDepth {
+    pub(crate) fn push(&mut self, coinductive_goal: bool) -> StackDepth {
         let depth = StackDepth {
             depth: self.entries.len(),
         };
@@ -58,7 +51,6 @@ impl Stack {
             panic!("overflow depth reached")
         }
 
-        let coinductive_goal = goal.is_coinductive(program);
         self.entries.push(StackEntry {
             coinductive_goal,
             cycle: false,

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -60,100 +60,6 @@ impl<I: Interner> Solution<I> {
         }
     }
 
-    /// There are multiple candidate solutions, which may or may not agree on
-    /// the values for existential variables; attempt to combine them. This
-    /// operation does not depend on the order of its arguments.
-    //
-    // This actually isn't as precise as it could be, in two ways:
-    //
-    // a. It might be that while there are multiple distinct candidates, they
-    //    all agree about *some things*. To be maximally precise, we would
-    //    compute the intersection of what they agree on. It's not clear though
-    //    that this is actually what we want Rust's inference to do, and it's
-    //    certainly not what it does today.
-    //
-    // b. There might also be an ambiguous candidate and a successful candidate,
-    //    both with the same refined-goal. In that case, we could probably claim
-    //    success, since if the conditions of the ambiguous candidate were met,
-    //    we know the success would apply.  Example: `?0: Clone` yields ambiguous
-    //    candidate `Option<?0>: Clone` and successful candidate `Option<?0>:
-    //    Clone`.
-    //
-    // But you get the idea.
-    pub(crate) fn combine(self, other: Solution<I>, interner: &I) -> Solution<I> {
-        use self::Guidance::*;
-
-        if self == other {
-            return self;
-        }
-
-        debug!(
-            "combine {} with {}",
-            self.display(interner),
-            other.display(interner)
-        );
-
-        // Otherwise, always downgrade to Ambig:
-
-        let guidance = match (self.into_guidance(), other.into_guidance()) {
-            (Definite(ref subst1), Definite(ref subst2)) if subst1 == subst2 => {
-                Definite(subst1.clone())
-            }
-            (Suggested(ref subst1), Suggested(ref subst2)) if subst1 == subst2 => {
-                Suggested(subst1.clone())
-            }
-            _ => Unknown,
-        };
-        Solution::Ambig(guidance)
-    }
-
-    /// View this solution purely in terms of type inference guidance
-    pub(crate) fn into_guidance(self) -> Guidance<I> {
-        match self {
-            Solution::Unique(constrained) => Guidance::Definite(Canonical {
-                value: constrained.value.subst,
-                binders: constrained.binders,
-            }),
-            Solution::Ambig(guidance) => guidance,
-        }
-    }
-
-    /// Extract a constrained substitution from this solution, even if ambiguous.
-    pub(crate) fn constrained_subst(&self) -> Option<Canonical<ConstrainedSubst<I>>> {
-        match *self {
-            Solution::Unique(ref constrained) => Some(constrained.clone()),
-            Solution::Ambig(Guidance::Definite(ref canonical))
-            | Solution::Ambig(Guidance::Suggested(ref canonical)) => {
-                let value = ConstrainedSubst {
-                    subst: canonical.value.clone(),
-                    constraints: vec![],
-                };
-                Some(Canonical {
-                    value,
-                    binders: canonical.binders.clone(),
-                })
-            }
-            Solution::Ambig(_) => None,
-        }
-    }
-
-    /// Determine whether this solution contains type information that *must*
-    /// hold.
-    pub(crate) fn has_definite(&self) -> bool {
-        match *self {
-            Solution::Unique(_) => true,
-            Solution::Ambig(Guidance::Definite(_)) => true,
-            _ => false,
-        }
-    }
-
-    pub(crate) fn is_ambig(&self) -> bool {
-        match *self {
-            Solution::Ambig(_) => true,
-            _ => false,
-        }
-    }
-
     pub fn display<'a>(&'a self, interner: &'a I) -> SolutionDisplay<'a, I> {
         SolutionDisplay {
             solution: self,
@@ -322,7 +228,29 @@ impl<I: Interner> Solver<I> {
                 ops.make_solution(goal, forest.iter_answers(&ops, goal), || true)
             }
             #[cfg(feature = "recursive-solver")]
-            SolverImpl::Recursive(ctx) => ctx.solver(program).solve_root_goal(goal).ok(),
+            SolverImpl::Recursive(ctx) => {
+                ctx.solver(program)
+                    .solve_root_goal(goal)
+                    .ok()
+                    .map(|s| match s {
+                        crate::recursive::lib::Solution::Unique(c) => {
+                            crate::solve::Solution::Unique(c)
+                        }
+                        crate::recursive::lib::Solution::Ambig(g) => {
+                            crate::solve::Solution::Ambig(match g {
+                                crate::recursive::lib::Guidance::Definite(g) => {
+                                    crate::solve::Guidance::Definite(g)
+                                }
+                                crate::recursive::lib::Guidance::Suggested(g) => {
+                                    crate::solve::Guidance::Suggested(g)
+                                }
+                                crate::recursive::lib::Guidance::Unknown => {
+                                    crate::solve::Guidance::Unknown
+                                }
+                            })
+                        }
+                    })
+            }
         }
     }
 
@@ -367,7 +295,27 @@ impl<I: Interner> Solver<I> {
             #[cfg(feature = "recursive-solver")]
             SolverImpl::Recursive(ctx) => {
                 // TODO support should_continue in recursive solver
-                ctx.solver(program).solve_root_goal(goal).ok()
+                ctx.solver(program)
+                    .solve_root_goal(goal)
+                    .ok()
+                    .map(|s| match s {
+                        crate::recursive::lib::Solution::Unique(c) => {
+                            crate::solve::Solution::Unique(c)
+                        }
+                        crate::recursive::lib::Solution::Ambig(g) => {
+                            crate::solve::Solution::Ambig(match g {
+                                crate::recursive::lib::Guidance::Definite(g) => {
+                                    crate::solve::Guidance::Definite(g)
+                                }
+                                crate::recursive::lib::Guidance::Suggested(g) => {
+                                    crate::solve::Guidance::Suggested(g)
+                                }
+                                crate::recursive::lib::Guidance::Unknown => {
+                                    crate::solve::Guidance::Unknown
+                                }
+                            })
+                        }
+                    })
             }
         }
     }

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -1,6 +1,5 @@
 use crate::ext::*;
 use crate::infer::InferenceTable;
-use crate::solve::slg::SlgContext;
 use crate::solve::slg::SlgContextOps;
 use crate::solve::slg::SubstitutionExt;
 use crate::solve::{Guidance, Solution};
@@ -12,9 +11,19 @@ use chalk_engine::context::{self, AnswerResult, ContextOps};
 use chalk_engine::CompleteAnswer;
 use std::fmt::Debug;
 
+/// Methods for combining solutions to yield an aggregate solution.
+pub trait AggregateOps<I: Interner> {
+    fn make_solution(
+        &self,
+        root_goal: &UCanonical<InEnvironment<Goal<I>>>,
+        answers: impl context::AnswerStream<I>,
+        should_continue: impl std::ops::Fn() -> bool,
+    ) -> Option<Solution<I>>;
+}
+
 /// Draws as many answers as it needs from `answers` (but
 /// no more!) in order to come up with a solution.
-impl<I: Interner> context::AggregateOps<I, SlgContext<I>> for SlgContextOps<'_, I> {
+impl<I: Interner> AggregateOps<I> for SlgContextOps<'_, I> {
     fn make_solution(
         &self,
         root_goal: &UCanonical<InEnvironment<Goal<I>>>,


### PR DESCRIPTION
This is about 95% of the work needed to put the recursive solver in a separate crate.

Everything in `chalk_solve::recursive::*` can get moved. `recursive.rs` is mostly the equivalent of the `slg` submodule.