### PR TITLE
Support logs in lowering tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/chalk-solve/Cargo.toml
+++ b/chalk-solve/Cargo.toml
@@ -14,6 +14,7 @@ ena = "0.14.0"
 itertools = "0.9.0"
 petgraph = "0.5.0"
 tracing = "0.1"
+tracing-subscriber = "0.2"
 rustc-hash = { version = "1.0.0" }
 
 chalk-derive = { version = "0.14.0-dev.0", path = "../chalk-derive" }

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -17,6 +17,7 @@ mod coinductive_goal;
 pub mod ext;
 pub mod goal_builder;
 mod infer;
+pub mod logging;
 #[cfg(feature = "recursive-solver")]
 pub mod recursive;
 pub mod rust_ir;

--- a/chalk-solve/src/logging.rs
+++ b/chalk-solve/src/logging.rs
@@ -1,0 +1,13 @@
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+/// Run an action with a tracing log subscriber. The logging level is loaded
+/// from `CHALK_DEBUG`.
+pub fn with_tracing_logs<T>(action: impl FnOnce() -> T) -> T {
+    let filter = EnvFilter::from_env("CHALK_DEBUG");
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .without_time()
+        .finish();
+    tracing::subscriber::with_default(subscriber, action)
+}

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -5,10 +5,11 @@ use chalk_integration::interner::ChalkIr;
 use chalk_integration::lowering::LowerGoal;
 use chalk_integration::query::LoweringDatabase;
 use chalk_solve::ext::*;
+use chalk_solve::logging::with_tracing_logs;
 use chalk_solve::RustIrDatabase;
 use chalk_solve::{Solution, SolverChoice};
 
-use crate::test_util::{assert_same, with_tracing_logs};
+use crate::test_util::assert_same;
 
 #[cfg(feature = "bench")]
 mod bench;

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -7,9 +7,8 @@ use chalk_integration::query::LoweringDatabase;
 use chalk_solve::ext::*;
 use chalk_solve::RustIrDatabase;
 use chalk_solve::{Solution, SolverChoice};
-use tracing_subscriber::{filter::EnvFilter, FmtSubscriber};
 
-use crate::test_util::assert_same;
+use crate::test_util::{assert_same, with_tracing_logs};
 
 #[cfg(feature = "bench")]
 mod bench;
@@ -208,13 +207,7 @@ macro_rules! test {
 }
 
 fn solve_goal(program_text: &str, goals: Vec<(&str, SolverChoice, TestGoal)>) {
-    let filter = EnvFilter::from_env("CHALK_DEBUG");
-    let subscriber = FmtSubscriber::builder()
-        .with_env_filter(filter)
-        .with_ansi(false)
-        .without_time()
-        .finish();
-    tracing::subscriber::with_default(subscriber, || {
+    with_tracing_logs(|| {
         println!("program {}", program_text);
         assert!(program_text.starts_with("{"));
         assert!(program_text.ends_with("}"));

--- a/tests/test_util.rs
+++ b/tests/test_util.rs
@@ -1,15 +1,19 @@
 #![allow(unused_macros)]
 
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
 macro_rules! lowering_success {
     (program $program:tt) => {
         let program_text = stringify!($program);
         assert!(program_text.starts_with("{"));
         assert!(program_text.ends_with("}"));
-        let result = chalk_integration::db::ChalkDatabase::with(
-            &program_text[1..program_text.len() - 1],
-            chalk_solve::SolverChoice::default(),
-        )
-        .checked_program();
+        let result = $crate::test_util::with_tracing_logs(|| {
+            chalk_integration::db::ChalkDatabase::with(
+                &program_text[1..program_text.len() - 1],
+                chalk_solve::SolverChoice::default(),
+            )
+            .checked_program()
+        });
         if let Err(ref e) = result {
             println!("lowering error: {}", e);
         }
@@ -22,16 +26,30 @@ macro_rules! lowering_error {
         let program_text = stringify!($program);
         assert!(program_text.starts_with("{"));
         assert!(program_text.ends_with("}"));
-        let error = chalk_integration::db::ChalkDatabase::with(
-            &program_text[1..program_text.len() - 1],
-            chalk_solve::SolverChoice::default(),
-        )
-        .checked_program()
-        .unwrap_err()
-        .to_string();
+        let error = $crate::test_util::with_tracing_logs(|| {
+            chalk_integration::db::ChalkDatabase::with(
+                &program_text[1..program_text.len() - 1],
+                chalk_solve::SolverChoice::default(),
+            )
+            .checked_program()
+            .unwrap_err()
+            .to_string()
+        });
         let expected = $expected.to_string();
         crate::test_util::assert_same(&error, &expected);
     };
+}
+
+/// Run an action with a tracing log subscriber. The logging level is loaded
+/// from `CHALK_DEBUG`.
+pub fn with_tracing_logs<T>(action: impl FnOnce() -> T) -> T {
+    let filter = EnvFilter::from_env("CHALK_DEBUG");
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .without_time()
+        .finish();
+    tracing::subscriber::with_default(subscriber, action)
 }
 
 pub fn assert_same(result: &str, expected: &str) {


### PR DESCRIPTION
Not sure if this was intentional, but now lowering test logs are shown with `CHALK_DEBUG`.