### PR TITLE
Recursive solver factoring and privacy

### DIFF
--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -5,9 +5,9 @@ mod search_graph;
 mod solve;
 mod stack;
 
-use self::fulfill::RecursiveSolver;
 use self::lib::{Minimums, Solution, UCanonicalGoal};
 use self::search_graph::{DepthFirstNumber, SearchGraph};
+use self::solve::{SolveDatabase, SolveIteration};
 use self::stack::{Stack, StackDepth};
 use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
 use chalk_ir::interner::Interner;
@@ -186,7 +186,7 @@ impl<'me, I: Interner> Solver<'me, I> {
     }
 }
 
-impl<'me, I: Interner> RecursiveSolver<I> for Solver<'me, I> {
+impl<'me, I: Interner> SolveDatabase<I> for Solver<'me, I> {
     /// Attempt to solve a goal that has been fully broken down into leaf form
     /// and canonicalized. This is where the action really happens, and is the
     /// place where we would perform caching in rustc (and may eventually do in Chalk).
@@ -278,5 +278,9 @@ impl<'me, I: Interner> RecursiveSolver<I> for Solver<'me, I> {
 
     fn interner(&self) -> &I {
         &self.program.interner()
+    }
+
+    fn db(&self) -> &dyn RustIrDatabase<I> {
+        self.program
     }
 }

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -5,27 +5,15 @@ mod search_graph;
 mod solve;
 mod stack;
 
-use self::fulfill::{Fulfill, RecursiveInferenceTable, RecursiveSolver};
-use self::lib::{Guidance, Minimums, Solution, UCanonicalGoal};
+use self::fulfill::RecursiveSolver;
+use self::lib::{Minimums, Solution, UCanonicalGoal};
 use self::search_graph::{DepthFirstNumber, SearchGraph};
 use self::stack::{Stack, StackDepth};
-use crate::clauses::program_clauses_for_goal;
-use crate::infer::{InferenceTable, ParameterEnaVariableExt};
-use crate::solve::truncate;
 use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
-use chalk_ir::fold::Fold;
-use chalk_ir::interner::{HasInterner, Interner};
-use chalk_ir::visit::Visit;
-use chalk_ir::zip::Zip;
+use chalk_ir::interner::Interner;
 use chalk_ir::{debug, debug_heading, info, info_heading};
-use chalk_ir::{
-    Binders, Canonical, ClausePriority, ConstrainedSubst, Constraint, DomainGoal, Environment,
-    Fallible, Floundered, GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClause,
-    ProgramClauseData, ProgramClauseImplication, Substitution, UCanonical, UniverseMap,
-    VariableKinds,
-};
+use chalk_ir::{Canonical, ConstrainedSubst, Fallible};
 use rustc_hash::FxHashMap;
-use std::fmt::Debug;
 
 pub(crate) struct RecursiveContext<I: Interner> {
     stack: Stack,

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -196,14 +196,6 @@ impl<'me, I: Interner> Solver<'me, I> {
             self.context.search_graph.rollback_to(dfn + 1);
         }
     }
-
-    fn program_clauses_for_goal(
-        &self,
-        environment: &Environment<I>,
-        goal: &DomainGoal<I>,
-    ) -> Result<Vec<ProgramClause<I>>, Floundered> {
-        program_clauses_for_goal(self.program, environment, goal)
-    }
 }
 
 impl<'me, I: Interner> RecursiveSolver<I> for Solver<'me, I> {

--- a/chalk-solve/src/recursive/combine.rs
+++ b/chalk-solve/src/recursive/combine.rs
@@ -1,25 +1,7 @@
-use super::fulfill::{Fulfill, RecursiveInferenceTable, RecursiveSolver};
-use super::lib::{Guidance, Minimums, Solution, UCanonicalGoal};
-use super::search_graph::{DepthFirstNumber, SearchGraph};
-use super::stack::{Stack, StackDepth};
-use super::Solver;
-use crate::clauses::program_clauses_for_goal;
-use crate::infer::{InferenceTable, ParameterEnaVariableExt};
-use crate::solve::truncate;
-use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
-use chalk_ir::fold::Fold;
-use chalk_ir::interner::{HasInterner, Interner};
-use chalk_ir::visit::Visit;
-use chalk_ir::zip::Zip;
-use chalk_ir::{debug, debug_heading, info, info_heading};
-use chalk_ir::{
-    Binders, Canonical, ClausePriority, ConstrainedSubst, Constraint, DomainGoal, Environment,
-    Fallible, Floundered, GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClause,
-    ProgramClauseData, ProgramClauseImplication, Substitution, UCanonical, UniverseMap,
-    VariableKinds,
-};
-use rustc_hash::FxHashMap;
-use std::fmt::Debug;
+use super::lib::Solution;
+use chalk_ir::debug;
+use chalk_ir::interner::Interner;
+use chalk_ir::{ClausePriority, DomainGoal, Fallible, GenericArg, Goal, GoalData};
 
 pub(super) fn with_priorities_for_goal<I: Interner>(
     interner: &I,

--- a/chalk-solve/src/recursive/combine.rs
+++ b/chalk-solve/src/recursive/combine.rs
@@ -1,0 +1,94 @@
+use super::fulfill::{Fulfill, RecursiveInferenceTable, RecursiveSolver};
+use super::lib::{Guidance, Minimums, Solution, UCanonicalGoal};
+use super::search_graph::{DepthFirstNumber, SearchGraph};
+use super::stack::{Stack, StackDepth};
+use super::Solver;
+use crate::clauses::program_clauses_for_goal;
+use crate::infer::{InferenceTable, ParameterEnaVariableExt};
+use crate::solve::truncate;
+use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
+use chalk_ir::fold::Fold;
+use chalk_ir::interner::{HasInterner, Interner};
+use chalk_ir::visit::Visit;
+use chalk_ir::zip::Zip;
+use chalk_ir::{debug, debug_heading, info, info_heading};
+use chalk_ir::{
+    Binders, Canonical, ClausePriority, ConstrainedSubst, Constraint, DomainGoal, Environment,
+    Fallible, Floundered, GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClause,
+    ProgramClauseData, ProgramClauseImplication, Substitution, UCanonical, UniverseMap,
+    VariableKinds,
+};
+use rustc_hash::FxHashMap;
+use std::fmt::Debug;
+
+pub(super) fn with_priorities_for_goal<I: Interner>(
+    interner: &I,
+    goal: &Goal<I>,
+    a: Fallible<Solution<I>>,
+    prio_a: ClausePriority,
+    b: Fallible<Solution<I>>,
+    prio_b: ClausePriority,
+) -> (Fallible<Solution<I>>, ClausePriority) {
+    let domain_goal = match goal.data(interner) {
+        GoalData::DomainGoal(domain_goal) => domain_goal,
+        _ => {
+            // non-domain goals currently have no priorities, so we always take the new solution here
+            return (b, prio_b);
+        }
+    };
+    match (a, b) {
+        (Ok(a), Ok(b)) => {
+            let (solution, prio) = with_priorities(interner, domain_goal, a, prio_a, b, prio_b);
+            (Ok(solution), prio)
+        }
+        (Ok(solution), Err(_)) => (Ok(solution), prio_a),
+        (Err(_), Ok(solution)) => (Ok(solution), prio_b),
+        (Err(_), Err(e)) => (Err(e), prio_b),
+    }
+}
+
+pub(super) fn with_priorities<I: Interner>(
+    interner: &I,
+    domain_goal: &DomainGoal<I>,
+    a: Solution<I>,
+    prio_a: ClausePriority,
+    b: Solution<I>,
+    prio_b: ClausePriority,
+) -> (Solution<I>, ClausePriority) {
+    match (prio_a, prio_b, a, b) {
+        (ClausePriority::High, ClausePriority::Low, higher, lower)
+        | (ClausePriority::Low, ClausePriority::High, lower, higher) => {
+            // if we have a high-priority solution and a low-priority solution,
+            // the high-priority solution overrides *if* they are both for the
+            // same inputs -- we don't want a more specific high-priority
+            // solution overriding a general low-priority one. Currently inputs
+            // only matter for projections; in a goal like `AliasEq(<?0 as
+            // Trait>::Type = ?1)`, ?0 is the input.
+            let inputs_higher = calculate_inputs(interner, domain_goal, &higher);
+            let inputs_lower = calculate_inputs(interner, domain_goal, &lower);
+            if inputs_higher == inputs_lower {
+                debug!(
+                    "preferring solution: {:?} over {:?} because of higher prio",
+                    higher, lower
+                );
+                (higher, ClausePriority::High)
+            } else {
+                (higher.combine(lower, interner), ClausePriority::High)
+            }
+        }
+        (_, _, a, b) => (a.combine(b, interner), prio_a),
+    }
+}
+
+fn calculate_inputs<I: Interner>(
+    interner: &I,
+    domain_goal: &DomainGoal<I>,
+    solution: &Solution<I>,
+) -> Vec<GenericArg<I>> {
+    if let Some(subst) = solution.constrained_subst() {
+        let subst_goal = subst.value.subst.apply(&domain_goal, interner);
+        subst_goal.inputs(interner)
+    } else {
+        domain_goal.inputs(interner)
+    }
+}

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -1,4 +1,5 @@
 use super::lib::{Guidance, Minimums, Solution};
+use super::solve::SolveDatabase;
 use chalk_ir::cast::Cast;
 use chalk_ir::fold::Fold;
 use chalk_ir::interner::{HasInterner, Interner};
@@ -119,16 +120,6 @@ pub(super) trait RecursiveInferenceTable<I: Interner> {
     fn needs_truncation(&mut self, interner: &I, max_size: usize, value: impl Visit<I>) -> bool;
 }
 
-pub(super) trait RecursiveSolver<I: Interner> {
-    fn solve_goal(
-        &mut self,
-        goal: UCanonical<InEnvironment<Goal<I>>>,
-        minimums: &mut Minimums,
-    ) -> Fallible<Solution<I>>;
-
-    fn interner(&self) -> &I;
-}
-
 /// A `Fulfill` is where we actually break down complex goals, instantiate
 /// variables, and perform inference. It's highly stateful. It's generally used
 /// in Chalk to try to solve a goal, and then package up what was learned in a
@@ -142,7 +133,7 @@ pub(super) trait RecursiveSolver<I: Interner> {
 pub(super) struct Fulfill<
     's,
     I: Interner,
-    Solver: RecursiveSolver<I>,
+    Solver: SolveDatabase<I>,
     Infer: RecursiveInferenceTable<I>,
 > {
     solver: &'s mut Solver,
@@ -162,7 +153,7 @@ pub(super) struct Fulfill<
     cannot_prove: bool,
 }
 
-impl<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: RecursiveInferenceTable<I>>
+impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I>>
     Fulfill<'s, I, Solver, Infer>
 {
     pub(super) fn new_with_clause(

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -56,7 +56,7 @@ enum NegativeSolution {
     Ambiguous,
 }
 
-pub(crate) trait RecursiveInferenceTable<I: Interner> {
+pub(super) trait RecursiveInferenceTable<I: Interner> {
     fn instantiate_binders_universally<'a, T>(
         &mut self,
         interner: &'a I,
@@ -119,7 +119,7 @@ pub(crate) trait RecursiveInferenceTable<I: Interner> {
     fn needs_truncation(&mut self, interner: &I, max_size: usize, value: impl Visit<I>) -> bool;
 }
 
-pub trait RecursiveSolver<I: Interner> {
+pub(super) trait RecursiveSolver<I: Interner> {
     fn solve_goal(
         &mut self,
         goal: UCanonical<InEnvironment<Goal<I>>>,
@@ -139,7 +139,7 @@ pub trait RecursiveSolver<I: Interner> {
 /// of type inference in general. But when solving trait constraints, *fresh*
 /// `Fulfill` instances will be created to solve canonicalized, free-standing
 /// goals, and transport what was learned back to the outer context.
-pub(crate) struct Fulfill<
+pub(super) struct Fulfill<
     's,
     I: Interner,
     Solver: RecursiveSolver<I>,
@@ -165,7 +165,7 @@ pub(crate) struct Fulfill<
 impl<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: RecursiveInferenceTable<I>>
     Fulfill<'s, I, Solver, Infer>
 {
-    pub(crate) fn new_with_clause(
+    pub(super) fn new_with_clause(
         solver: &'s mut Solver,
         infer: Infer,
         subst: Substitution<I>,
@@ -209,7 +209,7 @@ impl<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: RecursiveInferenceTable
         Ok(fulfill)
     }
 
-    pub(crate) fn new_with_simplification(
+    pub(super) fn new_with_simplification(
         solver: &'s mut Solver,
         infer: Infer,
         subst: Substitution<I>,
@@ -263,7 +263,7 @@ impl<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: RecursiveInferenceTable
     ///
     /// Wraps `InferenceTable::unify`; any resulting normalizations are added
     /// into our list of pending obligations with the given environment.
-    pub(crate) fn unify<T>(&mut self, environment: &Environment<I>, a: &T, b: &T) -> Fallible<()>
+    pub(super) fn unify<T>(&mut self, environment: &Environment<I>, a: &T, b: &T) -> Fallible<()>
     where
         T: ?Sized + Zip<I> + Debug,
     {
@@ -283,7 +283,7 @@ impl<'s, I: Interner, Solver: RecursiveSolver<I>, Infer: RecursiveInferenceTable
 
     /// Create obligations for the given goal in the given environment. This may
     /// ultimately create any number of obligations.
-    pub(crate) fn push_goal(
+    pub(super) fn push_goal(
         &mut self,
         environment: &Environment<I>,
         goal: Goal<I>,

--- a/chalk-solve/src/recursive/lib.rs
+++ b/chalk-solve/src/recursive/lib.rs
@@ -9,8 +9,8 @@ pub type UCanonicalGoal<I> = UCanonical<InEnvironment<Goal<I>>>;
 /// The `minimums` struct is used while solving to track whether we encountered
 /// any cycles in the process.
 #[derive(Copy, Clone, Debug)]
-pub struct Minimums {
-    pub positive: DepthFirstNumber,
+pub(super) struct Minimums {
+    pub(super) positive: DepthFirstNumber,
 }
 
 impl Minimums {

--- a/chalk-solve/src/recursive/search_graph.rs
+++ b/chalk-solve/src/recursive/search_graph.rs
@@ -17,7 +17,7 @@ pub(super) struct SearchGraph<I: Interner> {
 }
 
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct DepthFirstNumber {
+pub(super) struct DepthFirstNumber {
     index: usize,
 }
 

--- a/chalk-solve/src/recursive/solve.rs
+++ b/chalk-solve/src/recursive/solve.rs
@@ -1,25 +1,20 @@
 use super::combine;
-use super::fulfill::{Fulfill, RecursiveInferenceTable, RecursiveSolver};
+use super::fulfill::{Fulfill, RecursiveInferenceTable};
 use super::lib::{Guidance, Minimums, Solution, UCanonicalGoal};
-use super::search_graph::{DepthFirstNumber, SearchGraph};
-use super::stack::{Stack, StackDepth};
 use super::Solver;
 use crate::clauses::program_clauses_for_goal;
 use crate::infer::{InferenceTable, ParameterEnaVariableExt};
 use crate::solve::truncate;
-use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
 use chalk_ir::fold::Fold;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::Visit;
 use chalk_ir::zip::Zip;
-use chalk_ir::{debug, debug_heading, info, info_heading};
+use chalk_ir::{debug, debug_heading, info_heading};
 use chalk_ir::{
-    Binders, Canonical, ClausePriority, ConstrainedSubst, Constraint, DomainGoal, Environment,
-    Fallible, Floundered, GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClause,
-    ProgramClauseData, ProgramClauseImplication, Substitution, UCanonical, UniverseMap,
-    VariableKinds,
+    Binders, Canonical, ClausePriority, Constraint, DomainGoal, Environment, Fallible, Floundered,
+    GenericArg, GoalData, InEnvironment, NoSolution, ProgramClause, ProgramClauseData,
+    ProgramClauseImplication, Substitution, UCanonical, UniverseMap, VariableKinds,
 };
-use rustc_hash::FxHashMap;
 use std::fmt::Debug;
 
 impl<'me, I: Interner> Solver<'me, I> {

--- a/chalk-solve/src/recursive/solve.rs
+++ b/chalk-solve/src/recursive/solve.rs
@@ -1,0 +1,179 @@
+use super::combine;
+use super::fulfill::{Fulfill, RecursiveInferenceTable, RecursiveSolver};
+use super::lib::{Guidance, Minimums, Solution, UCanonicalGoal};
+use super::search_graph::{DepthFirstNumber, SearchGraph};
+use super::stack::{Stack, StackDepth};
+use super::Solver;
+use crate::clauses::program_clauses_for_goal;
+use crate::infer::{InferenceTable, ParameterEnaVariableExt};
+use crate::solve::truncate;
+use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
+use chalk_ir::fold::Fold;
+use chalk_ir::interner::{HasInterner, Interner};
+use chalk_ir::visit::Visit;
+use chalk_ir::zip::Zip;
+use chalk_ir::{debug, debug_heading, info, info_heading};
+use chalk_ir::{
+    Binders, Canonical, ClausePriority, ConstrainedSubst, Constraint, DomainGoal, Environment,
+    Fallible, Floundered, GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClause,
+    ProgramClauseData, ProgramClauseImplication, Substitution, UCanonical, UniverseMap,
+    VariableKinds,
+};
+use rustc_hash::FxHashMap;
+use std::fmt::Debug;
+
+impl<'me, I: Interner> Solver<'me, I> {
+    pub(super) fn solve_iteration(
+        &mut self,
+        canonical_goal: &UCanonicalGoal<I>,
+        minimums: &mut Minimums,
+    ) -> (Fallible<Solution<I>>, ClausePriority) {
+        let UCanonical {
+            universes,
+            canonical:
+                Canonical {
+                    binders,
+                    value: InEnvironment { environment, goal },
+                },
+        } = canonical_goal.clone();
+
+        match goal.data(self.program.interner()) {
+            GoalData::DomainGoal(domain_goal) => {
+                let canonical_goal = UCanonical {
+                    universes,
+                    canonical: Canonical {
+                        binders,
+                        value: InEnvironment {
+                            environment,
+                            goal: domain_goal.clone(),
+                        },
+                    },
+                };
+
+                // "Domain" goals (i.e., leaf goals that are Rust-specific) are
+                // always solved via some form of implication. We can either
+                // apply assumptions from our environment (i.e. where clauses),
+                // or from the lowered program, which includes fallback
+                // clauses. We try each approach in turn:
+
+                let InEnvironment { environment, goal } = &canonical_goal.canonical.value;
+
+                let (prog_solution, prog_prio) = {
+                    debug_heading!("prog_clauses");
+
+                    let prog_clauses = self.program_clauses_for_goal(environment, &goal);
+                    match prog_clauses {
+                        Ok(clauses) => self.solve_from_clauses(&canonical_goal, clauses, minimums),
+                        Err(Floundered) => {
+                            (Ok(Solution::Ambig(Guidance::Unknown)), ClausePriority::High)
+                        }
+                    }
+                };
+                debug!("prog_solution={:?}", prog_solution);
+
+                (prog_solution, prog_prio)
+            }
+
+            _ => {
+                let canonical_goal = UCanonical {
+                    universes,
+                    canonical: Canonical {
+                        binders,
+                        value: InEnvironment { environment, goal },
+                    },
+                };
+
+                self.solve_via_simplification(&canonical_goal, minimums)
+            }
+        }
+    }
+
+    fn solve_via_simplification(
+        &mut self,
+        canonical_goal: &UCanonicalGoal<I>,
+        minimums: &mut Minimums,
+    ) -> (Fallible<Solution<I>>, ClausePriority) {
+        debug_heading!("solve_via_simplification({:?})", canonical_goal);
+        let (infer, subst, goal) = self.new_inference_table(canonical_goal);
+        match Fulfill::new_with_simplification(self, infer, subst, goal) {
+            Ok(fulfill) => (fulfill.solve(minimums), ClausePriority::High),
+            Err(e) => (Err(e), ClausePriority::High),
+        }
+    }
+
+    /// See whether we can solve a goal by implication on any of the given
+    /// clauses. If multiple such solutions are possible, we attempt to combine
+    /// them.
+    fn solve_from_clauses<C>(
+        &mut self,
+        canonical_goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
+        clauses: C,
+        minimums: &mut Minimums,
+    ) -> (Fallible<Solution<I>>, ClausePriority)
+    where
+        C: IntoIterator<Item = ProgramClause<I>>,
+    {
+        let mut cur_solution = None;
+        for program_clause in clauses {
+            debug_heading!("clause={:?}", program_clause);
+
+            // If we have a completely ambiguous answer, it's not going to get better, so stop
+            if cur_solution == Some((Solution::Ambig(Guidance::Unknown), ClausePriority::High)) {
+                return (Ok(Solution::Ambig(Guidance::Unknown)), ClausePriority::High);
+            }
+
+            let res = match program_clause.data(self.program.interner()) {
+                ProgramClauseData::Implies(implication) => self.solve_via_implication(
+                    canonical_goal,
+                    &Binders::new(
+                        VariableKinds::from(self.program.interner(), vec![]),
+                        implication.clone(),
+                    ),
+                    minimums,
+                ),
+                ProgramClauseData::ForAll(implication) => {
+                    self.solve_via_implication(canonical_goal, implication, minimums)
+                }
+            };
+            if let (Ok(solution), priority) = res {
+                debug!("ok: solution={:?} prio={:?}", solution, priority);
+                cur_solution = Some(match cur_solution {
+                    None => (solution, priority),
+                    Some((cur, cur_priority)) => combine::with_priorities(
+                        self.program.interner(),
+                        &canonical_goal.canonical.value.goal,
+                        cur,
+                        cur_priority,
+                        solution,
+                        priority,
+                    ),
+                });
+            } else {
+                debug!("error");
+            }
+        }
+        cur_solution.map_or((Err(NoSolution), ClausePriority::High), |(s, p)| (Ok(s), p))
+    }
+
+    /// Modus ponens! That is: try to apply an implication by proving its premises.
+    fn solve_via_implication(
+        &mut self,
+        canonical_goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
+        clause: &Binders<ProgramClauseImplication<I>>,
+        minimums: &mut Minimums,
+    ) -> (Fallible<Solution<I>>, ClausePriority) {
+        info_heading!(
+            "solve_via_implication(\
+         \n    canonical_goal={:?},\
+         \n    clause={:?})",
+            canonical_goal,
+            clause
+        );
+
+        let (infer, subst, goal) = self.new_inference_table(canonical_goal);
+        match Fulfill::new_with_clause(self, infer, subst, goal, clause) {
+            Ok(fulfill) => (fulfill.solve(minimums), clause.skip_binders().priority),
+            Err(e) => (Err(e), ClausePriority::High),
+        }
+    }
+}

--- a/chalk-solve/src/recursive/solve.rs
+++ b/chalk-solve/src/recursive/solve.rs
@@ -193,6 +193,14 @@ impl<'me, I: Interner> Solver<'me, I> {
         let infer = RecursiveInferenceTableImpl { infer };
         (infer, subst, canonical_goal)
     }
+
+    fn program_clauses_for_goal(
+        &self,
+        environment: &Environment<I>,
+        goal: &DomainGoal<I>,
+    ) -> Result<Vec<ProgramClause<I>>, Floundered> {
+        program_clauses_for_goal(self.program, environment, goal)
+    }
 }
 struct RecursiveInferenceTableImpl<I: Interner> {
     infer: InferenceTable<I>,

--- a/chalk-solve/src/recursive/solve.rs
+++ b/chalk-solve/src/recursive/solve.rs
@@ -176,4 +176,118 @@ impl<'me, I: Interner> Solver<'me, I> {
             Err(e) => (Err(e), ClausePriority::High),
         }
     }
+
+    fn new_inference_table<T: Fold<I, I, Result = T> + HasInterner<Interner = I> + Clone>(
+        &self,
+        ucanonical_goal: &UCanonical<InEnvironment<T>>,
+    ) -> (
+        RecursiveInferenceTableImpl<I>,
+        Substitution<I>,
+        InEnvironment<T::Result>,
+    ) {
+        let (infer, subst, canonical_goal) = InferenceTable::from_canonical(
+            self.program.interner(),
+            ucanonical_goal.universes,
+            &ucanonical_goal.canonical,
+        );
+        let infer = RecursiveInferenceTableImpl { infer };
+        (infer, subst, canonical_goal)
+    }
+}
+struct RecursiveInferenceTableImpl<I: Interner> {
+    infer: InferenceTable<I>,
+}
+
+impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> {
+    fn instantiate_binders_universally<'a, T>(
+        &mut self,
+        interner: &'a I,
+        arg: &'a Binders<T>,
+    ) -> T::Result
+    where
+        T: Fold<I> + HasInterner<Interner = I>,
+    {
+        self.infer.instantiate_binders_universally(interner, arg)
+    }
+
+    fn instantiate_binders_existentially<'a, T>(
+        &mut self,
+        interner: &'a I,
+        arg: &'a Binders<T>,
+    ) -> T::Result
+    where
+        T: Fold<I> + HasInterner<Interner = I>,
+    {
+        self.infer.instantiate_binders_existentially(interner, arg)
+    }
+
+    fn canonicalize<T>(
+        &mut self,
+        interner: &I,
+        value: &T,
+    ) -> (Canonical<T::Result>, Vec<GenericArg<I>>)
+    where
+        T: Fold<I>,
+        T::Result: HasInterner<Interner = I>,
+    {
+        let res = self.infer.canonicalize(interner, value);
+        let free_vars = res
+            .free_vars
+            .into_iter()
+            .map(|free_var| free_var.to_generic_arg(interner))
+            .collect();
+        (res.quantified, free_vars)
+    }
+
+    fn u_canonicalize<T>(
+        &mut self,
+        interner: &I,
+        value0: &Canonical<T>,
+    ) -> (UCanonical<T::Result>, UniverseMap)
+    where
+        T: HasInterner<Interner = I> + Fold<I> + Visit<I>,
+        T::Result: HasInterner<Interner = I>,
+    {
+        let res = self.infer.u_canonicalize(interner, value0);
+        (res.quantified, res.universes)
+    }
+
+    fn unify<T>(
+        &mut self,
+        interner: &I,
+        environment: &Environment<I>,
+        a: &T,
+        b: &T,
+    ) -> Fallible<(
+        Vec<InEnvironment<DomainGoal<I>>>,
+        Vec<InEnvironment<Constraint<I>>>,
+    )>
+    where
+        T: ?Sized + Zip<I>,
+    {
+        let res = self.infer.unify(interner, environment, a, b)?;
+        Ok((res.goals, res.constraints))
+    }
+
+    fn instantiate_canonical<T>(&mut self, interner: &I, bound: &Canonical<T>) -> T::Result
+    where
+        T: HasInterner<Interner = I> + Fold<I> + Debug,
+    {
+        self.infer.instantiate_canonical(interner, bound)
+    }
+
+    fn invert_then_canonicalize<T>(
+        &mut self,
+        interner: &I,
+        value: &T,
+    ) -> Option<Canonical<T::Result>>
+    where
+        T: Fold<I, Result = T> + HasInterner<Interner = I>,
+    {
+        self.infer.invert_then_canonicalize(interner, value)
+    }
+
+    fn needs_truncation(&mut self, interner: &I, max_size: usize, value: impl Visit<I>) -> bool {
+        truncate::needs_truncation(interner, &mut self.infer, max_size, value)
+    }
 }


### PR DESCRIPTION
This branch just starts to factor the recursive solver into a few more files, and tightens up some of the privacy. 

My goal was to try and better separate out the "caching and loop logic", which I hope to eventually move to salsa, from the chalk-specific logic. For now I got as far as moving most of the chalk-specific stuff into the `solve` module.

The next step is going to be trying to factor out the caching stuff into a module that is generic over chalk-specific things, but that's for another day.