### PR TITLE
Refactor ProgramClauseData to remove Implies variant

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1671,7 +1671,7 @@ impl LowerClause for Clause {
             .into_iter()
             .map(
                 |implication: chalk_ir::Binders<chalk_ir::ProgramClauseImplication<ChalkIr>>| {
-                    chalk_ir::ProgramClauseData::ForAll(implication).intern(interner)
+                    chalk_ir::ProgramClauseData(implication).intern(interner)
                 },
             )
             .collect();

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -225,18 +225,6 @@ where
     }
 }
 
-impl<I: Interner> CastTo<ProgramClause<I>> for ProgramClauseImplication<I> {
-    fn cast_to(self, interner: &I) -> ProgramClause<I> {
-        ProgramClauseData(Binders::empty(interner, self.shifted_in(interner))).intern(interner)
-    }
-}
-
-impl<I: Interner> CastTo<ProgramClause<I>> for Binders<ProgramClauseImplication<I>> {
-    fn cast_to(self, interner: &I) -> ProgramClause<I> {
-        ProgramClauseData(self).intern(interner)
-    }
-}
-
 impl<T, U> CastTo<Option<U>> for Option<T>
 where
     T: CastTo<U>,

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -205,7 +205,8 @@ where
             priority: ClausePriority::High,
         };
 
-        ProgramClauseData(Binders::empty(interner, implication)).intern(interner)
+        ProgramClauseData(Binders::empty(interner, implication.shifted_in(interner)))
+            .intern(interner)
     }
 }
 
@@ -226,7 +227,7 @@ where
 
 impl<I: Interner> CastTo<ProgramClause<I>> for ProgramClauseImplication<I> {
     fn cast_to(self, interner: &I) -> ProgramClause<I> {
-        ProgramClauseData(Binders::empty(interner, self)).intern(interner)
+        ProgramClauseData(Binders::empty(interner, self.shifted_in(interner))).intern(interner)
     }
 }
 

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -199,12 +199,13 @@ where
     I: Interner,
 {
     fn cast_to(self, interner: &I) -> ProgramClause<I> {
-        ProgramClauseData::Implies(ProgramClauseImplication {
+        let implication = ProgramClauseImplication {
             consequence: self.cast(interner),
             conditions: Goals::new(interner),
             priority: ClausePriority::High,
-        })
-        .intern(interner)
+        };
+
+        ProgramClauseData(Binders::empty(interner, implication)).intern(interner)
     }
 }
 
