### PR TITLE
Where clauses on opaque types

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -512,11 +512,11 @@ impl LowerProgram for Program {
                                         chalk_ir::VariableKind::Ty(TyKind::General),
                                         Atom::from(FIXME_SELF),
                                     )),
-                                    |env1| {
-                                        let interner = env1.interner();
+                                    |env| {
+                                        let interner = env.interner();
                                         Ok(opaque_ty
                                             .bounds
-                                            .lower(&env1)?
+                                            .lower(&env)?
                                             .iter()
                                             .flat_map(|qil| {
                                                 // Instantiate the bounds with the innermost bound variable, which represents Self, as the self type.
@@ -529,6 +529,7 @@ impl LowerProgram for Program {
                                                     .intern(interner),
                                                 )
                                             })
+                                            .chain(opaque_ty.where_clauses.lower(&env)?)
                                             .collect())
                                     },
                                 )?;

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -95,6 +95,7 @@ pub struct OpaqueTyDefn {
     pub variable_kinds: Vec<VariableKind>,
     pub identifier: Identifier,
     pub bounds: Vec<QuantifiedInlineBound>,
+    pub where_clauses: Vec<QuantifiedWhereClause>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -73,7 +73,7 @@ FnReturn: Ty = {
 };
 
 FnDefn: FnDefn = {
-    "fn" <n:Id> <p:Angle<VariableKind>>"(" <args:FnArgs> ")" 
+    "fn" <n:Id> <p:Angle<VariableKind>>"(" <args:FnArgs> ")"
         <ret_ty:FnReturn?> <w:QuantifiedWhereClauses> ";" => FnDefn
     {
         name: n,
@@ -127,12 +127,14 @@ AssocTyDefn: AssocTyDefn = {
 };
 
 OpaqueTyDefn: OpaqueTyDefn = {
-    "opaque" "type" <identifier:Id> <p:Angle<VariableKind>> ":" <b:Plus<QuantifiedInlineBound>> "=" <ty:Ty> ";" => {
+    "opaque" "type" <identifier:Id> <p:Angle<VariableKind>> ":" <b:Plus<QuantifiedInlineBound>>
+        <w:QuantifiedWhereClauses> "=" <ty:Ty> ";" => {
         OpaqueTyDefn {
             ty,
             variable_kinds: p,
             identifier,
             bounds: b,
+            where_clauses: w,
         }
     }
 };
@@ -241,7 +243,7 @@ TyWithoutId: Ty = {
     "*" <m: RawMutability> <t:Ty> => Ty::Raw{ mutability: m, ty: Box::new(t) },
     "&" <l: Lifetime> "mut" <t:Ty> => Ty::Ref{ mutability: Mutability::Mut, lifetime: l, ty: Box::new(t) },
     "&" <l: Lifetime> <t:Ty> => Ty::Ref{ mutability: Mutability::Not, lifetime: l, ty: Box::new(t) },
-    "[" <t:Ty> "]" => Ty::Slice { ty: Box::new(t) }, 
+    "[" <t:Ty> "]" => Ty::Slice { ty: Box::new(t) },
     "[" <t:Ty> ";" <len:Const> "]" => Ty::Array { ty: Box::new(t), len },
 };
 

--- a/tests/test/opaque_types.rs
+++ b/tests/test/opaque_types.rs
@@ -47,6 +47,26 @@ fn opaque_reveal() {
 }
 
 #[test]
+fn opaque_where_clause() {
+    test! {
+        program {
+            struct Ty { }
+
+            trait Clone { }
+            trait Trait { }
+            impl Trait for Ty { }
+            opaque type T: Clone where T: Trait = Ty;
+        }
+
+        goal {
+            T: Trait
+        } yields {
+            "Unique; substitution []"
+        }
+    }
+}
+
+#[test]
 fn opaque_generics_simple() {
     test! {
         program {


### PR DESCRIPTION
I slightly prefer this:
```
opaque type T: Clone where T: Trait = Ty;
```
to this:
```
opaque type T: Clone = Ty where T: Trait;
```
since the where clause is on the bounds, not on the hidden type `Ty`