### PR TITLE
[WIP] WF checks for opaque types

### DIFF
--- a/chalk-integration/src/query.rs
+++ b/chalk-integration/src/query.rs
@@ -108,6 +108,10 @@ fn checked_program(db: &impl LoweringDatabase) -> Result<Arc<Program>, ChalkErro
             solver.verify_trait_impl(impl_id)?;
         }
 
+        for &opaque_id in program.opaque_ty_data.keys() {
+            solver.verify_opaque_type(opaque_id)?;
+        }
+
         Ok(())
     })?;
 

--- a/tests/test/opaque_types.rs
+++ b/tests/test/opaque_types.rs
@@ -66,7 +66,6 @@ fn opaque_generics_simple() {
         } yields {
             "Unique; substitution []"
         }
-
     }
 }
 

--- a/tests/test/wf_lowering.rs
+++ b/tests/test/wf_lowering.rs
@@ -819,3 +819,16 @@ fn drop_constraints() {
         }
     }
 }
+
+#[test]
+fn opaque_type_constraints() {
+    lowering_error! {
+        program {
+            trait MyTrait { }
+            struct S { }
+
+            opaque type T: MyTrait = S;
+    } error_msg {
+        "opaque type `T` does not meet well-formedness requirements"
+    }}
+}


### PR DESCRIPTION
Given this opaque type:
```
opaque type Foo<T>: A<U> + B<V> = HiddenTy<T>
```

The WF check should be something along these lines:
```
forall<T> {
    exists<U, V> {
        if (FromEnv(HiddenTy<T>: A<U>) && FromEnv(HiddenTy<T>: B<V>)) {
            FromEnv(Foo<T>: A<U>) && FromEnv(Foo<T>: B<V>)
        }
    }
}
```

Splitting it up might also be possible, but would run into problems when there are where clauses into play.