@@ -214,7 +215,7 @@ where
     T: HasInterner<Interner = I> + CastTo<DomainGoal<I>>,
 {
     fn cast_to(self, interner: &I) -> ProgramClause<I> {
-        ProgramClauseData::ForAll(self.map(|bound| ProgramClauseImplication {
+        ProgramClauseData(self.map(|bound| ProgramClauseImplication {
             consequence: bound.cast(interner),
             conditions: Goals::new(interner),
             priority: ClausePriority::High,
@@ -225,13 +226,13 @@ where
 
 impl<I: Interner> CastTo<ProgramClause<I>> for ProgramClauseImplication<I> {
     fn cast_to(self, interner: &I) -> ProgramClause<I> {
-        ProgramClauseData::Implies(self).intern(interner)
+        ProgramClauseData(Binders::empty(interner, self)).intern(interner)
     }
 }
 
 impl<I: Interner> CastTo<ProgramClause<I>> for Binders<ProgramClauseImplication<I>> {
     fn cast_to(self, interner: &I) -> ProgramClause<I> {
-        ProgramClauseData::ForAll(self).intern(interner)
+        ProgramClauseData(self).intern(interner)
     }
 }
 

--- a/chalk-ir/src/could_match.rs
+++ b/chalk-ir/src/could_match.rs
@@ -68,15 +68,7 @@ where
 
 impl<I: Interner> CouldMatch<DomainGoal<I>> for ProgramClauseData<I> {
     fn could_match(&self, interner: &I, other: &DomainGoal<I>) -> bool {
-        match self {
-            ProgramClauseData::Implies(implication) => {
-                implication.consequence.could_match(interner, other)
-            }
-
-            ProgramClauseData::ForAll(clause) => {
-                clause.value.consequence.could_match(interner, other)
-            }
-        }
+        self.0.value.consequence.could_match(interner, other)
     }
 }
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -699,10 +699,7 @@ impl<T: HasInterner + Debug> Debug for Binders<T> {
 
 impl<I: Interner> Debug for ProgramClauseData<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
-        match self {
-            ProgramClauseData::Implies(pc) => write!(fmt, "{:?}", pc),
-            ProgramClauseData::ForAll(pc) => write!(fmt, "{:?}", pc),
-        }
+        write!(fmt, "{:?}", self.0)
     }
 }
 

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -9,6 +9,7 @@ mod boring_impls;
 pub mod shift;
 mod subst;
 
+pub use self::shift::Shift;
 pub use self::subst::Subst;
 
 /// A "folder" is a transformer that can be used to make a copy of

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -290,14 +290,7 @@ impl<I: Interner, TI: TargetInterner<I>> SuperFold<I, TI> for ProgramClauseData<
         I: 'i,
         TI: 'i,
     {
-        match self {
-            ProgramClauseData::Implies(pci) => Ok(ProgramClauseData::Implies(
-                pci.fold_with(folder, outer_binder)?,
-            )),
-            ProgramClauseData::ForAll(pci) => Ok(ProgramClauseData::ForAll(
-                pci.fold_with(folder, outer_binder)?,
-            )),
-        }
+        Ok(ProgramClauseData(self.0.fold_with(folder, outer_binder)?))
     }
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1732,10 +1732,7 @@ impl std::ops::BitAnd for ClausePriority {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Fold, HasInterner, Zip)]
-pub enum ProgramClauseData<I: Interner> {
-    Implies(ProgramClauseImplication<I>),
-    ForAll(Binders<ProgramClauseImplication<I>>),
-}
+pub struct ProgramClauseData<I: Interner>(pub Binders<ProgramClauseImplication<I>>);
 
 impl<I: Interner> ProgramClauseImplication<I> {
     pub fn into_from_env_clause(self, interner: &I) -> ProgramClauseImplication<I> {
@@ -1753,14 +1750,7 @@ impl<I: Interner> ProgramClauseImplication<I> {
 
 impl<I: Interner> ProgramClauseData<I> {
     pub fn into_from_env_clause(self, interner: &I) -> ProgramClauseData<I> {
-        match self {
-            ProgramClauseData::Implies(implication) => {
-                ProgramClauseData::Implies(implication.into_from_env_clause(interner))
-            }
-            ProgramClauseData::ForAll(binders_implication) => ProgramClauseData::ForAll(
-                binders_implication.map(|i| i.into_from_env_clause(interner)),
-            ),
-        }
+        ProgramClauseData(self.0.map(|i| i.into_from_env_clause(interner)))
     }
 
     pub fn intern(self, interner: &I) -> ProgramClause<I> {

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -6,9 +6,9 @@
 
 use crate::{
     AdtId, AssocTypeId, ClausePriority, DebruijnIndex, FloatTy, FnDefId, GenericArg, Goals, ImplId,
-    IntTy, Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauseData,
-    ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution, SuperVisit,
-    TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
+    IntTy, Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauses,
+    QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution, SuperVisit, TraitId, UintTy,
+    UniverseIndex, Visit, VisitResult, Visitor,
 };
 use std::{marker::PhantomData, sync::Arc};
 
@@ -247,10 +247,7 @@ impl<I: Interner> SuperVisit<I> for ProgramClause<I> {
     {
         let interner = visitor.interner();
 
-        match self.data(interner) {
-            ProgramClauseData::Implies(pci) => pci.visit_with(visitor, outer_binder),
-            ProgramClauseData::ForAll(pci) => pci.visit_with(visitor, outer_binder),
-        }
+        self.data(interner).0.visit_with(visitor, outer_binder)
     }
 }
 

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use crate::cast::{Cast, CastTo};
 use crate::RustIrDatabase;
-use chalk_ir::fold::Fold;
+use chalk_ir::fold::{Fold, Shift};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
 
@@ -75,6 +75,13 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
             consequence: consequence.cast(interner),
             conditions: Goals::from(interner, conditions),
             priority,
+        };
+
+        let clause = if self.binders.is_empty() {
+            // Compensate for the added empty binder
+            clause.shifted_in(interner)
+        } else {
+            clause
         };
 
         self.clauses.push(

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -77,18 +77,13 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
             priority,
         };
 
-        if self.binders.len() == 0 {
-            self.clauses
-                .push(ProgramClauseData::Implies(clause).intern(interner));
-        } else {
-            self.clauses.push(
-                ProgramClauseData::ForAll(Binders::new(
-                    VariableKinds::from(interner, self.binders.clone()),
-                    clause,
-                ))
-                .intern(interner),
-            );
-        }
+        self.clauses.push(
+            ProgramClauseData(Binders::new(
+                VariableKinds::from(interner, self.binders.clone()),
+                clause,
+            ))
+            .intern(interner),
+        );
 
         debug!("pushed clause {:?}", self.clauses.last());
     }

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -1,19 +1,28 @@
-mod combine;
 mod fulfill;
 pub mod lib;
 mod search_graph;
-mod solve;
 mod stack;
 
-use self::lib::{Minimums, Solution, UCanonicalGoal};
+use self::fulfill::{Fulfill, RecursiveInferenceTable, RecursiveSolver};
+use self::lib::{Guidance, Minimums, Solution, UCanonicalGoal};
 use self::search_graph::{DepthFirstNumber, SearchGraph};
-use self::solve::{SolveDatabase, SolveIteration};
 use self::stack::{Stack, StackDepth};
+use crate::clauses::program_clauses_for_goal;
+use crate::infer::{InferenceTable, ParameterEnaVariableExt};
+use crate::solve::truncate;
 use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
-use chalk_ir::interner::Interner;
+use chalk_ir::fold::Fold;
+use chalk_ir::interner::{HasInterner, Interner};
+use chalk_ir::visit::Visit;
+use chalk_ir::zip::Zip;
 use chalk_ir::{debug, debug_heading, info, info_heading};
-use chalk_ir::{Canonical, ConstrainedSubst, Fallible};
+use chalk_ir::{
+    Binders, Canonical, ClausePriority, ConstrainedSubst, Constraint, DomainGoal, Environment,
+    Fallible, Floundered, GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClause,
+    ProgramClauseData, ProgramClauseImplication, Substitution, UCanonical, UniverseMap,
+};
 use rustc_hash::FxHashMap;
+use std::fmt::Debug;
 
 pub(crate) struct RecursiveContext<I: Interner> {
     stack: Stack,
@@ -28,6 +37,104 @@ pub(crate) struct RecursiveContext<I: Interner> {
     cache: FxHashMap<UCanonicalGoal<I>, Fallible<Solution<I>>>,
 
     caching_enabled: bool,
+}
+
+pub(crate) struct RecursiveInferenceTableImpl<I: Interner> {
+    pub(crate) infer: InferenceTable<I>,
+}
+
+impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> {
+    fn instantiate_binders_universally<'a, T>(
+        &mut self,
+        interner: &'a I,
+        arg: &'a Binders<T>,
+    ) -> T::Result
+    where
+        T: Fold<I> + HasInterner<Interner = I>,
+    {
+        self.infer.instantiate_binders_universally(interner, arg)
+    }
+
+    fn instantiate_binders_existentially<'a, T>(
+        &mut self,
+        interner: &'a I,
+        arg: &'a Binders<T>,
+    ) -> T::Result
+    where
+        T: Fold<I> + HasInterner<Interner = I>,
+    {
+        self.infer.instantiate_binders_existentially(interner, arg)
+    }
+
+    fn canonicalize<T>(
+        &mut self,
+        interner: &I,
+        value: &T,
+    ) -> (Canonical<T::Result>, Vec<GenericArg<I>>)
+    where
+        T: Fold<I>,
+        T::Result: HasInterner<Interner = I>,
+    {
+        let res = self.infer.canonicalize(interner, value);
+        let free_vars = res
+            .free_vars
+            .into_iter()
+            .map(|free_var| free_var.to_generic_arg(interner))
+            .collect();
+        (res.quantified, free_vars)
+    }
+
+    fn u_canonicalize<T>(
+        &mut self,
+        interner: &I,
+        value0: &Canonical<T>,
+    ) -> (UCanonical<T::Result>, UniverseMap)
+    where
+        T: HasInterner<Interner = I> + Fold<I> + Visit<I>,
+        T::Result: HasInterner<Interner = I>,
+    {
+        let res = self.infer.u_canonicalize(interner, value0);
+        (res.quantified, res.universes)
+    }
+
+    fn unify<T>(
+        &mut self,
+        interner: &I,
+        environment: &Environment<I>,
+        a: &T,
+        b: &T,
+    ) -> Fallible<(
+        Vec<InEnvironment<DomainGoal<I>>>,
+        Vec<InEnvironment<Constraint<I>>>,
+    )>
+    where
+        T: ?Sized + Zip<I>,
+    {
+        let res = self.infer.unify(interner, environment, a, b)?;
+        Ok((res.goals, res.constraints))
+    }
+
+    fn instantiate_canonical<T>(&mut self, interner: &I, bound: &Canonical<T>) -> T::Result
+    where
+        T: HasInterner<Interner = I> + Fold<I> + Debug,
+    {
+        self.infer.instantiate_canonical(interner, bound)
+    }
+
+    fn invert_then_canonicalize<T>(
+        &mut self,
+        interner: &I,
+        value: &T,
+    ) -> Option<Canonical<T::Result>>
+    where
+        T: Fold<I, Result = T> + HasInterner<Interner = I>,
+    {
+        self.infer.invert_then_canonicalize(interner, value)
+    }
+
+    fn needs_truncation(&mut self, interner: &I, max_size: usize, value: impl Visit<I>) -> bool {
+        truncate::needs_truncation(interner, &mut self.infer, max_size, value)
+    }
 }
 
 /// A Solver is the basic context in which you can propose goals for a given
@@ -82,6 +189,25 @@ impl<I: Interner> RecursiveContext<I> {
 }
 
 impl<'me, I: Interner> Solver<'me, I> {
+    pub(crate) fn new_inference_table<
+        T: Fold<I, I, Result = T> + HasInterner<Interner = I> + Clone,
+    >(
+        &self,
+        ucanonical_goal: &UCanonical<InEnvironment<T>>,
+    ) -> (
+        RecursiveInferenceTableImpl<I>,
+        Substitution<I>,
+        InEnvironment<T::Result>,
+    ) {
+        let (infer, subst, canonical_goal) = InferenceTable::from_canonical(
+            self.program.interner(),
+            ucanonical_goal.universes,
+            &ucanonical_goal.canonical,
+        );
+        let infer = crate::recursive::RecursiveInferenceTableImpl { infer };
+        (infer, subst, canonical_goal)
+    }
+
     /// Solves a canonical goal. The substitution returned in the
     /// solution will be for the fully decomposed goal. For example, given the
     /// program
@@ -129,9 +255,68 @@ impl<'me, I: Interner> Solver<'me, I> {
         // - None < Some(CannotProve)
         // the function which maps the loop iteration to `answer` is a nondecreasing function
         // so this function will eventually be constant and the loop terminates.
+        let minimums = &mut Minimums::new();
         loop {
-            let minimums = &mut Minimums::new();
-            let (current_answer, current_prio) = self.solve_iteration(&canonical_goal, minimums);
+            let UCanonical {
+                universes,
+                canonical:
+                    Canonical {
+                        binders,
+                        value: InEnvironment { environment, goal },
+                    },
+            } = canonical_goal.clone();
+
+            let (current_answer, current_prio) = match goal.data(self.program.interner()) {
+                GoalData::DomainGoal(domain_goal) => {
+                    let canonical_goal = UCanonical {
+                        universes,
+                        canonical: Canonical {
+                            binders,
+                            value: InEnvironment {
+                                environment,
+                                goal: domain_goal.clone(),
+                            },
+                        },
+                    };
+
+                    // "Domain" goals (i.e., leaf goals that are Rust-specific) are
+                    // always solved via some form of implication. We can either
+                    // apply assumptions from our environment (i.e. where clauses),
+                    // or from the lowered program, which includes fallback
+                    // clauses. We try each approach in turn:
+
+                    let InEnvironment { environment, goal } = &canonical_goal.canonical.value;
+
+                    let (prog_solution, prog_prio) = {
+                        debug_heading!("prog_clauses");
+
+                        let prog_clauses = self.program_clauses_for_goal(environment, &goal);
+                        match prog_clauses {
+                            Ok(clauses) => {
+                                self.solve_from_clauses(&canonical_goal, clauses, minimums)
+                            }
+                            Err(Floundered) => {
+                                (Ok(Solution::Ambig(Guidance::Unknown)), ClausePriority::High)
+                            }
+                        }
+                    };
+                    debug!("prog_solution={:?}", prog_solution);
+
+                    (prog_solution, prog_prio)
+                }
+
+                _ => {
+                    let canonical_goal = UCanonical {
+                        universes,
+                        canonical: Canonical {
+                            binders,
+                            value: InEnvironment { environment, goal },
+                        },
+                    };
+
+                    self.solve_via_simplification(&canonical_goal, minimums)
+                }
+            };
 
             debug!(
                 "solve_new_subgoal: loop iteration result = {:?} with minimums {:?}",
@@ -149,7 +334,7 @@ impl<'me, I: Interner> Solver<'me, I> {
             let old_answer = &self.context.search_graph[dfn].solution;
             let old_prio = self.context.search_graph[dfn].solution_priority;
 
-            let (current_answer, current_prio) = combine::with_priorities_for_goal(
+            let (current_answer, current_prio) = combine_with_priorities_for_goal(
                 self.program.interner(),
                 &canonical_goal.canonical.value.goal,
                 old_answer.clone(),
@@ -184,9 +369,98 @@ impl<'me, I: Interner> Solver<'me, I> {
             self.context.search_graph.rollback_to(dfn + 1);
         }
     }
+
+    fn solve_via_simplification(
+        &mut self,
+        canonical_goal: &UCanonicalGoal<I>,
+        minimums: &mut Minimums,
+    ) -> (Fallible<Solution<I>>, ClausePriority) {
+        debug_heading!("solve_via_simplification({:?})", canonical_goal);
+        let (infer, subst, goal) = self.new_inference_table(canonical_goal);
+        match Fulfill::new_with_simplification(self, infer, subst, goal) {
+            Ok(fulfill) => (fulfill.solve(minimums), ClausePriority::High),
+            Err(e) => (Err(e), ClausePriority::High),
+        }
+    }
+
+    /// See whether we can solve a goal by implication on any of the given
+    /// clauses. If multiple such solutions are possible, we attempt to combine
+    /// them.
+    fn solve_from_clauses<C>(
+        &mut self,
+        canonical_goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
+        clauses: C,
+        minimums: &mut Minimums,
+    ) -> (Fallible<Solution<I>>, ClausePriority)
+    where
+        C: IntoIterator<Item = ProgramClause<I>>,
+    {
+        let mut cur_solution = None;
+        for program_clause in clauses {
+            debug_heading!("clause={:?}", program_clause);
+
+            // If we have a completely ambiguous answer, it's not going to get better, so stop
+            if cur_solution == Some((Solution::Ambig(Guidance::Unknown), ClausePriority::High)) {
+                return (Ok(Solution::Ambig(Guidance::Unknown)), ClausePriority::High);
+            }
+
+            let res = {
+                let ProgramClauseData(implication) = program_clause.data(self.program.interner());
+
+                self.solve_via_implication(canonical_goal, implication, minimums)
+            };
+            if let (Ok(solution), priority) = res {
+                debug!("ok: solution={:?} prio={:?}", solution, priority);
+                cur_solution = Some(match cur_solution {
+                    None => (solution, priority),
+                    Some((cur, cur_priority)) => combine_with_priorities(
+                        self.program.interner(),
+                        &canonical_goal.canonical.value.goal,
+                        cur,
+                        cur_priority,
+                        solution,
+                        priority,
+                    ),
+                });
+            } else {
+                debug!("error");
+            }
+        }
+        cur_solution.map_or((Err(NoSolution), ClausePriority::High), |(s, p)| (Ok(s), p))
+    }
+
+    /// Modus ponens! That is: try to apply an implication by proving its premises.
+    fn solve_via_implication(
+        &mut self,
+        canonical_goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
+        clause: &Binders<ProgramClauseImplication<I>>,
+        minimums: &mut Minimums,
+    ) -> (Fallible<Solution<I>>, ClausePriority) {
+        info_heading!(
+            "solve_via_implication(\
+             \n    canonical_goal={:?},\
+             \n    clause={:?})",
+            canonical_goal,
+            clause
+        );
+
+        let (infer, subst, goal) = self.new_inference_table(canonical_goal);
+        match Fulfill::new_with_clause(self, infer, subst, goal, clause) {
+            Ok(fulfill) => (fulfill.solve(minimums), clause.skip_binders().priority),
+            Err(e) => (Err(e), ClausePriority::High),
+        }
+    }
+
+    fn program_clauses_for_goal(
+        &self,
+        environment: &Environment<I>,
+        goal: &DomainGoal<I>,
+    ) -> Result<Vec<ProgramClause<I>>, Floundered> {
+        program_clauses_for_goal(self.program, environment, goal)
+    }
 }
 
-impl<'me, I: Interner> SolveDatabase<I> for Solver<'me, I> {
+impl<'me, I: Interner> RecursiveSolver<I> for Solver<'me, I> {
     /// Attempt to solve a goal that has been fully broken down into leaf form
     /// and canonicalized. This is where the action really happens, and is the
     /// place where we would perform caching in rustc (and may eventually do in Chalk).
@@ -279,8 +553,77 @@ impl<'me, I: Interner> SolveDatabase<I> for Solver<'me, I> {
     fn interner(&self) -> &I {
         &self.program.interner()
     }
+}
 
-    fn db(&self) -> &dyn RustIrDatabase<I> {
-        self.program
+fn calculate_inputs<I: Interner>(
+    interner: &I,
+    domain_goal: &DomainGoal<I>,
+    solution: &Solution<I>,
+) -> Vec<GenericArg<I>> {
+    if let Some(subst) = solution.constrained_subst() {
+        let subst_goal = subst.value.subst.apply(&domain_goal, interner);
+        subst_goal.inputs(interner)
+    } else {
+        domain_goal.inputs(interner)
+    }
+}
+
+fn combine_with_priorities_for_goal<I: Interner>(
+    interner: &I,
+    goal: &Goal<I>,
+    a: Fallible<Solution<I>>,
+    prio_a: ClausePriority,
+    b: Fallible<Solution<I>>,
+    prio_b: ClausePriority,
+) -> (Fallible<Solution<I>>, ClausePriority) {
+    let domain_goal = match goal.data(interner) {
+        GoalData::DomainGoal(domain_goal) => domain_goal,
+        _ => {
+            // non-domain goals currently have no priorities, so we always take the new solution here
+            return (b, prio_b);
+        }
+    };
+    match (a, b) {
+        (Ok(a), Ok(b)) => {
+            let (solution, prio) =
+                combine_with_priorities(interner, domain_goal, a, prio_a, b, prio_b);
+            (Ok(solution), prio)
+        }
+        (Ok(solution), Err(_)) => (Ok(solution), prio_a),
+        (Err(_), Ok(solution)) => (Ok(solution), prio_b),
+        (Err(_), Err(e)) => (Err(e), prio_b),
+    }
+}
+
+fn combine_with_priorities<I: Interner>(
+    interner: &I,
+    domain_goal: &DomainGoal<I>,
+    a: Solution<I>,
+    prio_a: ClausePriority,
+    b: Solution<I>,
+    prio_b: ClausePriority,
+) -> (Solution<I>, ClausePriority) {
+    match (prio_a, prio_b, a, b) {
+        (ClausePriority::High, ClausePriority::Low, higher, lower)
+        | (ClausePriority::Low, ClausePriority::High, lower, higher) => {
+            // if we have a high-priority solution and a low-priority solution,
+            // the high-priority solution overrides *if* they are both for the
+            // same inputs -- we don't want a more specific high-priority
+            // solution overriding a general low-priority one. Currently inputs
+            // only matter for projections; in a goal like `AliasEq(<?0 as
+            // Trait>::Type = ?1)`, ?0 is the input.
+            let inputs_higher = calculate_inputs(interner, domain_goal, &higher);
+            let inputs_lower = calculate_inputs(interner, domain_goal, &lower);
+            if inputs_higher == inputs_lower {
+                debug!(
+                    "preferring solution: {:?} over {:?} because of higher prio",
+                    higher, lower
+                );
+                (higher, ClausePriority::High)
+            } else {
+                (higher.combine(lower, interner), ClausePriority::High)
+            }
+        }
+        (_, _, a, b) => (a.combine(b, interner), prio_a),
     }
 }

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -1,28 +1,19 @@
+mod combine;
 mod fulfill;
 pub mod lib;
 mod search_graph;
+mod solve;
 mod stack;
 
-use self::fulfill::{Fulfill, RecursiveInferenceTable, RecursiveSolver};
-use self::lib::{Guidance, Minimums, Solution, UCanonicalGoal};
+use self::lib::{Minimums, Solution, UCanonicalGoal};
 use self::search_graph::{DepthFirstNumber, SearchGraph};
+use self::solve::{SolveDatabase, SolveIteration};
 use self::stack::{Stack, StackDepth};
-use crate::clauses::program_clauses_for_goal;
-use crate::infer::{InferenceTable, ParameterEnaVariableExt};
-use crate::solve::truncate;
 use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
-use chalk_ir::fold::Fold;
-use chalk_ir::interner::{HasInterner, Interner};
-use chalk_ir::visit::Visit;
-use chalk_ir::zip::Zip;
+use chalk_ir::interner::Interner;
 use chalk_ir::{debug, debug_heading, info, info_heading};
-use chalk_ir::{
-    Binders, Canonical, ClausePriority, ConstrainedSubst, Constraint, DomainGoal, Environment,
-    Fallible, Floundered, GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClause,
-    ProgramClauseData, ProgramClauseImplication, Substitution, UCanonical, UniverseMap,
-};
+use chalk_ir::{Canonical, ConstrainedSubst, Fallible};
 use rustc_hash::FxHashMap;
-use std::fmt::Debug;
 
 pub(crate) struct RecursiveContext<I: Interner> {
     stack: Stack,
@@ -37,104 +28,6 @@ pub(crate) struct RecursiveContext<I: Interner> {
     cache: FxHashMap<UCanonicalGoal<I>, Fallible<Solution<I>>>,
 
     caching_enabled: bool,
-}
-
-pub(crate) struct RecursiveInferenceTableImpl<I: Interner> {
-    pub(crate) infer: InferenceTable<I>,
-}
-
-impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> {
-    fn instantiate_binders_universally<'a, T>(
-        &mut self,
-        interner: &'a I,
-        arg: &'a Binders<T>,
-    ) -> T::Result
-    where
-        T: Fold<I> + HasInterner<Interner = I>,
-    {
-        self.infer.instantiate_binders_universally(interner, arg)
-    }
-
-    fn instantiate_binders_existentially<'a, T>(
-        &mut self,
-        interner: &'a I,
-        arg: &'a Binders<T>,
-    ) -> T::Result
-    where
-        T: Fold<I> + HasInterner<Interner = I>,
-    {
-        self.infer.instantiate_binders_existentially(interner, arg)
-    }
-
-    fn canonicalize<T>(
-        &mut self,
-        interner: &I,
-        value: &T,
-    ) -> (Canonical<T::Result>, Vec<GenericArg<I>>)
-    where
-        T: Fold<I>,
-        T::Result: HasInterner<Interner = I>,
-    {
-        let res = self.infer.canonicalize(interner, value);
-        let free_vars = res
-            .free_vars
-            .into_iter()
-            .map(|free_var| free_var.to_generic_arg(interner))
-            .collect();
-        (res.quantified, free_vars)
-    }
-
-    fn u_canonicalize<T>(
-        &mut self,
-        interner: &I,
-        value0: &Canonical<T>,
-    ) -> (UCanonical<T::Result>, UniverseMap)
-    where
-        T: HasInterner<Interner = I> + Fold<I> + Visit<I>,
-        T::Result: HasInterner<Interner = I>,
-    {
-        let res = self.infer.u_canonicalize(interner, value0);
-        (res.quantified, res.universes)
-    }
-
-    fn unify<T>(
-        &mut self,
-        interner: &I,
-        environment: &Environment<I>,
-        a: &T,
-        b: &T,
-    ) -> Fallible<(
-        Vec<InEnvironment<DomainGoal<I>>>,
-        Vec<InEnvironment<Constraint<I>>>,
-    )>
-    where
-        T: ?Sized + Zip<I>,
-    {
-        let res = self.infer.unify(interner, environment, a, b)?;
-        Ok((res.goals, res.constraints))
-    }
-
-    fn instantiate_canonical<T>(&mut self, interner: &I, bound: &Canonical<T>) -> T::Result
-    where
-        T: HasInterner<Interner = I> + Fold<I> + Debug,
-    {
-        self.infer.instantiate_canonical(interner, bound)
-    }
-
-    fn invert_then_canonicalize<T>(
-        &mut self,
-        interner: &I,
-        value: &T,
-    ) -> Option<Canonical<T::Result>>
-    where
-        T: Fold<I, Result = T> + HasInterner<Interner = I>,
-    {
-        self.infer.invert_then_canonicalize(interner, value)
-    }
-
-    fn needs_truncation(&mut self, interner: &I, max_size: usize, value: impl Visit<I>) -> bool {
-        truncate::needs_truncation(interner, &mut self.infer, max_size, value)
-    }
 }
 
 /// A Solver is the basic context in which you can propose goals for a given
@@ -189,25 +82,6 @@ impl<I: Interner> RecursiveContext<I> {
 }
 
 impl<'me, I: Interner> Solver<'me, I> {
-    pub(crate) fn new_inference_table<
-        T: Fold<I, I, Result = T> + HasInterner<Interner = I> + Clone,
-    >(
-        &self,
-        ucanonical_goal: &UCanonical<InEnvironment<T>>,
-    ) -> (
-        RecursiveInferenceTableImpl<I>,
-        Substitution<I>,
-        InEnvironment<T::Result>,
-    ) {
-        let (infer, subst, canonical_goal) = InferenceTable::from_canonical(
-            self.program.interner(),
-            ucanonical_goal.universes,
-            &ucanonical_goal.canonical,
-        );
-        let infer = crate::recursive::RecursiveInferenceTableImpl { infer };
-        (infer, subst, canonical_goal)
-    }
-
     /// Solves a canonical goal. The substitution returned in the
     /// solution will be for the fully decomposed goal. For example, given the
     /// program
@@ -255,68 +129,9 @@ impl<'me, I: Interner> Solver<'me, I> {
         // - None < Some(CannotProve)
         // the function which maps the loop iteration to `answer` is a nondecreasing function
         // so this function will eventually be constant and the loop terminates.
-        let minimums = &mut Minimums::new();
         loop {
-            let UCanonical {
-                universes,
-                canonical:
-                    Canonical {
-                        binders,
-                        value: InEnvironment { environment, goal },
-                    },
-            } = canonical_goal.clone();
-
-            let (current_answer, current_prio) = match goal.data(self.program.interner()) {
-                GoalData::DomainGoal(domain_goal) => {
-                    let canonical_goal = UCanonical {
-                        universes,
-                        canonical: Canonical {
-                            binders,
-                            value: InEnvironment {
-                                environment,
-                                goal: domain_goal.clone(),
-                            },
-                        },
-                    };
-
-                    // "Domain" goals (i.e., leaf goals that are Rust-specific) are
-                    // always solved via some form of implication. We can either
-                    // apply assumptions from our environment (i.e. where clauses),
-                    // or from the lowered program, which includes fallback
-                    // clauses. We try each approach in turn:
-
-                    let InEnvironment { environment, goal } = &canonical_goal.canonical.value;
-
-                    let (prog_solution, prog_prio) = {
-                        debug_heading!("prog_clauses");
-
-                        let prog_clauses = self.program_clauses_for_goal(environment, &goal);
-                        match prog_clauses {
-                            Ok(clauses) => {
-                                self.solve_from_clauses(&canonical_goal, clauses, minimums)
-                            }
-                            Err(Floundered) => {
-                                (Ok(Solution::Ambig(Guidance::Unknown)), ClausePriority::High)
-                            }
-                        }
-                    };
-                    debug!("prog_solution={:?}", prog_solution);
-
-                    (prog_solution, prog_prio)
-                }
-
-                _ => {
-                    let canonical_goal = UCanonical {
-                        universes,
-                        canonical: Canonical {
-                            binders,
-                            value: InEnvironment { environment, goal },
-                        },
-                    };
-
-                    self.solve_via_simplification(&canonical_goal, minimums)
-                }
-            };
+            let minimums = &mut Minimums::new();
+            let (current_answer, current_prio) = self.solve_iteration(&canonical_goal, minimums);
 
             debug!(
                 "solve_new_subgoal: loop iteration result = {:?} with minimums {:?}",
@@ -334,7 +149,7 @@ impl<'me, I: Interner> Solver<'me, I> {
             let old_answer = &self.context.search_graph[dfn].solution;
             let old_prio = self.context.search_graph[dfn].solution_priority;
 
-            let (current_answer, current_prio) = combine_with_priorities_for_goal(
+            let (current_answer, current_prio) = combine::with_priorities_for_goal(
                 self.program.interner(),
                 &canonical_goal.canonical.value.goal,
                 old_answer.clone(),
@@ -369,98 +184,9 @@ impl<'me, I: Interner> Solver<'me, I> {
             self.context.search_graph.rollback_to(dfn + 1);
         }
     }
-
-    fn solve_via_simplification(
-        &mut self,
-        canonical_goal: &UCanonicalGoal<I>,
-        minimums: &mut Minimums,
-    ) -> (Fallible<Solution<I>>, ClausePriority) {
-        debug_heading!("solve_via_simplification({:?})", canonical_goal);
-        let (infer, subst, goal) = self.new_inference_table(canonical_goal);
-        match Fulfill::new_with_simplification(self, infer, subst, goal) {
-            Ok(fulfill) => (fulfill.solve(minimums), ClausePriority::High),
-            Err(e) => (Err(e), ClausePriority::High),
-        }
-    }
-
-    /// See whether we can solve a goal by implication on any of the given
-    /// clauses. If multiple such solutions are possible, we attempt to combine
-    /// them.
-    fn solve_from_clauses<C>(
-        &mut self,
-        canonical_goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
-        clauses: C,
-        minimums: &mut Minimums,
-    ) -> (Fallible<Solution<I>>, ClausePriority)
-    where
-        C: IntoIterator<Item = ProgramClause<I>>,
-    {
-        let mut cur_solution = None;
-        for program_clause in clauses {
-            debug_heading!("clause={:?}", program_clause);
-
-            // If we have a completely ambiguous answer, it's not going to get better, so stop
-            if cur_solution == Some((Solution::Ambig(Guidance::Unknown), ClausePriority::High)) {
-                return (Ok(Solution::Ambig(Guidance::Unknown)), ClausePriority::High);
-            }
-
-            let res = {
-                let ProgramClauseData(implication) = program_clause.data(self.program.interner());
-
-                self.solve_via_implication(canonical_goal, implication, minimums)
-            };
-            if let (Ok(solution), priority) = res {
-                debug!("ok: solution={:?} prio={:?}", solution, priority);
-                cur_solution = Some(match cur_solution {
-                    None => (solution, priority),
-                    Some((cur, cur_priority)) => combine_with_priorities(
-                        self.program.interner(),
-                        &canonical_goal.canonical.value.goal,
-                        cur,
-                        cur_priority,
-                        solution,
-                        priority,
-                    ),
-                });
-            } else {
-                debug!("error");
-            }
-        }
-        cur_solution.map_or((Err(NoSolution), ClausePriority::High), |(s, p)| (Ok(s), p))
-    }
-
-    /// Modus ponens! That is: try to apply an implication by proving its premises.
-    fn solve_via_implication(
-        &mut self,
-        canonical_goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
-        clause: &Binders<ProgramClauseImplication<I>>,
-        minimums: &mut Minimums,
-    ) -> (Fallible<Solution<I>>, ClausePriority) {
-        info_heading!(
-            "solve_via_implication(\
-             \n    canonical_goal={:?},\
-             \n    clause={:?})",
-            canonical_goal,
-            clause
-        );
-
-        let (infer, subst, goal) = self.new_inference_table(canonical_goal);
-        match Fulfill::new_with_clause(self, infer, subst, goal, clause) {
-            Ok(fulfill) => (fulfill.solve(minimums), clause.skip_binders().priority),
-            Err(e) => (Err(e), ClausePriority::High),
-        }
-    }
-
-    fn program_clauses_for_goal(
-        &self,
-        environment: &Environment<I>,
-        goal: &DomainGoal<I>,
-    ) -> Result<Vec<ProgramClause<I>>, Floundered> {
-        program_clauses_for_goal(self.program, environment, goal)
-    }
 }
 
-impl<'me, I: Interner> RecursiveSolver<I> for Solver<'me, I> {
+impl<'me, I: Interner> SolveDatabase<I> for Solver<'me, I> {
     /// Attempt to solve a goal that has been fully broken down into leaf form
     /// and canonicalized. This is where the action really happens, and is the
     /// place where we would perform caching in rustc (and may eventually do in Chalk).
@@ -553,77 +279,8 @@ impl<'me, I: Interner> RecursiveSolver<I> for Solver<'me, I> {
     fn interner(&self) -> &I {
         &self.program.interner()
     }
-}
 
-fn calculate_inputs<I: Interner>(
-    interner: &I,
-    domain_goal: &DomainGoal<I>,
-    solution: &Solution<I>,
-) -> Vec<GenericArg<I>> {
-    if let Some(subst) = solution.constrained_subst() {
-        let subst_goal = subst.value.subst.apply(&domain_goal, interner);
-        subst_goal.inputs(interner)
-    } else {
-        domain_goal.inputs(interner)
-    }
-}
-
-fn combine_with_priorities_for_goal<I: Interner>(
-    interner: &I,
-    goal: &Goal<I>,
-    a: Fallible<Solution<I>>,
-    prio_a: ClausePriority,
-    b: Fallible<Solution<I>>,
-    prio_b: ClausePriority,
-) -> (Fallible<Solution<I>>, ClausePriority) {
-    let domain_goal = match goal.data(interner) {
-        GoalData::DomainGoal(domain_goal) => domain_goal,
-        _ => {
-            // non-domain goals currently have no priorities, so we always take the new solution here
-            return (b, prio_b);
-        }
-    };
-    match (a, b) {
-        (Ok(a), Ok(b)) => {
-            let (solution, prio) =
-                combine_with_priorities(interner, domain_goal, a, prio_a, b, prio_b);
-            (Ok(solution), prio)
-        }
-        (Ok(solution), Err(_)) => (Ok(solution), prio_a),
-        (Err(_), Ok(solution)) => (Ok(solution), prio_b),
-        (Err(_), Err(e)) => (Err(e), prio_b),
-    }
-}
-
-fn combine_with_priorities<I: Interner>(
-    interner: &I,
-    domain_goal: &DomainGoal<I>,
-    a: Solution<I>,
-    prio_a: ClausePriority,
-    b: Solution<I>,
-    prio_b: ClausePriority,
-) -> (Solution<I>, ClausePriority) {
-    match (prio_a, prio_b, a, b) {
-        (ClausePriority::High, ClausePriority::Low, higher, lower)
-        | (ClausePriority::Low, ClausePriority::High, lower, higher) => {
-            // if we have a high-priority solution and a low-priority solution,
-            // the high-priority solution overrides *if* they are both for the
-            // same inputs -- we don't want a more specific high-priority
-            // solution overriding a general low-priority one. Currently inputs
-            // only matter for projections; in a goal like `AliasEq(<?0 as
-            // Trait>::Type = ?1)`, ?0 is the input.
-            let inputs_higher = calculate_inputs(interner, domain_goal, &higher);
-            let inputs_lower = calculate_inputs(interner, domain_goal, &lower);
-            if inputs_higher == inputs_lower {
-                debug!(
-                    "preferring solution: {:?} over {:?} because of higher prio",
-                    higher, lower
-                );
-                (higher, ClausePriority::High)
-            } else {
-                (higher.combine(lower, interner), ClausePriority::High)
-            }
-        }
-        (_, _, a, b) => (a.combine(b, interner), prio_a),
+    fn db(&self) -> &dyn RustIrDatabase<I> {
+        self.program
     }
 }

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -83,11 +83,11 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
             consequence,
             conditions,
             priority: _,
-        } = match clause.data(interner) {
-            ProgramClauseData::Implies(implication) => implication.clone(),
-            ProgramClauseData::ForAll(implication) => self
-                .infer
-                .instantiate_binders_existentially(interner, implication),
+        } = {
+            let ProgramClauseData(implication) = clause.data(interner);
+
+            self.infer
+                .instantiate_binders_existentially(interner, implication)
         };
         debug!("consequence = {:?}", consequence);
         debug!("conditions = {:?}", conditions);


### PR DESCRIPTION
Closes #511 

~~As far as I can tell, I didn't change the logic of anything. However, when I checked the test suite there were still some failing tests. I've listed them here just in case they are relevant.~~


Initially failing tests
  
```
test test::coherence::downstream_impl_of_fundamental_43355 ... FAILED
test test::coherence::fundamental_traits ... FAILED
test test::coherence::local_negative_reasoning_in_coherence ... FAILED
test test::coherence::nonoverlapping_assoc_types ... FAILED
test test::coherence::overlapping_assoc_types ... FAILED
test test::coherence::overlapping_assoc_types_error ... FAILED
test test::coherence::two_blanket_impls ... FAILED
test test::misc::flounder_ambiguous ... FAILED
test test::projection::normalize_into_iterator ... FAILED
test test::projection::projection_from_env_a ... FAILED
test test::projection::projection_from_env_slow ... FAILED
test test::wf_goals::struct_wf ... FAILED
test test::wf_lowering::copy_constraints ... FAILED
test test::wf_lowering::drop_constraints ... FAILED
test test::wf_lowering::implied_bounds ... FAILED
```

Looking into the reason now.