### PR TITLE
remove IntoIterator impl for &Binders

### DIFF
--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1655,22 +1655,6 @@ where
     }
 }
 
-/// Allows iterating over a `&Binders<Vec<T>>`, for instance. Each
-/// element will be a `Binders<&T>`.
-impl<'a, V> IntoIterator for &'a Binders<V>
-where
-    V: HasInterner,
-    &'a V: IntoIterator,
-    <&'a V as IntoIterator>::Item: HasInterner<Interner = V::Interner>,
-{
-    type Item = Binders<<&'a V as IntoIterator>::Item>;
-    type IntoIter = BindersIntoIterator<&'a V>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.map_ref(|r| r).into_iter()
-    }
-}
-
 /// Allows iterating over a Binders<Vec<T>>, for instance.
 /// Each element will include the same set of parameter bounds.
 impl<V, U> IntoIterator for Binders<V>

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -168,7 +168,7 @@ impl<I: Interner> ToProgramClauses<I> for OpaqueTyDatum<I> {
             ));
 
             let substitution = Substitution::from1(interner, alias_placeholder_ty.clone());
-            for bound in &opaque_ty_bound.bounds {
+            for bound in opaque_ty_bound.bounds {
                 // Implemented(!T<..>: Bound).
                 let bound_with_placeholder_ty = bound.substitute(interner, &substitution);
                 builder.push_binders(&bound_with_placeholder_ty, |builder, bound| {


### PR DESCRIPTION
Removing a redundant `IntoIterator` impl for `&Binders` following [this](https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/Unfriendly.20chalk.20error.20in.20rustc/near/200161806) zulip convo. 

The reason to do this is 
a) you can achieve the same effect by doing `binders.as_ref().into_iter()` 
b) because of the somewhat recursive nature of the definition (both `Item` and `Self` contain `Binders<_>`) it often results in cryptic errors if typechecking is unsuccessfull (you can check zulip convo for examples).