### PR TITLE
Fix coherence issue with associated types in generic bound

### DIFF
--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -364,18 +364,18 @@ fn program_clauses_that_could_match<I: Interner>(
                     )?;
                 }
 
+                push_program_clauses_for_associated_type_values_in_impls_of(
+                    builder,
+                    trait_id,
+                    trait_parameters,
+                );
+
                 push_clauses_for_compatible_normalize(
                     db,
                     builder,
                     interner,
                     trait_id,
                     proj.associated_ty_id,
-                );
-
-                push_program_clauses_for_associated_type_values_in_impls_of(
-                    builder,
-                    trait_id,
-                    trait_parameters,
                 );
             }
             AliasTy::Opaque(_) => (),

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -389,10 +389,12 @@ fn program_clauses_that_could_match<I: Interner>(
 /// Adds clauses to allow normalizing possible downstream associated type
 /// implementations when in the "compatible" mode. Example clauses:
 ///
-///     for<type, type, type> Normalize(<^0.0 as Trait<^0.1>>::Item -> ^0.2)
-///         :- Compatible, Implemented(^0.0: Trait<^0.1>), DownstreamType(^0.1), CannotProve
-///     for<type, type, type> Normalize(<^0.0 as Trait<^0.1>>::Item -> ^0.2)
-///         :- Compatible, Implemented(^0.0: Trait<^0.1>), IsFullyVisible(^0.0), DownstreamType(^0.1), CannotProve
+/// ```notrust
+/// for<type, type, type> Normalize(<^0.0 as Trait<^0.1>>::Item -> ^0.2)
+///     :- Compatible, Implemented(^0.0: Trait<^0.1>), DownstreamType(^0.1), CannotProve
+/// for<type, type, type> Normalize(<^0.0 as Trait<^0.1>>::Item -> ^0.2)
+///     :- Compatible, Implemented(^0.0: Trait<^0.1>), IsFullyVisible(^0.0), DownstreamType(^0.1), CannotProve
+/// ```
 fn push_clauses_for_compatible_normalize<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -3,11 +3,12 @@ use self::env_elaborator::elaborate_env_clauses;
 use self::program_clauses::ToProgramClauses;
 use crate::split::Split;
 use crate::RustIrDatabase;
-use chalk_ir::cast::Cast;
+use chalk_ir::cast::{Cast, Caster};
 use chalk_ir::could_match::CouldMatch;
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
 use rustc_hash::FxHashSet;
+use std::iter;
 use tracing::{debug, instrument};
 
 pub mod builder;
@@ -364,6 +365,7 @@ fn program_clauses_that_could_match<I: Interner>(
                 }
 
                 push_clauses_for_compatible_normalize(
+                    db,
                     builder,
                     interner,
                     trait_id,
@@ -384,55 +386,59 @@ fn program_clauses_that_could_match<I: Interner>(
     Ok(clauses)
 }
 
-/// Adds the clause:
+/// Adds clauses to allow normalizing possible downstream associated type
+/// implementations when in the "compatible" mode. Example clauses:
 ///
-/// for<type, type> Normalize(<^0.0 as Trait>::Item -> ^0.1)
-///     :- Implemented(^0.0: Trait), Compatible, DownstreamType(^0.0), CannotProve
+///     for<type, type, type> Normalize(<^0.0 as Trait<^0.1>>::Item -> ^0.2)
+///         :- Compatible, Implemented(^0.0: Trait<^0.1>), DownstreamType(^0.1), CannotProve
+///     for<type, type, type> Normalize(<^0.0 as Trait<^0.1>>::Item -> ^0.2)
+///         :- Compatible, Implemented(^0.0: Trait<^0.1>), IsFullyVisible(^0.0), DownstreamType(^0.1), CannotProve
 fn push_clauses_for_compatible_normalize<I: Interner>(
+    db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,
     interner: &I,
     trait_id: TraitId<I>,
     associated_ty_id: AssocTypeId<I>,
 ) {
-    // FIXME: Simplify?
-    builder.push_binders(
-        &Binders::new(
-            VariableKinds::from(
-                interner,
-                vec![
-                    VariableKind::Ty(TyKind::General),
-                    VariableKind::Ty(TyKind::General),
-                ],
-            ),
-            vec![
-                TyData::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, 0)).intern(interner),
-                TyData::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, 1)).intern(interner),
-            ],
-        ),
-        |builder, mut tys| {
-            let ty1 = tys.remove(0);
-            let ty2 = tys.remove(0);
-            builder.push_clause(
-                DomainGoal::Normalize(Normalize {
-                    ty: ty2,
-                    alias: AliasTy::Projection(ProjectionTy {
-                        associated_ty_id,
-                        substitution: Substitution::from(interner, Some(ty1.clone())),
+    let trait_datum = db.trait_datum(trait_id);
+    let trait_binders = trait_datum.binders.map_ref(|b| &b.where_clauses);
+    builder.push_binders(&trait_binders, |builder, where_clauses| {
+        let projection = ProjectionTy {
+            associated_ty_id,
+            substitution: builder.substitution_in_scope(),
+        };
+        let trait_ref = TraitRef {
+            trait_id,
+            substitution: builder.substitution_in_scope(),
+        };
+        let type_parameters: Vec<_> = trait_ref.type_parameters(interner).collect();
+
+        builder.push_bound_ty(|builder, target_ty| {
+            for i in 0..type_parameters.len() {
+                builder.push_clause(
+                    DomainGoal::Normalize(Normalize {
+                        ty: target_ty.clone(),
+                        alias: AliasTy::Projection(projection.clone()),
                     }),
-                }),
-                &[
-                    WhereClause::Implemented(TraitRef {
-                        trait_id,
-                        substitution: Substitution::from(interner, Some(ty1.clone())),
-                    })
-                    .cast(interner),
-                    DomainGoal::Compatible(()).cast(interner),
-                    DomainGoal::DownstreamType(ty1).cast(interner),
-                    GoalData::CannotProve(()).intern(interner),
-                ],
-            );
-        },
-    );
+                    where_clauses
+                        .iter()
+                        .cloned()
+                        .casted(interner)
+                        .chain(iter::once(DomainGoal::Compatible(()).cast(interner)))
+                        .chain(iter::once(
+                            WhereClause::Implemented(trait_ref.clone()).cast(interner),
+                        ))
+                        .chain((0..i).map(|j| {
+                            DomainGoal::IsFullyVisible(type_parameters[j].clone()).cast(interner)
+                        }))
+                        .chain(iter::once(
+                            DomainGoal::DownstreamType(type_parameters[i].clone()).cast(interner),
+                        ))
+                        .chain(iter::once(GoalData::CannotProve(()).intern(interner))),
+                );
+            }
+        });
+    });
 }
 
 /// Generate program clauses from the associated-type values

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -386,8 +386,8 @@ fn program_clauses_that_could_match<I: Interner>(
 
 /// Adds the clause:
 ///
-/// forall<T1, T2> Normalize(<T1 as Trait>::Item -> T2)
-///     :- Implemented(T1: Trait), Compatible, DownstreamType(T1), CannotProve
+/// for<type, type> Normalize(<^0.0 as Trait>::Item -> ^0.1)
+///     :- Implemented(^0.0: Trait), Compatible, DownstreamType(^0.0), CannotProve
 fn push_clauses_for_compatible_normalize<I: Interner>(
     builder: &mut ClauseBuilder<'_, I>,
     interner: &I,

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -325,6 +325,7 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
                 self.unify(&environment, &a, &b)?;
             }
             GoalData::CannotProve(()) => {
+                debug!("Pushed a CannotProve goal, setting cannot_prove = true");
                 self.cannot_prove = true;
             }
         }
