### PR TITLE
Ucanonicalization fix

### DIFF
--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -89,6 +89,11 @@ impl<'q, I: Interner> Canonicalizer<'q, I> {
     }
 
     fn add(&mut self, free_var: ParameterEnaVariable<I>) -> usize {
+        self.max_universe = max(
+            self.max_universe,
+            self.table.universe_of_unbound_var(*free_var.skip_kind()),
+        );
+
         self.free_vars
             .iter()
             .position(|v| v.skip_kind() == free_var.skip_kind())

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -672,3 +672,29 @@ fn not_really_ambig() {
         }
     }
 }
+
+#[test]
+fn canonicalization_regression() {
+    test! {
+        program {
+            trait ForAny<X> {}
+            trait ForSame<X> {}
+
+            impl<X, Y> ForAny<X> for Y {}
+            impl<X> ForSame<X> for X {}
+        }
+
+        goal {
+            forall<A> {
+                forall<B> {
+                    exists<E> {
+                        A: ForAny<E>,
+                        B: ForSame<E>
+                    }
+                }
+            }
+        } yields {
+            "Unique; substitution [?0 := !2_0], lifetime constraints []"
+        }
+    }
+}


### PR DESCRIPTION
This pr fixes canonicalization so it accounts for inference var universes. I thought I could bundle this with the rework of `Canonical` to include placeholder vars, but it turned out to be harder than I expected, so I want to push this fix separately. 
cc #512 