### PR TITLE
Fix built-in Fn impls when generics are involved

### DIFF
--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -102,11 +102,6 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
                 let bound = fn_def_datum
                     .binders
                     .substitute(builder.interner(), &apply.substitution);
-                let self_ty = ApplicationTy {
-                    name: apply.name,
-                    substitution: builder.substitution_in_scope(),
-                }
-                .intern(interner);
                 push_clauses_for_apply(
                     db,
                     builder,

--- a/tests/test/fn_def.rs
+++ b/tests/test/fn_def.rs
@@ -96,5 +96,73 @@ fn fn_def_implements_fn_traits() {
         } yields {
             "Unique"
         }
+
+        goal {
+            bar: Fn<(i32,)>
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            Normalize(<bar as FnOnce<(i32,)>>::Output -> ())
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            baz: Fn<(i32,)>
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            Normalize(<baz as FnOnce<(i32,)>>::Output -> u8)
+        } yields {
+            "Unique"
+        }
+    }
+}
+
+#[test]
+fn generic_fn_implements_fn_traits() {
+    test! {
+        program {
+            #[lang(fn_once)]
+            trait FnOnce<Args> {
+                type Output;
+            }
+
+            #[lang(fn_mut)]
+            trait FnMut<Args> where Self: FnOnce<Args> { }
+
+            #[lang(fn)]
+            trait Fn<Args> where Self: FnMut<Args> { }
+
+            fn foo<T>(t: T) -> T;
+        }
+
+        goal {
+            exists<T> { foo<T>: Fn<(T,)> }
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            forall<T> { foo<T>: Fn<(T,)> }
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            exists<T> { Normalize(<foo<T> as FnOnce<(T,)>>::Output -> T) }
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            forall<T> { Normalize(<foo<T> as FnOnce<(T,)>>::Output -> T) }
+        } yields {
+            "Unique"
+        }
     }
 }


### PR DESCRIPTION
There were two problems:
 - the FnDef impl was using a wrong substitution for the FnDef (calling
   `builder.substitution_in_scope()`, which wasn't even necessarily the same
   number of parameters -- not sure what the intention was there)
 - when looking for `Normalize` clauses, the self type wasn't generalized (so
   bound variables were handled wrongly). (This lead to crashes when trying to
   integrate it in rust-analyzer: rust-analyzer/rust-analyzer#4982)