### PR TITLE
Add FnOnce trait, and provide impl for Function type

### DIFF
--- a/book/src/clauses/well_known_traits.md
+++ b/book/src/clauses/well_known_traits.md
@@ -28,7 +28,7 @@ Some common examples of auto traits are `Send` and `Sync`.
 [coinductive_section]: ../engine/logic/coinduction.html#coinduction-and-refinement-strands
 
 # Current state 
-| Type            | Copy | Clone | Sized | Unsize | Drop | FnOnce  | Unpin  | Generator | auto traits |
+| Type            | Copy | Clone | Sized | Unsize | Drop | FnOnce/FnMut/Fn  | Unpin  | Generator | auto traits |
 | ---             | ---  | ---   | ---   | ---    | ---  | --- | ---    |  ---      |  ---        |
 | tuple types     | ✅    | ✅    | ✅     | ✅     | ⚬    | ⚬  |  ⚬      |  ⚬       |   ❌         |
 | structs         | ⚬    | ⚬    |  ✅    | ✅     | ⚬    | ⚬  |  ⚬      |  ⚬       |   ✅         |

--- a/book/src/clauses/well_known_traits.md
+++ b/book/src/clauses/well_known_traits.md
@@ -28,7 +28,7 @@ Some common examples of auto traits are `Send` and `Sync`.
 [coinductive_section]: ../engine/logic/coinduction.html#coinduction-and-refinement-strands
 
 # Current state 
-| Type            | Copy | Clone | Sized | Unsize | Drop | Fn  | Unpin  | Generator | auto traits |
+| Type            | Copy | Clone | Sized | Unsize | Drop | FnOnce  | Unpin  | Generator | auto traits |
 | ---             | ---  | ---   | ---   | ---    | ---  | --- | ---    |  ---      |  ---        |
 | tuple types     | ✅    | ✅    | ✅     | ✅     | ⚬    | ⚬  |  ⚬      |  ⚬       |   ❌         |
 | structs         | ⚬    | ⚬    |  ✅    | ✅     | ⚬    | ⚬  |  ⚬      |  ⚬       |   ✅         |
@@ -37,7 +37,7 @@ Some common examples of auto traits are `Send` and `Sync`.
 | never type      | 📚   |  📚   |  ✅   |  ⚬    |  ⚬    | ⚬   |   ⚬    |  ⚬       |   ❌       |
 | trait objects   | ⚬    | ⚬    | ⚬     |  ✅    | ⚬    | ⚬   | ⚬      |  ⚬       |    ⚬        |
 | functions defs  | ✅    | ✅    | ✅     | ⚬     | ⚬    |  ❌  | ⚬      |  ⚬       |    ❌         |
