### PR TITLE
new version: 0.13.0-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,14 +150,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chalk"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 dependencies = [
- "chalk-derive 0.12.0-dev.0",
- "chalk-engine 0.12.0-dev.0",
- "chalk-integration 0.12.0-dev.0",
- "chalk-ir 0.12.0-dev.0",
- "chalk-parse 0.12.0-dev.0",
- "chalk-solve 0.12.0-dev.0",
+ "chalk-derive 0.13.0-dev.0",
+ "chalk-engine 0.13.0-dev.0",
+ "chalk-integration 0.13.0-dev.0",
+ "chalk-ir 0.13.0-dev.0",
+ "chalk-parse 0.13.0-dev.0",
+ "chalk-solve 0.13.0-dev.0",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-derive"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -179,37 +179,37 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 dependencies = [
- "chalk-derive 0.12.0-dev.0",
- "chalk-ir 0.12.0-dev.0",
+ "chalk-derive 0.13.0-dev.0",
+ "chalk-ir 0.13.0-dev.0",
  "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chalk-integration"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 dependencies = [
- "chalk-derive 0.12.0-dev.0",
- "chalk-engine 0.12.0-dev.0",
- "chalk-ir 0.12.0-dev.0",
- "chalk-parse 0.12.0-dev.0",
- "chalk-solve 0.12.0-dev.0",
+ "chalk-derive 0.13.0-dev.0",
+ "chalk-engine 0.13.0-dev.0",
+ "chalk-ir 0.13.0-dev.0",
+ "chalk-parse 0.13.0-dev.0",
+ "chalk-solve 0.13.0-dev.0",
  "salsa 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chalk-ir"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 dependencies = [
- "chalk-derive 0.12.0-dev.0",
+ "chalk-derive 0.13.0-dev.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chalk-parse"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 dependencies = [
  "lalrpop 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -219,12 +219,12 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 dependencies = [
- "chalk-derive 0.12.0-dev.0",
- "chalk-engine 0.12.0-dev.0",
- "chalk-integration 0.12.0-dev.0",
- "chalk-ir 0.12.0-dev.0",
+ "chalk-derive 0.13.0-dev.0",
+ "chalk-engine 0.13.0-dev.0",
+ "chalk-integration 0.13.0-dev.0",
+ "chalk-ir 0.13.0-dev.0",
  "ena 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 description = "Model of the Rust trait system"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -21,12 +21,12 @@ salsa = "0.10.0"
 serde = "1.0"
 serde_derive = "1.0"
 
-chalk-derive = { version = "0.12.0-dev.0", path = "chalk-derive" }
-chalk-engine = { version = "0.12.0-dev.0", path = "chalk-engine" }
-chalk-ir = { version = "0.12.0-dev.0", path = "chalk-ir" }
-chalk-solve = { version = "0.12.0-dev.0", path = "chalk-solve" }
-chalk-parse = { version = "0.12.0-dev.0", path = "chalk-parse" }
-chalk-integration = { version = "0.12.0-dev.0", path = "chalk-integration" }
+chalk-derive = { version = "0.13.0-dev.0", path = "chalk-derive" }
+chalk-engine = { version = "0.13.0-dev.0", path = "chalk-engine" }
+chalk-ir = { version = "0.13.0-dev.0", path = "chalk-ir" }
+chalk-solve = { version = "0.13.0-dev.0", path = "chalk-solve" }
+chalk-parse = { version = "0.13.0-dev.0", path = "chalk-parse" }
+chalk-integration = { version = "0.13.0-dev.0", path = "chalk-integration" }
 
 [workspace]
 

--- a/chalk-derive/Cargo.toml
+++ b/chalk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-derive"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 description = "A helper crate for use by chalk crates for `derive` macros."
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]

--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-engine"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 description = "Core trait engine from Chalk project"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -15,5 +15,5 @@ default = []
 [dependencies]
 rustc-hash = { version = "1.1.0" }
 
-chalk-derive = { version = "0.12.0-dev.0", path = "../chalk-derive" }
-chalk-ir = { version = "0.12.0-dev.0", path = "../chalk-ir" }
+chalk-derive = { version = "0.13.0-dev.0", path = "../chalk-derive" }
+chalk-ir = { version = "0.13.0-dev.0", path = "../chalk-ir" }

--- a/chalk-integration/Cargo.toml
+++ b/chalk-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-integration"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 license = "Apache-2.0/MIT"
 description = "Sample solver setup for Chalk"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -13,8 +13,8 @@ publish = false
 string_cache = "0.8.0"
 salsa = "0.10.0"
 
-chalk-derive = { version = "0.12.0-dev.0", path = "../chalk-derive" }
-chalk-engine = { version = "0.12.0-dev.0", path = "../chalk-engine" }
-chalk-ir = { version = "0.12.0-dev.0", path = "../chalk-ir" }
-chalk-solve = { version = "0.12.0-dev.0", path = "../chalk-solve" }
-chalk-parse = { version = "0.12.0-dev.0", path = "../chalk-parse" }
+chalk-derive = { version = "0.13.0-dev.0", path = "../chalk-derive" }
+chalk-engine = { version = "0.13.0-dev.0", path = "../chalk-engine" }
+chalk-ir = { version = "0.13.0-dev.0", path = "../chalk-ir" }
+chalk-solve = { version = "0.13.0-dev.0", path = "../chalk-solve" }
+chalk-parse = { version = "0.13.0-dev.0", path = "../chalk-parse" }

--- a/chalk-ir/Cargo.toml
+++ b/chalk-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-ir"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 description = "Chalk's internal representation of types, goals, and clauses"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -11,5 +11,5 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.4.0"
-chalk-derive = { version = "0.12.0-dev.0", path = "../chalk-derive" }
+chalk-derive = { version = "0.13.0-dev.0", path = "../chalk-derive" }
 

--- a/chalk-parse/Cargo.toml
+++ b/chalk-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-parse"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 description = "Parser for the Chalk project"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]

--- a/chalk-solve/Cargo.toml
+++ b/chalk-solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-solve"
-version = "0.12.0-dev.0"
+version = "0.13.0-dev.0"
 description = "Combines the chalk-engine with chalk-ir"
 license = "Apache-2.0/MIT"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -15,9 +15,9 @@ itertools = "0.9.0"
 petgraph = "0.5.0"
 rustc-hash = { version = "1.0.0" }
 
-chalk-derive = { version = "0.12.0-dev.0", path = "../chalk-derive" }
-chalk-engine = { version = "0.12.0-dev.0", path = "../chalk-engine", optional = true }
-chalk-ir = { version = "0.12.0-dev.0", path = "../chalk-ir" }
+chalk-derive = { version = "0.13.0-dev.0", path = "../chalk-derive" }
+chalk-engine = { version = "0.13.0-dev.0", path = "../chalk-engine", optional = true }
+chalk-ir = { version = "0.13.0-dev.0", path = "../chalk-ir" }
 
 [dev-dependencies]
 chalk-integration = { path = "../chalk-integration" }


### PR DESCRIPTION
The automation failed to produce the 0.12.0 release, so we have to
manually bump these version numbers.