@@ -497,6 +498,7 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
         };
 
         if self.cannot_prove {
+            debug!("Goal cannot be proven (cannot_prove = true), returning ambiguous");
             return Ok(Solution::Ambig(Guidance::Unknown));
         }
 

--- a/tests/test/coherence.rs
+++ b/tests/test/coherence.rs
@@ -209,6 +209,24 @@ fn overlapping_assoc_types_error() {
     }
 }
 
+/// See https://github.com/rust-lang/chalk/issues/515
+#[test]
+fn overlapping_assoc_types_error_simple() {
+    lowering_error! {
+        program {
+            trait Iterator { type Item; }
+            trait Trait {}
+
+            struct Foo {}
+
+            impl<T> Trait for T where T: Iterator<Item = u32> {}
+            impl<T> Trait for T where T: Iterator<Item = u32> {}
+        } error_msg {
+            "overlapping impls of trait `Trait`"
+        }
+    }
+}
+
 #[test]
 fn overlapping_negative_positive_impls() {
     lowering_error! {

--- a/tests/test/coherence.rs
+++ b/tests/test/coherence.rs
@@ -227,6 +227,24 @@ fn overlapping_assoc_types_error_simple() {
     }
 }
 
+/// See https://github.com/rust-lang/chalk/issues/515
+#[test]
+fn overlapping_assoc_types_error_generics() {
+    lowering_error! {
+        program {
+            trait Iterator<I> { type Item; }
+            trait Trait {}
+
+            struct Foo {}
+
+            impl<T, I> Trait for T where T: Iterator<I, Item = u32> {}
+            impl<T, I> Trait for T where T: Iterator<I, Item = u32> {}
+        } error_msg {
+            "overlapping impls of trait `Trait`"
+        }
+    }
+}
+
 #[test]
 fn overlapping_negative_positive_impls() {
     lowering_error! {


### PR DESCRIPTION
The normalize clause needs to be simplified, and may not be the right approach, but it works.

Fixes #515 