-| functions ptrs  | ✅    | ✅    | ✅     | ⚬     | ⚬    | ❌   | ⚬      |  ⚬       |    ❌         |
+| functions ptrs  | ✅    | ✅    | ✅     | ⚬     | ⚬    |  ✅  | ⚬      |  ⚬       |    ❌         |
 | raw ptrs        | 📚   |  📚  |   ✅   |  ⚬    |   ⚬   |  ⚬  |   ⚬    |   ⚬      |      ❌      |
 | immutable refs  | 📚   |  📚  |   ✅   |  ⚬    |   ⚬   |  ⚬  |   ⚬    |   ⚬      |      ❌      |
 | mutable refs    | ⚬    |  ⚬   |   ✅   |  ⚬    |   ⚬   |  ⚬  |   ⚬    |   ⚬      |      ❌      |

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1394,18 +1394,20 @@ impl LowerTy for Ty {
 
             Ty::ForAll {
                 ref lifetime_names,
-                ref ty,
+                ref types,
             } => {
                 let quantified_env = env.introduce(lifetime_names.iter().map(|id| {
                     chalk_ir::WithKind::new(chalk_ir::VariableKind::Lifetime, id.str.clone())
                 }))?;
 
+                let mut lowered_tys = Vec::with_capacity(types.len());
+                for ty in types {
+                    lowered_tys.push(ty.lower(&quantified_env)?.cast(interner));
+                }
+
                 let function = chalk_ir::Fn {
                     num_binders: lifetime_names.len(),
-                    substitution: Substitution::from(
-                        interner,
-                        Some(ty.lower(&quantified_env)?.cast(interner)),
-                    ),
+                    substitution: Substitution::from(interner, lowered_tys),
                 };
                 Ok(chalk_ir::TyData::Function(function).intern(interner))
             }
@@ -1822,6 +1824,7 @@ impl LowerWellKnownTrait for WellKnownTrait {
             Self::Copy => rust_ir::WellKnownTrait::Copy,
             Self::Clone => rust_ir::WellKnownTrait::Clone,
             Self::Drop => rust_ir::WellKnownTrait::Drop,
+            Self::FnOnceTrait => rust_ir::WellKnownTrait::FnOnceTrait,
         }
     }
 }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1824,9 +1824,9 @@ impl LowerWellKnownTrait for WellKnownTrait {
             Self::Copy => rust_ir::WellKnownTrait::Copy,
             Self::Clone => rust_ir::WellKnownTrait::Clone,
             Self::Drop => rust_ir::WellKnownTrait::Drop,
-            Self::FnOnceTrait => rust_ir::WellKnownTrait::FnOnceTrait,
-            Self::FnMutTrait => rust_ir::WellKnownTrait::FnMutTrait,
-            Self::FnTrait => rust_ir::WellKnownTrait::FnTrait,
+            Self::FnOnce => rust_ir::WellKnownTrait::FnOnce,
+            Self::FnMut => rust_ir::WellKnownTrait::FnMut,
+            Self::Fn => rust_ir::WellKnownTrait::Fn,
         }
     }
 }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1825,6 +1825,8 @@ impl LowerWellKnownTrait for WellKnownTrait {
             Self::Clone => rust_ir::WellKnownTrait::Clone,
             Self::Drop => rust_ir::WellKnownTrait::Drop,
             Self::FnOnceTrait => rust_ir::WellKnownTrait::FnOnceTrait,
+            Self::FnMutTrait => rust_ir::WellKnownTrait::FnMutTrait,
+            Self::FnTrait => rust_ir::WellKnownTrait::FnTrait,
         }
     }
 }

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -68,6 +68,7 @@ pub enum WellKnownTrait {
     Copy,
     Clone,
     Drop,
+    FnOnceTrait,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -210,7 +211,7 @@ pub enum Ty {
     },
     ForAll {
         lifetime_names: Vec<Identifier>,
-        ty: Box<Ty>,
+        types: Vec<Box<Ty>>,
     },
     Tuple {
         types: Vec<Box<Ty>>,

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -68,9 +68,9 @@ pub enum WellKnownTrait {
     Copy,
     Clone,
     Drop,
-    FnOnceTrait,
-    FnMutTrait,
-    FnTrait,
+    FnOnce,
+    FnMut,
+    Fn,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -69,6 +69,8 @@ pub enum WellKnownTrait {
     Clone,
     Drop,
     FnOnceTrait,
+    FnMutTrait,
+    FnTrait,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -51,6 +51,7 @@ WellKnownTrait: WellKnownTrait = {
      "#" "[" "lang" "(" "copy" ")" "]" => WellKnownTrait::Copy,
      "#" "[" "lang" "(" "clone" ")" "]" => WellKnownTrait::Clone,
      "#" "[" "lang" "(" "drop" ")" "]" => WellKnownTrait::Drop,
+     "#" "[" "lang" "(" "fn_once" ")" "]" => WellKnownTrait::FnOnceTrait,
 };
 
 StructDefn: StructDefn = {
@@ -220,16 +221,16 @@ pub Ty: Ty = {
 };
 
 TyWithoutId: Ty = {
-    "for" "<" <l:Comma<LifetimeId>> ">" "fn" "(" <t:Ty> ")" => Ty::ForAll {
+    "for" "<" <l:Comma<LifetimeId>> ">" "fn" "(" <types:Comma<Ty>> ")" => Ty::ForAll {
         lifetime_names: l,
-        ty: Box::new(t)
+        types: types.into_iter().map(Box::new).collect()
     },
     <ScalarType> => Ty::Scalar { ty: <> },
     "str" => Ty::Str,
     "!" => Ty::Never,
-    "fn" "(" <t:Ty> ")" => Ty::ForAll {
+    "fn" "(" <types:Comma<Ty>> ")" => Ty::ForAll {
         lifetime_names: vec![],
-        ty: Box::new(t)
+        types: types.into_iter().map(Box::new).collect()
     },
     "dyn" <b:Plus<QuantifiedInlineBound>> "+" <l:Lifetime> => Ty::Dyn {
         bounds: b,

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -52,6 +52,8 @@ WellKnownTrait: WellKnownTrait = {
      "#" "[" "lang" "(" "clone" ")" "]" => WellKnownTrait::Clone,
      "#" "[" "lang" "(" "drop" ")" "]" => WellKnownTrait::Drop,
      "#" "[" "lang" "(" "fn_once" ")" "]" => WellKnownTrait::FnOnceTrait,
+     "#" "[" "lang" "(" "fn_mut" ")" "]" => WellKnownTrait::FnMutTrait,
+     "#" "[" "lang" "(" "fn" ")" "]" => WellKnownTrait::FnTrait,
 };
 
 StructDefn: StructDefn = {

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -223,16 +223,22 @@ pub Ty: Ty = {
 };
 
 TyWithoutId: Ty = {
-    "for" "<" <l:Comma<LifetimeId>> ">" "fn" "(" <types:Comma<Ty>> ")" => Ty::ForAll {
+    "for" "<" <l:Comma<LifetimeId>> ">" "fn" "(" <types:Comma<Ty>> ")" <ret_ty:FnReturn?> => Ty::ForAll {
         lifetime_names: l,
-        types: types.into_iter().map(Box::new).collect()
+        types: types
+                   .into_iter()
+                   .chain(std::iter::once(ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() })))
+                   .map(Box::new).collect()
     },
     <ScalarType> => Ty::Scalar { ty: <> },
     "str" => Ty::Str,
     "!" => Ty::Never,
-    "fn" "(" <types:Comma<Ty>> ")" => Ty::ForAll {
+    "fn" "(" <types:Comma<Ty>> ")" <ret_ty:FnReturn?> => Ty::ForAll {
         lifetime_names: vec![],
-        types: types.into_iter().map(Box::new).collect()
+        types: types
+                   .into_iter()
+                   .chain(std::iter::once(ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() })))
+                   .map(Box::new).collect()
     },
     "dyn" <b:Plus<QuantifiedInlineBound>> "+" <l:Lifetime> => Ty::Dyn {
         bounds: b,

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -51,9 +51,9 @@ WellKnownTrait: WellKnownTrait = {
      "#" "[" "lang" "(" "copy" ")" "]" => WellKnownTrait::Copy,
      "#" "[" "lang" "(" "clone" ")" "]" => WellKnownTrait::Clone,
      "#" "[" "lang" "(" "drop" ")" "]" => WellKnownTrait::Drop,
-     "#" "[" "lang" "(" "fn_once" ")" "]" => WellKnownTrait::FnOnceTrait,
-     "#" "[" "lang" "(" "fn_mut" ")" "]" => WellKnownTrait::FnMutTrait,
-     "#" "[" "lang" "(" "fn" ")" "]" => WellKnownTrait::FnTrait,
+     "#" "[" "lang" "(" "fn_once" ")" "]" => WellKnownTrait::FnOnce,
+     "#" "[" "lang" "(" "fn_mut" ")" "]" => WellKnownTrait::FnMut,
+     "#" "[" "lang" "(" "fn" ")" "]" => WellKnownTrait::Fn,
 };
 
 StructDefn: StructDefn = {

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -295,7 +295,7 @@ fn program_clauses_that_could_match<I: Interner>(
             }
 
             if let Some(well_known) = trait_datum.well_known {
-                builtin_traits::add_builtin_program_clauses(db, builder, well_known, trait_ref);
+                builtin_traits::add_builtin_program_clauses(db, builder, well_known, trait_ref)?;
             }
         }
         DomainGoal::Holds(WhereClause::AliasEq(alias_eq)) => match &alias_eq.alias {
@@ -370,7 +370,7 @@ fn program_clauses_that_could_match<I: Interner>(
                 if let Some(well_known) = trait_datum.well_known {
                     builtin_traits::add_builtin_assoc_program_clauses(
                         db, builder, well_known, self_ty,
-                    );
+                    )?;
                 }
 
                 push_program_clauses_for_associated_type_values_in_impls_of(

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -367,6 +367,12 @@ fn program_clauses_that_could_match<I: Interner>(
                     return Err(Floundered);
                 }
 
+                if let Some(well_known) = trait_datum.well_known {
+                    builtin_traits::add_builtin_assoc_program_clauses(
+                        db, builder, well_known, proj,
+                    );
+                }
+
                 push_program_clauses_for_associated_type_values_in_impls_of(
                     builder,
                     trait_id,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -358,18 +358,18 @@ fn program_clauses_that_could_match<I: Interner>(
 
                 let trait_datum = db.trait_datum(trait_id);
 
+                let self_ty = alias.self_type_parameter(interner);
+
                 // Flounder if the self-type is unknown and the trait is non-enumerable.
                 //
                 // e.g., Normalize(<?X as Iterator>::Item = u32)
-                if (alias.self_type_parameter(interner).is_var(interner))
-                    && trait_datum.is_non_enumerable_trait()
-                {
+                if (self_ty.is_var(interner)) && trait_datum.is_non_enumerable_trait() {
                     return Err(Floundered);
                 }
 
                 if let Some(well_known) = trait_datum.well_known {
                     builtin_traits::add_builtin_assoc_program_clauses(
-                        db, builder, well_known, proj,
+                        db, builder, well_known, self_ty,
                     );
                 }
 

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -33,8 +33,8 @@ pub fn add_builtin_program_clauses<I: Interner>(
             WellKnownTrait::Sized => sized::add_sized_program_clauses(db, builder, &trait_ref, ty),
             WellKnownTrait::Copy => copy::add_copy_program_clauses(db, builder, &trait_ref, ty),
             WellKnownTrait::Clone => clone::add_clone_program_clauses(db, builder, &trait_ref, ty),
-            WellKnownTrait::FnOnceTrait => {
-                fn_::add_fn_once_program_clauses(db, builder, &trait_ref, ty)
+            WellKnownTrait::FnOnceTrait | WellKnownTrait::FnMutTrait | WellKnownTrait::FnTrait => {
+                fn_::add_fn_trait_program_clauses(db, builder, &trait_ref, ty)
             }
             // Drop impls are provided explicitly
             WellKnownTrait::Drop => (),

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -1,6 +1,6 @@
 use super::{builder::ClauseBuilder, generalize};
 use crate::{Interner, RustIrDatabase, TraitRef, WellKnownTrait};
-use chalk_ir::{ProjectionTy, Substitution, Ty, AliasTy};
+use chalk_ir::{AliasTy, ProjectionTy, Substitution, Ty};
 
 mod clone;
 mod copy;

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -4,6 +4,7 @@ use chalk_ir::{Substitution, Ty};
 
 mod clone;
 mod copy;
+mod fn_;
 mod sized;
 
 /// For well known traits we have special hard-coded impls, either as an
@@ -32,6 +33,9 @@ pub fn add_builtin_program_clauses<I: Interner>(
             WellKnownTrait::Sized => sized::add_sized_program_clauses(db, builder, &trait_ref, ty),
             WellKnownTrait::Copy => copy::add_copy_program_clauses(db, builder, &trait_ref, ty),
             WellKnownTrait::Clone => clone::add_clone_program_clauses(db, builder, &trait_ref, ty),
+            WellKnownTrait::FnOnceTrait => {
+                fn_::add_fn_once_program_clauses(db, builder, &trait_ref, ty)
+            }
             // Drop impls are provided explicitly
             WellKnownTrait::Drop => (),
         }

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -34,7 +34,7 @@ pub fn add_builtin_program_clauses<I: Interner>(
             WellKnownTrait::Copy => copy::add_copy_program_clauses(db, builder, &trait_ref, ty),
             WellKnownTrait::Clone => clone::add_clone_program_clauses(db, builder, &trait_ref, ty),
             WellKnownTrait::FnOnce | WellKnownTrait::FnMut | WellKnownTrait::Fn => {
-                fn_family::add_fn_trait_program_clauses(db, builder, trait_ref.trait_id, ty)
+                fn_family::add_fn_trait_program_clauses(db, builder, trait_ref.trait_id, self_ty)
             }
             // Drop impls are provided explicitly
             WellKnownTrait::Drop => (),
@@ -55,7 +55,7 @@ pub fn add_builtin_assoc_program_clauses<I: Interner>(
             let interner = db.interner();
             let self_ty = AliasTy::Projection(proj.clone()).self_type_parameter(interner);
             let trait_id = db.well_known_trait_id(well_known).unwrap();
-            fn_family::add_fn_trait_program_clauses(db, builder, trait_id, self_ty.data(interner));
+            fn_family::add_fn_trait_program_clauses(db, builder, trait_id, self_ty);
         }
         _ => {}
     }

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -33,7 +33,7 @@ pub fn add_builtin_program_clauses<I: Interner>(
             WellKnownTrait::Sized => sized::add_sized_program_clauses(db, builder, &trait_ref, ty),
             WellKnownTrait::Copy => copy::add_copy_program_clauses(db, builder, &trait_ref, ty),
             WellKnownTrait::Clone => clone::add_clone_program_clauses(db, builder, &trait_ref, ty),
-            WellKnownTrait::FnOnceTrait | WellKnownTrait::FnMutTrait | WellKnownTrait::FnTrait => {
+            WellKnownTrait::FnOnce | WellKnownTrait::FnMut | WellKnownTrait::Fn => {
                 fn_::add_fn_trait_program_clauses(db, builder, trait_ref.trait_id, ty, false)
             }
             // Drop impls are provided explicitly
@@ -51,7 +51,7 @@ pub fn add_builtin_assoc_program_clauses<I: Interner>(
     proj: &ProjectionTy<I>,
 ) {
     match well_known {
-        WellKnownTrait::FnOnceTrait => {
+        WellKnownTrait::FnOnce => {
             let interner = db.interner();
             let self_ty = proj
                 .substitution

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -1,6 +1,6 @@
 use super::{builder::ClauseBuilder, generalize};
 use crate::{Interner, RustIrDatabase, TraitRef, WellKnownTrait};
-use chalk_ir::{AliasTy, ProjectionTy, Substitution, Ty};
+use chalk_ir::{Substitution, Ty};
 
 mod clone;
 mod copy;
@@ -48,12 +48,10 @@ pub fn add_builtin_assoc_program_clauses<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,
     well_known: WellKnownTrait,
-    proj: &ProjectionTy<I>,
+    self_ty: Ty<I>,
 ) {
     match well_known {
         WellKnownTrait::FnOnce => {
-            let interner = db.interner();
-            let self_ty = AliasTy::Projection(proj.clone()).self_type_parameter(interner);
             let trait_id = db.well_known_trait_id(well_known).unwrap();
             fn_family::add_fn_trait_program_clauses(db, builder, trait_id, self_ty);
         }

--- a/chalk-solve/src/clauses/builtin_traits/fn_.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_.rs
@@ -1,0 +1,47 @@
+use crate::clauses::ClauseBuilder;
+use crate::infer::instantiate::IntoBindersAndValue;
+use crate::{Interner, RustIrDatabase, TraitRef};
+use chalk_ir::{ApplicationTy, Binders, Substitution, Ty, TyData, TypeName, VariableKinds};
+
+pub fn add_fn_once_program_clauses<I: Interner>(
+    db: &dyn RustIrDatabase<I>,
+    builder: &mut ClauseBuilder<'_, I>,
+    trait_ref: &TraitRef<I>,
+    ty: &TyData<I>,
+) {
+    match ty {
+        TyData::Function(fn_val) => {
+            let interner = db.interner();
+            let (binders, sub) = fn_val.into_binders_and_value(interner);
+
+            // We are constructing a reference to `FnOnce<Args>`, where
+            // `Args` is a tuple of the function's argument types
+            let tupled = Ty::new(
+                interner,
+                TyData::Apply(ApplicationTy {
+                    name: TypeName::Tuple(sub.len(interner)),
+                    substitution: sub.clone(),
+                }),
+            );
+
+            let self_ty = Ty::new(interner, ty);
+
+            let tupled_sub = Substitution::from(interner, vec![self_ty, tupled]);
+            // Given a function type `fn(A1, A2, ..., AN)`, construct a `TraitRef`
+            // of the form `fn(A1, A2, ..., AN): FnOnce<(A1, A2, ..., AN)>`
+            let new_trait_ref = TraitRef {
+                trait_id: trait_ref.trait_id,
+                substitution: tupled_sub,
+            };
+
+            // Functions types come with a binder, which we push so
+            // that the `TraitRef` properly references any bound lifetimes
+            // (e.g. `for<'a> fn(&'a u8): FnOnce<(&'b u8)>`)
+            let bound_ref = Binders::new(VariableKinds::from(interner, binders), new_trait_ref);
+            builder.push_binders(&bound_ref, |this, inner_trait| {
+                this.push_fact(inner_trait);
+            })
+        }
+        _ => {}
+    }
+}

--- a/chalk-solve/src/clauses/builtin_traits/fn_.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_.rs
@@ -60,9 +60,9 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
             let bound_ref = Binders::new(VariableKinds::from(interner, binders), new_trait_ref);
             builder.push_binders(&bound_ref, |this, inner_trait| {
                 if assoc_output {
-                    //The `Output` type is defined on the `FnOnceTrait`
+                    //The `Output` type is defined on the `FnOnce`
                     let fn_once = db.trait_datum(trait_id);
-                    assert_eq!(fn_once.well_known, Some(WellKnownTrait::FnOnceTrait));
+                    assert_eq!(fn_once.well_known, Some(WellKnownTrait::FnOnce));
                     let assoc_types = &fn_once.associated_ty_ids;
                     if assoc_types.len() != 1 {
                         panic!(

--- a/chalk-solve/src/clauses/builtin_traits/fn_.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_.rs
@@ -3,7 +3,8 @@ use crate::infer::instantiate::IntoBindersAndValue;
 use crate::{Interner, RustIrDatabase, TraitRef};
 use chalk_ir::{ApplicationTy, Binders, Substitution, Ty, TyData, TypeName, VariableKinds};
 
-pub fn add_fn_once_program_clauses<I: Interner>(
+// Handles clauses for FnOnce/FnMut/Fn
+pub fn add_fn_trait_program_clauses<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,
     trait_ref: &TraitRef<I>,

--- a/chalk-solve/src/clauses/builtin_traits/fn_.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_.rs
@@ -1,27 +1,46 @@
 use crate::clauses::ClauseBuilder;
 use crate::infer::instantiate::IntoBindersAndValue;
+use crate::rust_ir::WellKnownTrait;
 use crate::{Interner, RustIrDatabase, TraitRef};
-use chalk_ir::{ApplicationTy, Binders, Substitution, Ty, TyData, TypeName, VariableKinds};
+use chalk_ir::{
+    AliasTy, ApplicationTy, Binders, Normalize, ProjectionTy, Substitution, TraitId, Ty, TyData,
+    TypeName, VariableKinds,
+};
 
-// Handles clauses for FnOnce/FnMut/Fn
+/// Handles clauses for FnOnce/FnMut/Fn.
+/// If `assoc_output` is `true`, we push a clause of the form
+/// `Normalize(<fn(A) -> B as FnOnce<(A,)>>::Output -> B) :- Implemented(fn(A) -> B as FnOnce<(A,)>`
+///
+/// If `assoc_output` is `false`, we push a clause of the form
+/// `Implemented(fn(A) -> B as FnOnce<(A,)>)`
 pub fn add_fn_trait_program_clauses<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,
-    trait_ref: &TraitRef<I>,
+    trait_id: TraitId<I>,
     ty: &TyData<I>,
+    assoc_output: bool,
 ) {
     match ty {
         TyData::Function(fn_val) => {
             let interner = db.interner();
-            let (binders, sub) = fn_val.into_binders_and_value(interner);
+            let (binders, orig_sub) = fn_val.into_binders_and_value(interner);
+            // Take all of the arguments except for the last one, which
+            // represents the return type
+            let arg_sub = Substitution::from(
+                interner,
+                orig_sub.iter(interner).take(orig_sub.len(interner) - 1),
+            );
+            let fn_output_ty = orig_sub
+                .at(interner, orig_sub.len(interner) - 1)
+                .assert_ty_ref(interner);
 
             // We are constructing a reference to `FnOnce<Args>`, where
             // `Args` is a tuple of the function's argument types
             let tupled = Ty::new(
                 interner,
                 TyData::Apply(ApplicationTy {
-                    name: TypeName::Tuple(sub.len(interner)),
-                    substitution: sub.clone(),
+                    name: TypeName::Tuple(arg_sub.len(interner)),
+                    substitution: arg_sub.clone(),
                 }),
             );
 
@@ -31,8 +50,8 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
             // Given a function type `fn(A1, A2, ..., AN)`, construct a `TraitRef`
             // of the form `fn(A1, A2, ..., AN): FnOnce<(A1, A2, ..., AN)>`
             let new_trait_ref = TraitRef {
-                trait_id: trait_ref.trait_id,
-                substitution: tupled_sub,
+                trait_id,
+                substitution: tupled_sub.clone(),
             };
 
             // Functions types come with a binder, which we push so
@@ -40,7 +59,33 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
             // (e.g. `for<'a> fn(&'a u8): FnOnce<(&'b u8)>`)
             let bound_ref = Binders::new(VariableKinds::from(interner, binders), new_trait_ref);
             builder.push_binders(&bound_ref, |this, inner_trait| {
-                this.push_fact(inner_trait);
+                if assoc_output {
+                    //The `Output` type is defined on the `FnOnceTrait`
+                    let fn_once = db.trait_datum(trait_id);
+                    assert_eq!(fn_once.well_known, Some(WellKnownTrait::FnOnceTrait));
+                    let assoc_types = &fn_once.associated_ty_ids;
+                    if assoc_types.len() != 1 {
+                        panic!(
+                            "FnOnce trait should have exactly one associated type, found {:?}",
+                            assoc_types
+                        );
+                    }
+
+                    // Construct `Normalize(<fn(A) -> B as FnOnce<(A,)>>::Output -> B)`
+                    let assoc_output_ty = assoc_types[0];
+                    let proj_ty = ProjectionTy {
+                        associated_ty_id: assoc_output_ty,
+                        substitution: tupled_sub,
+                    };
+                    let normalize = Normalize {
+                        alias: AliasTy::Projection(proj_ty),
+                        ty: fn_output_ty.clone(),
+                    };
+
+                    this.push_clause(normalize, std::iter::once(inner_trait));
+                } else {
+                    this.push_fact(inner_trait);
+                }
             })
         }
         _ => {}

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -25,7 +25,6 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
             let (binders, orig_sub) = fn_val.into_binders_and_value(interner);
             let bound_ref = Binders::new(VariableKinds::from(interner, binders), orig_sub);
             builder.push_binders(&bound_ref, |builder, orig_sub| {
-
                 let all_params: Vec<_> = orig_sub.iter(interner).cloned().collect();
 
                 // The last parameter represents the function return type

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -23,15 +23,12 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
     match self_ty.data(interner) {
         TyData::Function(fn_val) => {
             let (binders, orig_sub) = fn_val.into_binders_and_value(interner);
-            // Take all of the arguments except for the last one, which
-            // represents the return type
-            let arg_sub = Substitution::from(
-                interner,
-                orig_sub.iter(interner).take(orig_sub.len(interner) - 1),
-            );
-            let fn_output_ty = orig_sub
-                .at(interner, orig_sub.len(interner) - 1)
-                .assert_ty_ref(interner);
+            let all_params: Vec<_> = orig_sub.iter(interner).cloned().collect();
+
+            // The last parameter represents the function return type
+            let (arg_sub, fn_output_ty) = all_params.split_at(all_params.len() - 1);
+            let arg_sub = Substitution::from(interner, arg_sub);
+            let fn_output_ty = fn_output_ty[0].assert_ty_ref(interner);
 
             // We are constructing a reference to `FnOnce<Args>`, where
             // `Args` is a tuple of the function's argument types

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -63,12 +63,12 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
                     let fn_once = db.trait_datum(trait_id);
                     assert_eq!(fn_once.well_known, Some(WellKnownTrait::FnOnce));
                     let assoc_types = &fn_once.associated_ty_ids;
-                    if assoc_types.len() != 1 {
-                        panic!(
-                            "FnOnce trait should have exactly one associated type, found {:?}",
-                            assoc_types
-                        );
-                    }
+                    assert_eq!(
+                        assoc_types.len(),
+                        1,
+                        "FnOnce trait should have exactly one associated type, found {:?}",
+                        assoc_types
+                    );
 
                     // Construct `Normalize(<fn(A) -> B as FnOnce<(A,)>>::Output -> B)`
                     let assoc_output_ty = assoc_types[0];
@@ -81,7 +81,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
                         ty: fn_output_ty.clone(),
                     };
 
-                    this.push_clause(normalize, std::iter::once(inner_trait));
+                    this.push_fact(normalize);
                 }
             });
         }

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -17,11 +17,11 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,
     trait_id: TraitId<I>,
-    ty: &TyData<I>,
+    self_ty: Ty<I>,
 ) {
-    match ty {
+    let interner = db.interner();
+    match self_ty.data(interner) {
         TyData::Function(fn_val) => {
-            let interner = db.interner();
             let (binders, orig_sub) = fn_val.into_binders_and_value(interner);
             // Take all of the arguments except for the last one, which
             // represents the return type
@@ -43,9 +43,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
                 }),
             );
 
-            let self_ty = Ty::new(interner, ty);
-
-            let tupled_sub = Substitution::from(interner, vec![self_ty, tupled]);
+            let tupled_sub = Substitution::from(interner, vec![self_ty.clone(), tupled]);
             // Given a function type `fn(A1, A2, ..., AN)`, construct a `TraitRef`
             // of the form `fn(A1, A2, ..., AN): FnOnce<(A1, A2, ..., AN)>`
             let new_trait_ref = TraitRef {

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -219,9 +219,9 @@ pub enum WellKnownTrait {
     /// The trait `FnOnce<Args>` - the generic argument `Args` is always a tuple
     /// corresponding to the arguments of a function implementing this trait.
     /// E.g. `fn(u8, bool): FnOnce<(u8, bool)>`
-    FnOnceTrait,
-    FnMutTrait,
-    FnTrait,
+    FnOnce,
+    FnMut,
+    Fn,
 }
 
 impl<I: Interner> TraitDatum<I> {

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -220,6 +220,8 @@ pub enum WellKnownTrait {
     /// corresponding to the arguments of a function implementing this trait.
     /// E.g. `fn(u8, bool): FnOnce<(u8, bool)>`
     FnOnceTrait,
+    FnMutTrait,
+    FnTrait,
 }
 
 impl<I: Interner> TraitDatum<I> {

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -216,6 +216,10 @@ pub enum WellKnownTrait {
     Copy,
     Clone,
     Drop,
+    /// The trait `FnOnce<Args>` - the generic argument `Args` is always a tuple
+    /// corresponding to the arguments of a function implementing this trait.
+    /// E.g. `fn(u8, bool): FnOnce<(u8, bool)>`
+    FnOnceTrait,
 }
 
 impl<I: Interner> TraitDatum<I> {

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -471,7 +471,7 @@ impl WfWellKnownGoals {
     ) -> Option<Goal<I>> {
         match db.trait_datum(trait_ref.trait_id).well_known? {
             WellKnownTrait::Copy => Self::copy_impl_constraint(db, trait_ref),
-            WellKnownTrait::Drop | WellKnownTrait::Clone | WellKnownTrait::Sized => None,
+            WellKnownTrait::Drop | WellKnownTrait::Clone | WellKnownTrait::Sized | WellKnownTrait::FnOnceTrait => None,
         }
     }
 
@@ -486,7 +486,7 @@ impl WfWellKnownGoals {
 
         match db.trait_datum(impl_datum.trait_id()).well_known? {
             // You can't add a manual implementation of Sized
-            WellKnownTrait::Sized => Some(GoalData::CannotProve(()).intern(interner)),
+            WellKnownTrait::Sized | WellKnownTrait::FnOnceTrait => Some(GoalData::CannotProve(()).intern(interner)),
             WellKnownTrait::Drop => Self::drop_impl_constraint(db, impl_datum),
             WellKnownTrait::Copy | WellKnownTrait::Clone => None,
         }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -471,7 +471,12 @@ impl WfWellKnownGoals {
     ) -> Option<Goal<I>> {
         match db.trait_datum(trait_ref.trait_id).well_known? {
             WellKnownTrait::Copy => Self::copy_impl_constraint(db, trait_ref),
-            WellKnownTrait::Drop | WellKnownTrait::Clone | WellKnownTrait::Sized | WellKnownTrait::FnOnceTrait => None,
+            WellKnownTrait::Drop
+            | WellKnownTrait::Clone
+            | WellKnownTrait::Sized
+            | WellKnownTrait::FnOnceTrait
+            | WellKnownTrait::FnMutTrait
+            | WellKnownTrait::FnTrait => None,
         }
     }
 
@@ -486,7 +491,10 @@ impl WfWellKnownGoals {
 
         match db.trait_datum(impl_datum.trait_id()).well_known? {
             // You can't add a manual implementation of Sized
-            WellKnownTrait::Sized | WellKnownTrait::FnOnceTrait => Some(GoalData::CannotProve(()).intern(interner)),
+            WellKnownTrait::Sized
+            | WellKnownTrait::FnOnceTrait
+            | WellKnownTrait::FnMutTrait
+            | WellKnownTrait::FnTrait => Some(GoalData::CannotProve(()).intern(interner)),
             WellKnownTrait::Drop => Self::drop_impl_constraint(db, impl_datum),
             WellKnownTrait::Copy | WellKnownTrait::Clone => None,
         }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -474,9 +474,9 @@ impl WfWellKnownGoals {
             WellKnownTrait::Drop
             | WellKnownTrait::Clone
             | WellKnownTrait::Sized
-            | WellKnownTrait::FnOnceTrait
-            | WellKnownTrait::FnMutTrait
-            | WellKnownTrait::FnTrait => None,
+            | WellKnownTrait::FnOnce
+            | WellKnownTrait::FnMut
+            | WellKnownTrait::Fn => None,
         }
     }
 
@@ -492,9 +492,9 @@ impl WfWellKnownGoals {
         match db.trait_datum(impl_datum.trait_id()).well_known? {
             // You can't add a manual implementation of Sized
             WellKnownTrait::Sized
-            | WellKnownTrait::FnOnceTrait
-            | WellKnownTrait::FnMutTrait
-            | WellKnownTrait::FnTrait => Some(GoalData::CannotProve(()).intern(interner)),
+            | WellKnownTrait::FnOnce
+            | WellKnownTrait::FnMut
+            | WellKnownTrait::Fn => Some(GoalData::CannotProve(()).intern(interner)),
             WellKnownTrait::Drop => Self::drop_impl_constraint(db, impl_datum),
             WellKnownTrait::Copy | WellKnownTrait::Clone => None,
         }

--- a/tests/test/functions.rs
+++ b/tests/test/functions.rs
@@ -6,10 +6,28 @@ fn function_implement_fn_once() {
         program {
             #[lang(fn_once)]
             trait FnOnce<Args> { }
+
+            #[lang(fn_mut)]
+            trait FnMut<Args> where Self: FnOnce<Args> { }
+
+            #[lang(fn)]
+            trait Fn<Args> where Self: FnMut<Args> { }
         }
 
         goal {
             fn(u8): FnOnce<(u8,)>
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            fn(u8): FnMut<(u8,)>
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            fn(u8): Fn<(u8,)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }

--- a/tests/test/functions.rs
+++ b/tests/test/functions.rs
@@ -1,6 +1,66 @@
 use super::*;
 
 #[test]
+fn function_implement_fn_once() {
+    test! {
+        program {
+            #[lang(fn_once)]
+            trait FnOnce<Args> { }
+        }
+
+        goal {
+            fn(u8): FnOnce<(u8,)>
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            fn(u8, u32): FnOnce<(u8,u32)>
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            fn(i32): FnOnce<(bool,)>
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            forall<'a> {
+                for<'b> fn(&'b u8): FnOnce<(&'a u8,)>
+            }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            forall<'a, 'b> {
+                for<'c> fn(&'c u8, &'c i32): FnOnce<(&'a u8, &'b i32)>
+            }
+        } yields {
+            "Unique; substitution [], lifetime constraints [InEnvironment { environment: Env([]), goal: '!1_0: '!1_1 }, InEnvironment { environment: Env([]), goal: '!1_1: '!1_0 }]"
+        }
+
+        goal {
+            forall<T, U> {
+                fn(T, T): FnOnce<(T, U)>
+            }
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            forall<T, U> {
+                fn(T, U): FnOnce<(T, T)>
+            }
+        } yields {
+            "No possible solution"
+        }
+    }
+}
+
+#[test]
 fn functions_are_sized() {
     test! {
         program {

--- a/tests/test/functions.rs
+++ b/tests/test/functions.rs
@@ -16,42 +16,54 @@ fn function_implement_fn_traits() {
             trait Fn<Args> where Self: FnMut<Args> { }
         }
 
+        // Simple test: make sure a fully monomorphic type implements FnOnce
         goal {
             fn(u8): FnOnce<(u8,)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
 
+        // Same as above, but for FnMut
         goal {
             fn(u8): FnMut<(u8,)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
 
+        // Same as above, but for Fn
         goal {
             fn(u8): Fn<(u8,)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
 
+        // Function pointres implicity return `()` when no return
+        // type is specified - make sure that normalization understands
+        // this
         goal {
             Normalize(<fn(u8) as FnOnce<(u8,)>>::Output -> ())
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
 
+        // Tests normalizing when an explicit return type is used
         goal {
             Normalize(<fn(u8) -> bool as FnOnce<(u8,)>>::Output -> bool)
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
 
+        // Tests that we fail to normalize when there's a mismatch with
+        // fully monomorphic types.
         goal {
             Normalize(<fn(u8) -> bool as FnOnce<(u8,)>>::Output -> u8)
         } yields {
             "No possible solution"
         }
 
+        // Ensures that we don't find a solution when doing so would
+        // require us to conclude that two different universally quantified
+        // types (T and V) are equal.
         goal {
             forall<T, V> {
                 Normalize(<fn(u8, V) -> T as FnOnce<(u8, V)>>::Output -> V)
@@ -60,6 +72,7 @@ fn function_implement_fn_traits() {
             "No possible solution"
         }
 
+        // Tests that we can normalize a generic function pointer type
         goal {
             forall<T, V> {
                 exists<U> {
@@ -70,18 +83,25 @@ fn function_implement_fn_traits() {
             "Unique; substitution [?0 := !1_0], lifetime constraints []"
         }
 
+        // Tests that we properly tuple function arguments when constrcting
+        // the `FnOnce` impl
         goal {
             fn(u8, u32): FnOnce<(u8,u32)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
 
+        // Tests that we don't find a solution when fully monomorphic
+        // types are mismatched
         goal {
             fn(i32): FnOnce<(bool,)>
         } yields {
             "No possible solution"
         }
 
+        // Tests function pointer types that use the function's binder
+        // Universally quantified lifetimes that differ only in their
+        // name ('a vs 'b) should be considered equivalent here
         goal {
             forall<'a> {
                 for<'b> fn(&'b u8): FnOnce<(&'a u8,)>
@@ -90,6 +110,10 @@ fn function_implement_fn_traits() {
             "Unique; substitution [], lifetime constraints []"
         }
 
+        // Tests that a 'stricter' function (requires lifetimes to be the same)
+        // can implement `FnOnce` for a 'less strict' signature (dose not require
+        // lifetimes to be the same), provided that the lifetimes are *actually*
+        // the same.
         goal {
             forall<'a, 'b> {
                 for<'c> fn(&'c u8, &'c i32): FnOnce<(&'a u8, &'b i32)>
@@ -98,6 +122,22 @@ fn function_implement_fn_traits() {
             "Unique; substitution [], lifetime constraints [InEnvironment { environment: Env([]), goal: '!1_0: '!1_1 }, InEnvironment { environment: Env([]), goal: '!1_1: '!1_0 }]"
         }
 
+        // Tests the opposite case as the previous test: a 'less strict' function
+        // (does not require lifetimes to be the same) can implement `FnOnce` for
+        // a 'stricter' signature (requires lifetimes to be the same) without
+        // any additional requirements
+        goal {
+            forall<'a> {
+                for<'b, 'c> fn(&'b u8, &'c i32): FnOnce<(&'a u8, &'a i32)>
+            }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        // Similiar to the above test, but for types instead of lifetimes:
+        // a 'stricter' function (requires types to be the same) can never
+        // implement `FnOnce` for a 'less strict' signature (does not require
+        // types to be the same)
         goal {
             forall<T, U> {
                 fn(T, T): FnOnce<(T, U)>
@@ -106,6 +146,9 @@ fn function_implement_fn_traits() {
             "No possible solution"
         }
 
+        // Tests the opposite case as a previous test: a 'less strict'
+        // function can never implement 'FnOnce' for a 'more strict' signature
+        // (does not require types to bthe same)
         goal {
             forall<T, U> {
                 fn(T, U): FnOnce<(T, T)>

--- a/tests/test/functions.rs
+++ b/tests/test/functions.rs
@@ -1,11 +1,13 @@
 use super::*;
 
 #[test]
-fn function_implement_fn_once() {
+fn function_implement_fn_traits() {
     test! {
         program {
             #[lang(fn_once)]
-            trait FnOnce<Args> { }
+            trait FnOnce<Args> {
+                type Output;
+            }
 
             #[lang(fn_mut)]
             trait FnMut<Args> where Self: FnOnce<Args> { }
@@ -30,6 +32,42 @@ fn function_implement_fn_once() {
             fn(u8): Fn<(u8,)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            Normalize(<fn(u8) as FnOnce<(u8,)>>::Output -> ())
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            Normalize(<fn(u8) -> bool as FnOnce<(u8,)>>::Output -> bool)
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            Normalize(<fn(u8) -> bool as FnOnce<(u8,)>>::Output -> u8)
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            forall<T, V> {
+                Normalize(<fn(u8, V) -> T as FnOnce<(u8, V)>>::Output -> V)
+            }
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            forall<T, V> {
+                exists<U> {
+                    Normalize(<fn(u8, V) -> T as FnOnce<(u8, V)>>::Output -> U)
+                }
+            }
+        } yields {
+            "Unique; substitution [?0 := !1_0], lifetime constraints []"
         }
 
         goal {

--- a/tests/test/functions.rs
+++ b/tests/test/functions.rs
@@ -14,6 +14,12 @@ fn function_implement_fn_traits() {
 
             #[lang(fn)]
             trait Fn<Args> where Self: FnMut<Args> { }
+
+            struct Ty { }
+
+            trait Clone { }
+            opaque type MyOpaque: Clone = Ty;
+
         }
 
         // Simple test: make sure a fully monomorphic type implements FnOnce
@@ -155,6 +161,22 @@ fn function_implement_fn_traits() {
             }
         } yields {
             "No possible solution"
+        }
+
+        // Tests that we flounder for inference variables
+        goal {
+            exists<T> {
+                T: FnOnce<()>
+            }
+        } yields_first[SolverChoice::slg(3, None)] {
+            "Floundered"
+        }
+
+        // Tests that we flounder for alias type (opaque)
+        goal {
+            MyOpaque: FnOnce<()>
+        } yields_first[SolverChoice::slg(3, None)] {
+            "Floundered"
         }
     }
 }


### PR DESCRIPTION
Works towards #363

I've followed the approach taken by rustc, where `FnOnce` has single
generic argument: the tupled function parameters
(e.g. `fn(u8, bool): FnOnce<(u8, bool)>`).

I also extended the grammar to allow functions to take more than one
argument.