### PR TITLE
Incorporate region constraints into program clauses

### DIFF
--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -8,7 +8,7 @@
 use crate::{CompleteAnswer, ExClause};
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    AnswerSubst, Binders, Canonical, ConstrainedSubst, Constraint, DomainGoal, Environment,
+    AnswerSubst, Binders, Canonical, ConstrainedSubst, Constraints, DomainGoal, Environment,
     Fallible, Floundered, GenericArg, Goal, InEnvironment, ProgramClause, ProgramClauses,
     Substitution, UCanonical, UniverseMap,
 };
@@ -94,7 +94,7 @@ pub trait ContextOps<I: Interner, C: Context<I>>: Sized + Clone + Debug {
     ) -> (
         C::InferenceTable,
         Substitution<I>,
-        Vec<InEnvironment<Constraint<I>>>,
+        Constraints<I>,
         Vec<InEnvironment<Goal<I>>>,
     );
 
@@ -181,7 +181,7 @@ pub trait UnificationOps<I: Interner, C: Context<I>> {
         &mut self,
         interner: &I,
         subst: Substitution<I>,
-        constraints: Vec<InEnvironment<Constraint<I>>>,
+        constraints: Constraints<I>,
     ) -> Canonical<ConstrainedSubst<I>>;
 
     // Used by: logic
@@ -189,7 +189,7 @@ pub trait UnificationOps<I: Interner, C: Context<I>> {
         &mut self,
         interner: &I,
         subst: Substitution<I>,
-        constraints: Vec<InEnvironment<Constraint<I>>>,
+        constraints: Constraints<I>,
         delayed_subgoals: Vec<InEnvironment<Goal<I>>>,
     ) -> Canonical<AnswerSubst<I>>;
 

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -8,7 +8,7 @@
 use crate::{CompleteAnswer, ExClause};
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    AnswerSubst, Binders, Canonical, ConstrainedSubst, Constraints, DomainGoal, Environment,
+    AnswerSubst, Binders, Canonical, ConstrainedSubst, Constraint, DomainGoal, Environment,
     Fallible, Floundered, GenericArg, Goal, InEnvironment, ProgramClause, ProgramClauses,
     Substitution, UCanonical, UniverseMap,
 };
@@ -94,7 +94,7 @@ pub trait ContextOps<I: Interner, C: Context<I>>: Sized + Clone + Debug {
     ) -> (
         C::InferenceTable,
         Substitution<I>,
-        Constraints<I>,
+        Vec<InEnvironment<Constraint<I>>>,
         Vec<InEnvironment<Goal<I>>>,
     );
 
@@ -181,7 +181,7 @@ pub trait UnificationOps<I: Interner, C: Context<I>> {
         &mut self,
         interner: &I,
         subst: Substitution<I>,
-        constraints: Constraints<I>,
+        constraints: Vec<InEnvironment<Constraint<I>>>,
     ) -> Canonical<ConstrainedSubst<I>>;
 
     // Used by: logic
@@ -189,7 +189,7 @@ pub trait UnificationOps<I: Interner, C: Context<I>> {
         &mut self,
         interner: &I,
         subst: Substitution<I>,
-        constraints: Constraints<I>,
+        constraints: Vec<InEnvironment<Constraint<I>>>,
         delayed_subgoals: Vec<InEnvironment<Goal<I>>>,
     ) -> Canonical<AnswerSubst<I>>;
 

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -60,7 +60,7 @@ use chalk_derive::{Fold, HasInterner, Visit};
 use chalk_ir::interner::{Interner, TargetInterner};
 use chalk_ir::visit::VisitResult;
 use chalk_ir::{
-    AnswerSubst, Canonical, ConstrainedSubst, Constraints, DebruijnIndex, Goal, InEnvironment,
+    AnswerSubst, Canonical, ConstrainedSubst, Constraint, DebruijnIndex, Goal, InEnvironment,
     Substitution,
 };
 
@@ -94,7 +94,7 @@ pub struct ExClause<I: Interner> {
     pub ambiguous: bool,
 
     /// Region constraints we have accumulated.
-    pub constraints: Constraints<I>,
+    pub constraints: Vec<InEnvironment<Constraint<I>>>,
 
     /// Subgoals: literals that must be proven
     pub subgoals: Vec<Literal<I>>,

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -60,7 +60,7 @@ use chalk_derive::{Fold, HasInterner, Visit};
 use chalk_ir::interner::{Interner, TargetInterner};
 use chalk_ir::visit::VisitResult;
 use chalk_ir::{
-    AnswerSubst, Canonical, ConstrainedSubst, Constraint, DebruijnIndex, Goal, InEnvironment,
+    AnswerSubst, Canonical, ConstrainedSubst, Constraints, DebruijnIndex, Goal, InEnvironment,
     Substitution,
 };
 
@@ -94,7 +94,7 @@ pub struct ExClause<I: Interner> {
     pub ambiguous: bool,
 
     /// Region constraints we have accumulated.
-    pub constraints: Vec<InEnvironment<Constraint<I>>>,
+    pub constraints: Constraints<I>,
 
     /// Subgoals: literals that must be proven
     pub subgoals: Vec<Literal<I>>,

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -1477,7 +1477,11 @@ impl<'forest, I: Interner, C: Context<I> + 'forest, CO: ContextOps<I, C> + 'fore
         let is_trivial_answer = {
             self.context
                 .is_trivial_substitution(&self.forest.tables[table].table_goal, &answer.subst)
-                && answer.subst.value.constraints.is_empty()
+                && answer
+                    .subst
+                    .value
+                    .constraints
+                    .is_empty(self.context.interner())
         };
 
         if let Some(answer_index) = self.forest.tables[table].push_answer(answer) {

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -4,7 +4,7 @@ use crate::{ExClause, Literal, TimeStamp};
 
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    Constraint, Environment, Fallible, Goal, GoalData, InEnvironment, QuantifierKind, Substitution,
+    Environment, Fallible, Goal, GoalData, InEnvironment, QuantifierKind, Substitution,
 };
 use tracing::debug;
 
@@ -68,9 +68,6 @@ impl<I: Interner, C: Context<I>> Forest<I, C> {
                     &goal.b,
                     &mut ex_clause,
                 )?,
-                GoalData::AddRegionConstraint(a, b) => ex_clause.constraints.push(
-                    InEnvironment::new(&environment, Constraint::Outlives(a.clone(), b.clone())),
-                ),
                 GoalData::DomainGoal(domain_goal) => {
                     ex_clause
                         .subgoals

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -4,7 +4,7 @@ use crate::{ExClause, Literal, TimeStamp};
 
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    Environment, Fallible, Goal, GoalData, InEnvironment, QuantifierKind, Substitution,
+    Constraints, Environment, Fallible, Goal, GoalData, InEnvironment, QuantifierKind, Substitution,
 };
 use tracing::debug;
 
@@ -22,7 +22,7 @@ impl<I: Interner, C: Context<I>> Forest<I, C> {
         let mut ex_clause = ExClause {
             subst,
             ambiguous: false,
-            constraints: vec![],
+            constraints: Constraints::empty(context.interner()),
             subgoals: vec![],
             delayed_subgoals: vec![],
             answer_time: TimeStamp::default(),

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -4,7 +4,7 @@ use crate::{ExClause, Literal, TimeStamp};
 
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    Constraints, Environment, Fallible, Goal, GoalData, InEnvironment, QuantifierKind, Substitution,
+    Environment, Fallible, Goal, GoalData, InEnvironment, QuantifierKind, Substitution,
 };
 use tracing::debug;
 
@@ -22,7 +22,7 @@ impl<I: Interner, C: Context<I>> Forest<I, C> {
         let mut ex_clause = ExClause {
             subst,
             ambiguous: false,
-            constraints: Constraints::empty(context.interner()),
+            constraints: vec![],
             subgoals: vec![],
             delayed_subgoals: vec![],
             answer_time: TimeStamp::default(),

--- a/chalk-integration/src/interner.rs
+++ b/chalk-integration/src/interner.rs
@@ -2,9 +2,9 @@ use crate::tls;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::{
     AdtId, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKind, CanonicalVarKinds, ConstData,
-    Goals, Lifetime, OpaqueTy, OpaqueTyId, ProgramClauseImplication, ProgramClauses, ProjectionTy,
-    QuantifiedWhereClauses, SeparatorTraitRef, Substitution, TraitId, Ty, VariableKind,
-    VariableKinds,
+    Constraint, Goals, InEnvironment, Lifetime, OpaqueTy, OpaqueTyId, ProgramClauseImplication,
+    ProgramClauses, ProjectionTy, QuantifiedWhereClauses, SeparatorTraitRef, Substitution, TraitId,
+    Ty, VariableKind, VariableKinds,
 };
 use chalk_ir::{
     GenericArg, GenericArgData, Goal, GoalData, LifetimeData, ProgramClause, ProgramClauseData,
@@ -53,6 +53,7 @@ impl Interner for ChalkIr {
     type InternedQuantifiedWhereClauses = Vec<QuantifiedWhereClause<ChalkIr>>;
     type InternedVariableKinds = Vec<VariableKind<ChalkIr>>;
     type InternedCanonicalVarKinds = Vec<CanonicalVarKind<ChalkIr>>;
+    type InternedConstraints = Vec<InEnvironment<Constraint<ChalkIr>>>;
     type DefId = RawId;
     type InternedAdtId = RawId;
     type Identifier = Identifier;
@@ -343,6 +344,20 @@ impl Interner for ChalkIr {
         canonical_var_kinds: &'a Self::InternedCanonicalVarKinds,
     ) -> &'a [CanonicalVarKind<ChalkIr>] {
         canonical_var_kinds
+    }
+
+    fn intern_constraints<E>(
+        &self,
+        data: impl IntoIterator<Item = Result<InEnvironment<Constraint<Self>>, E>>,
+    ) -> Result<Self::InternedConstraints, E> {
+        data.into_iter().collect()
+    }
+
+    fn constraints_data<'a>(
+        &self,
+        constraints: &'a Self::InternedConstraints,
+    ) -> &'a [InEnvironment<Constraint<Self>>] {
+        constraints
     }
 }
 

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1854,7 +1854,7 @@ impl LowerClause for Clause {
                 .map(|consequence| chalk_ir::ProgramClauseImplication {
                     consequence,
                     conditions: conditions.clone(),
-                    constraints: Vec::new(),
+                    constraints: chalk_ir::Constraints::empty(interner),
                     priority: ClausePriority::High,
                 })
                 .collect::<Vec<_>>();

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1854,6 +1854,7 @@ impl LowerClause for Clause {
                 .map(|consequence| chalk_ir::ProgramClauseImplication {
                     consequence,
                     conditions: conditions.clone(),
+                    constraints: Vec::new(),
                     priority: ClausePriority::High,
                 })
                 .collect::<Vec<_>>();

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -206,6 +206,7 @@ where
         let implication = ProgramClauseImplication {
             consequence: self.cast(interner),
             conditions: Goals::empty(interner),
+            constraints: Vec::new(),
             priority: ClausePriority::High,
         };
 
@@ -223,6 +224,7 @@ where
         ProgramClauseData(self.map(|bound| ProgramClauseImplication {
             consequence: bound.cast(interner),
             conditions: Goals::empty(interner),
+            constraints: Vec::new(),
             priority: ClausePriority::High,
         }))
         .intern(interner)

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -89,6 +89,7 @@ reflexive_impl!(for(I: Interner) ProgramClause<I>);
 reflexive_impl!(for(I: Interner) QuantifiedWhereClause<I>);
 reflexive_impl!(for(I: Interner) VariableKinds<I>);
 reflexive_impl!(for(I: Interner) CanonicalVarKinds<I>);
+reflexive_impl!(for(I: Interner) Constraint<I>);
 
 impl<I: Interner> CastTo<WhereClause<I>> for TraitRef<I> {
     fn cast_to(self, _interner: &I) -> WhereClause<I> {
@@ -206,7 +207,7 @@ where
         let implication = ProgramClauseImplication {
             consequence: self.cast(interner),
             conditions: Goals::empty(interner),
-            constraints: Vec::new(),
+            constraints: Constraints::empty(interner),
             priority: ClausePriority::High,
         };
 
@@ -224,7 +225,7 @@ where
         ProgramClauseData(self.map(|bound| ProgramClauseImplication {
             consequence: bound.cast(interner),
             conditions: Goals::empty(interner),
-            constraints: Vec::new(),
+            constraints: Constraints::empty(interner),
             priority: ClausePriority::High,
         }))
         .intern(interner)

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -96,6 +96,12 @@ impl<I: Interner> Debug for ProgramClauses<I> {
     }
 }
 
+impl<I: Interner> Debug for Constraints<I> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
+        I::debug_constraints(self, fmt).unwrap_or_else(|| write!(fmt, "{:?}", self.interned))
+    }
+}
+
 impl<I: Interner> Debug for ApplicationTy<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         I::debug_application_ty(self, fmt).unwrap_or_else(|| write!(fmt, "ApplicationTy(?)"))

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -326,9 +326,6 @@ impl<I: Interner> Debug for GoalData<I> {
             GoalData::Not(ref g) => write!(fmt, "not {{ {:?} }}", g),
             GoalData::EqGoal(ref wc) => write!(fmt, "{:?}", wc),
             GoalData::DomainGoal(ref wc) => write!(fmt, "{:?}", wc),
-            GoalData::AddRegionConstraint(ref a, ref b) => {
-                write!(fmt, "AddRegionConstraint({:?}: {:?})", a, b)
-            }
             GoalData::CannotProve(()) => write!(fmt, r"¯\_(ツ)_/¯"),
         }
     }

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -213,6 +213,26 @@ impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for QuantifiedWhereClauses<
     }
 }
 
+impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for Constraints<I> {
+    type Result = Constraints<TI>;
+    fn fold_with<'i>(
+        &self,
+        folder: &mut dyn Folder<'i, I, TI>,
+        outer_binder: DebruijnIndex,
+    ) -> Fallible<Self::Result>
+    where
+        I: 'i,
+        TI: 'i,
+    {
+        let interner = folder.interner();
+        let target_interner = folder.target_interner();
+        let folded = self
+            .iter(interner)
+            .map(|p| p.fold_with(folder, outer_binder));
+        Ok(Constraints::from_fallible(target_interner, folded)?)
+    }
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! copy_fold {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -2558,9 +2558,6 @@ pub enum GoalData<I: Interner> {
     /// proven via program clauses
     DomainGoal(DomainGoal<I>),
 
-    /// Adds a region constraint requiring `'a : 'b`, given two lifetimes `'a, 'b`
-    AddRegionConstraint(Lifetime<I>, Lifetime<I>),
-
     /// Indicates something that cannot be proven to be true or false
     /// definitively. This can occur with overflow but also with
     /// unifications of skolemized variables like `forall<X,Y> { X = Y

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -2008,6 +2008,9 @@ pub struct ProgramClauseImplication<I: Interner> {
     /// The condition goals that should hold.
     pub conditions: Goals<I>,
 
+    /// The lifetime constraints that should be proven.
+    pub constraints: Vec<InEnvironment<Constraint<I>>>,
+
     /// The relative priority of the implication.
     pub priority: ClausePriority,
 }
@@ -2043,6 +2046,7 @@ impl<I: Interner> ProgramClauseImplication<I> {
             ProgramClauseImplication {
                 consequence: self.consequence.into_from_env_goal(interner),
                 conditions: self.conditions.clone(),
+                constraints: self.constraints.clone(),
                 priority: self.priority,
             }
         } else {
@@ -2617,7 +2621,7 @@ pub enum QuantifierKind {
 /// lifetime constraints, instead gathering them up to return with our solution
 /// for later checking. This allows for decoupling between type and region
 /// checking in the compiler.
-#[derive(Clone, PartialEq, Eq, Hash, Fold, Visit, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, Fold, Visit, HasInterner, Zip)]
 pub enum Constraint<I: Interner> {
     /// Outlives constraint `'a: 'b`, indicating that the value of `'a` must be
     /// a superset of the value of `'b`.

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -5,10 +5,10 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::{
-    AdtId, AssocTypeId, ClausePriority, ClosureId, DebruijnIndex, FloatTy, FnDefId, GenericArg,
-    Goals, ImplId, IntTy, Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause,
-    ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution, SuperVisit,
-    TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
+    AdtId, AssocTypeId, ClausePriority, ClosureId, Constraints, DebruijnIndex, FloatTy, FnDefId,
+    GenericArg, Goals, ImplId, IntTy, Interner, Mutability, OpaqueTyId, PlaceholderIndex,
+    ProgramClause, ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution,
+    SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
 };
 use std::{marker::PhantomData, sync::Arc};
 
@@ -255,6 +255,21 @@ impl<I: Interner> SuperVisit<I> for ProgramClause<I> {
 }
 
 impl<I: Interner> Visit<I> for ProgramClauses<I> {
+    fn visit_with<'i, R: VisitResult>(
+        &self,
+        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        outer_binder: DebruijnIndex,
+    ) -> R
+    where
+        I: 'i,
+    {
+        let interner = visitor.interner();
+
+        visit_iter(self.iter(interner), visitor, outer_binder)
+    }
+}
+
+impl<I: Interner> Visit<I> for Constraints<I> {
     fn visit_with<'i, R: VisitResult>(
         &self,
         visitor: &mut dyn Visitor<'i, I, Result = R>,

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -270,6 +270,17 @@ impl<I: Interner> Zip<I> for ProgramClauses<I> {
     }
 }
 
+impl<I: Interner> Zip<I> for Constraints<I> {
+    fn zip_with<'i, Z: Zipper<'i, I>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()>
+    where
+        I: 'i,
+    {
+        let interner = zipper.interner();
+        Zip::zip_with(zipper, a.as_slice(interner), b.as_slice(interner))?;
+        Ok(())
+    }
+}
+
 impl<I: Interner> Zip<I> for QuantifiedWhereClauses<I> {
     fn zip_with<'i, Z: Zipper<'i, I>>(zipper: &mut Z, a: &Self, b: &Self) -> Fallible<()>
     where

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -313,15 +313,7 @@ fn program_clauses_that_could_match<I: Interner>(
                 .opaque_ty_data(opaque_ty.opaque_ty_id)
                 .to_program_clauses(builder),
         },
-        DomainGoal::Holds(WhereClause::LifetimeOutlives(LifetimeOutlives { a, b })) => {
-            builder.push_clause(
-                WhereClause::LifetimeOutlives(LifetimeOutlives {
-                    a: a.clone(),
-                    b: b.clone(),
-                }),
-                Some(GoalData::AddRegionConstraint(a.clone(), b.clone()).intern(interner)),
-            );
-        }
+        DomainGoal::Holds(WhereClause::LifetimeOutlives(LifetimeOutlives { .. })) => {}
         DomainGoal::WellFormed(WellFormed::Trait(trait_ref))
         | DomainGoal::LocalImplAllowed(trait_ref) => {
             db.trait_datum(trait_ref.trait_id)

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -313,17 +313,18 @@ fn program_clauses_that_could_match<I: Interner>(
                 .opaque_ty_data(opaque_ty.opaque_ty_id)
                 .to_program_clauses(builder),
         },
-        DomainGoal::Holds(WhereClause::LifetimeOutlives(LifetimeOutlives { a, b })) => {
-            builder.push_fact_with_constraints(
-                DomainGoal::Holds(WhereClause::LifetimeOutlives(LifetimeOutlives {
-                    a: a.clone(),
-                    b: b.clone(),
-                })),
-                Some(InEnvironment::new(
-                    environment,
-                    Constraint::Outlives(a.clone(), b.clone()),
-                )),
-            );
+        DomainGoal::Holds(WhereClause::LifetimeOutlives(..)) => {
+            builder.push_bound_lifetime(|builder, a| {
+                builder.push_bound_lifetime(|builder, b| {
+                    builder.push_fact_with_constraints(
+                        DomainGoal::Holds(WhereClause::LifetimeOutlives(LifetimeOutlives {
+                            a: a.clone(),
+                            b: b.clone(),
+                        })),
+                        Some(InEnvironment::new(environment, Constraint::Outlives(a, b))),
+                    );
+                })
+            });
         }
         DomainGoal::WellFormed(WellFormed::Trait(trait_ref))
         | DomainGoal::LocalImplAllowed(trait_ref) => {

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -313,7 +313,18 @@ fn program_clauses_that_could_match<I: Interner>(
                 .opaque_ty_data(opaque_ty.opaque_ty_id)
                 .to_program_clauses(builder),
         },
-        DomainGoal::Holds(WhereClause::LifetimeOutlives(LifetimeOutlives { .. })) => {}
+        DomainGoal::Holds(WhereClause::LifetimeOutlives(LifetimeOutlives { a, b })) => {
+            builder.push_fact_with_constraints(
+                DomainGoal::Holds(WhereClause::LifetimeOutlives(LifetimeOutlives {
+                    a: a.clone(),
+                    b: b.clone(),
+                })),
+                Some(InEnvironment::new(
+                    environment,
+                    Constraint::Outlives(a.clone(), b.clone()),
+                )),
+            );
+        }
         DomainGoal::WellFormed(WellFormed::Trait(trait_ref))
         | DomainGoal::LocalImplAllowed(trait_ref) => {
             db.trait_datum(trait_ref.trait_id)

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -163,7 +163,6 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
     /// unaffected and hence the context remains usable. Invokes `op`,
     /// passing a type representing this new type variable in as an
     /// argument.
-    #[allow(dead_code)]
     pub fn push_bound_ty(&mut self, op: impl FnOnce(&mut Self, Ty<I>)) {
         let interner = self.interner();
         let binders = Binders::new(
@@ -178,6 +177,28 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
                 .assert_ty_ref(interner)
                 .clone();
             op(this, ty)
+        });
+    }
+
+    /// Push a single binder, for a lifetime, at the end of the binder
+    /// list.  The indices of previously bound variables are
+    /// unaffected and hence the context remains usable. Invokes `op`,
+    /// passing a lifetime representing this new lifetime variable in as an
+    /// argument.
+    pub fn push_bound_lifetime(&mut self, op: impl FnOnce(&mut Self, Lifetime<I>)) {
+        let interner = self.interner();
+        let binders = Binders::new(
+            VariableKinds::from1(interner, VariableKind::Lifetime),
+            PhantomData::<I>,
+        );
+        self.push_binders(&binders, |this, PhantomData| {
+            let lifetime = this
+                .placeholders_in_scope()
+                .last()
+                .unwrap()
+                .assert_lifetime_ref(interner)
+                .clone();
+            op(this, lifetime)
         });
     }
 

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -85,7 +85,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
         let clause = ProgramClauseImplication {
             consequence: consequence.cast(interner),
             conditions: Goals::from(interner, conditions),
-            constraints: constraints.into_iter().collect(),
+            constraints: Constraints::from(interner, constraints),
             priority,
         };
 

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -793,7 +793,7 @@ impl<I: Interner> ToProgramClauses<I> for AssociatedTyDatum<I> {
             //    forall<Self> {
             //        AliasEq(<Self as Foo>::Assoc = (Foo::Assoc)<Self>).
             //    }
-            builder.push_fact_with_priority(projection_eq, ClausePriority::Low);
+            builder.push_fact_with_priority(projection_eq, None, ClausePriority::Low);
 
             // Well-formedness of projection type.
             //

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -292,10 +292,8 @@ fn lifetime_constraint_indirect() {
     // '!1.
     let t_a = ty!(apply (item 0) (lifetime (placeholder 1)));
     let t_b = ty!(apply (item 0) (lifetime (infer 1)));
-    let UnificationResult { goals, constraints } =
-        table.unify(interner, &environment0, &t_a, &t_b).unwrap();
+    let UnificationResult { goals } = table.unify(interner, &environment0, &t_a, &t_b).unwrap();
     assert!(goals.is_empty());
-    assert!(constraints.is_empty());
 
     // Here, we try to unify `?0` (the type variable in universe 0)
     // with something that involves `'?1`. Since `'?1` has been
@@ -303,16 +301,14 @@ fn lifetime_constraint_indirect() {
     // we will replace `'!1` with a new variable `'?2` and introduce a
     // (likely unsatisfiable) constraint relating them.
     let t_c = ty!(infer 0);
-    let UnificationResult { goals, constraints } =
-        table.unify(interner, &environment0, &t_c, &t_b).unwrap();
-    assert!(goals.is_empty());
-    assert_eq!(constraints.len(), 2);
+    let UnificationResult { goals } = table.unify(interner, &environment0, &t_c, &t_b).unwrap();
+    assert_eq!(goals.len(), 2);
     assert_eq!(
-        format!("{:?}", constraints[0]),
+        format!("{:?}", goals[0]),
         "InEnvironment { environment: Env([]), goal: \'?2: \'!1_0 }",
     );
     assert_eq!(
-        format!("{:?}", constraints[1]),
+        format!("{:?}", goals[1]),
         "InEnvironment { environment: Env([]), goal: \'!1_0: \'?2 }",
     );
 }

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -38,12 +38,14 @@ struct Unifier<'t, I: Interner> {
     table: &'t mut InferenceTable<I>,
     environment: &'t Environment<I>,
     goals: Vec<InEnvironment<Goal<I>>>,
+    constraints: Vec<InEnvironment<Constraint<I>>>,
     interner: &'t I,
 }
 
 #[derive(Debug)]
 pub(crate) struct UnificationResult<I: Interner> {
     pub(crate) goals: Vec<InEnvironment<Goal<I>>>,
+    pub(crate) constraints: Vec<InEnvironment<Constraint<I>>>,
 }
 
 impl<'t, I: Interner> Unifier<'t, I> {
@@ -56,6 +58,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
             environment: environment,
             table: table,
             goals: vec![],
+            constraints: vec![],
             interner,
         }
     }
@@ -68,7 +71,10 @@ impl<'t, I: Interner> Unifier<'t, I> {
         T: ?Sized + Zip<I>,
     {
         Zip::zip_with(&mut self, a, b)?;
-        Ok(UnificationResult { goals: self.goals })
+        Ok(UnificationResult {
+            goals: self.goals,
+            constraints: self.constraints,
+        })
     }
 
     fn unify_ty_ty(&mut self, a: &Ty<I>, b: &Ty<I>) -> Fallible<()> {
@@ -331,7 +337,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
 
             (&LifetimeData::Placeholder(_), &LifetimeData::Placeholder(_)) => {
                 if a != b {
-                    Ok(self.push_lifetime_eq_subgoal(a.clone(), b.clone()))
+                    Ok(self.push_lifetime_eq_constraint(a.clone(), b.clone()))
                 } else {
                     Ok(())
                 }
@@ -372,7 +378,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
                 "{:?} in {:?} cannot see {:?}; pushing constraint",
                 var, var_ui, value_ui
             );
-            Ok(self.push_lifetime_eq_subgoal(a.clone(), b.clone()))
+            Ok(self.push_lifetime_eq_constraint(a.clone(), b.clone()))
         }
     }
 
@@ -460,14 +466,15 @@ impl<'t, I: Interner> Unifier<'t, I> {
         Ok(())
     }
 
-    fn push_lifetime_eq_subgoal(&mut self, a: Lifetime<I>, b: Lifetime<I>) {
-        let interner = self.interner;
-        let b_outlives_a = GoalData::AddRegionConstraint(b.clone(), a.clone()).intern(interner);
-        self.goals
-            .push(InEnvironment::new(self.environment, b_outlives_a));
-        let a_outlives_b = GoalData::AddRegionConstraint(a, b).intern(interner);
-        self.goals
-            .push(InEnvironment::new(self.environment, a_outlives_b));
+    fn push_lifetime_eq_constraint(&mut self, a: Lifetime<I>, b: Lifetime<I>) {
+        self.constraints.push(InEnvironment::new(
+            self.environment,
+            Constraint::Outlives(a.clone(), b.clone()),
+        ));
+        self.constraints.push(InEnvironment::new(
+            self.environment,
+            Constraint::Outlives(b, a),
+        ));
     }
 }
 
@@ -569,8 +576,10 @@ where
             // exists<'x> forall<'b> ?T = Foo<'x>, where 'x = 'b
 
             let tick_x = self.unifier.table.new_variable(self.universe_index);
-            self.unifier
-                .push_lifetime_eq_subgoal(tick_x.to_lifetime(interner), ui.to_lifetime(interner));
+            self.unifier.push_lifetime_eq_constraint(
+                tick_x.to_lifetime(interner),
+                ui.to_lifetime(interner),
+            );
             Ok(tick_x.to_lifetime(interner))
         } else {
             // If the `ui` is higher than `self.universe_index`, then we can name

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -11,7 +11,7 @@ use self::solve::{SolveDatabase, SolveIteration};
 use self::stack::{Stack, StackDepth};
 use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
 use chalk_ir::interner::Interner;
-use chalk_ir::{Canonical, ConstrainedSubst, Fallible};
+use chalk_ir::{Canonical, ConstrainedSubst, Constraints, Fallible};
 use rustc_hash::FxHashMap;
 use tracing::{debug, info, instrument};
 
@@ -208,7 +208,7 @@ impl<'me, I: Interner> SolveDatabase<I> for Solver<'me, I> {
                 if self.context.stack.coinductive_cycle_from(depth) {
                     let value = ConstrainedSubst {
                         subst: goal.trivial_substitution(self.program.interner()),
-                        constraints: vec![],
+                        constraints: Constraints::empty(self.program.interner()),
                     };
                     debug!("applying coinductive semantics");
                     return Ok(Solution::Unique(Canonical {

--- a/chalk-solve/src/recursive/combine.rs
+++ b/chalk-solve/src/recursive/combine.rs
@@ -68,7 +68,7 @@ fn calculate_inputs<I: Interner>(
     domain_goal: &DomainGoal<I>,
     solution: &Solution<I>,
 ) -> Vec<GenericArg<I>> {
-    if let Some(subst) = solution.constrained_subst() {
+    if let Some(subst) = solution.constrained_subst(interner) {
         let subst_goal = subst.value.subst.apply(&domain_goal, interner);
         subst_goal.inputs(interner)
     } else {

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -99,10 +99,7 @@ pub(super) trait RecursiveInferenceTable<I: Interner> {
         environment: &Environment<I>,
         a: &T,
         b: &T,
-    ) -> Fallible<(
-        Vec<InEnvironment<Goal<I>>>,
-        Vec<InEnvironment<Constraint<I>>>,
-    )>
+    ) -> Fallible<Vec<InEnvironment<Goal<I>>>>
     where
         T: ?Sized + Zip<I>;
 
@@ -264,13 +261,11 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
     where
         T: ?Sized + Zip<I> + Debug,
     {
-        let (goals, constraints) = self
+        let goals = self
             .infer
             .unify(self.solver.interner(), environment, a, b)?;
         debug!("unify({:?}, {:?}) succeeded", a, b);
         debug!("unify: goals={:?}", goals);
-        debug!("unify: constraints={:?}", constraints);
-        self.constraints.extend(constraints);
         for goal in goals {
             let goal = goal.cast(self.solver.interner());
             self.push_obligation(Obligation::Prove(goal));
@@ -336,6 +331,7 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self, minimums))]
     fn prove(
         &mut self,
         wc: &InEnvironment<Goal<I>>,

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -7,8 +7,8 @@ use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::Visit;
 use chalk_ir::zip::Zip;
 use chalk_ir::{
-    Binders, Canonical, ConstrainedSubst, Constraint, DomainGoal, Environment, EqGoal, Fallible,
-    GenericArg, Goal, GoalData, InEnvironment, LifetimeOutlives, NoSolution,
+    Binders, Canonical, ConstrainedSubst, Constraint, Constraints, DomainGoal, Environment, EqGoal,
+    Fallible, GenericArg, Goal, GoalData, InEnvironment, LifetimeOutlives, NoSolution,
     ProgramClauseImplication, QuantifierKind, Substitution, UCanonical, UniverseMap, WhereClause,
 };
 use rustc_hash::FxHashSet;
@@ -181,7 +181,9 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
             .instantiate_binders_existentially(fulfill.solver.interner(), clause);
 
         debug!(?consequence, ?conditions, ?constraints);
-        fulfill.constraints.extend(constraints);
+        fulfill
+            .constraints
+            .extend(constraints.as_slice(fulfill.interner()).to_owned());
 
         debug!("the subst is {:?}", fulfill.subst);
 
@@ -401,7 +403,8 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
             "fulfill::apply_solution: adding constraints {:?}",
             constraints
         );
-        self.constraints.extend(constraints);
+        self.constraints
+            .extend(constraints.as_slice(self.interner()).to_owned());
 
         // We use the empty environment for unification here because we're
         // really just doing a substitution on unconstrained variables, which is
@@ -452,7 +455,9 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
                         } = self.prove(wc, minimums)?;
 
                         if solution.has_definite() {
-                            if let Some(constrained_subst) = solution.constrained_subst() {
+                            if let Some(constrained_subst) =
+                                solution.constrained_subst(self.interner())
+                            {
                                 self.apply_solution(free_vars, universes, constrained_subst);
                                 progress = true;
                             }
@@ -506,7 +511,7 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
             // No obligations remain, so we have definitively solved our goals,
             // and the current inference state is the unique way to solve them.
 
-            let constraints = self.constraints.into_iter().collect();
+            let constraints = Constraints::from(self.interner(), self.constraints.clone());
             let constrained = self.infer.canonicalize(
                 self.solver.interner(),
                 &ConstrainedSubst {
@@ -522,10 +527,13 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
         // need to determine how to package up what we learned about type
         // inference as an ambiguous solution.
 
-        let interner = self.solver.interner();
-        let canonical_subst = self.infer.canonicalize(interner, &self.subst);
+        let canonical_subst = self.infer.canonicalize(self.solver.interner(), &self.subst);
 
-        if canonical_subst.0.value.is_identity_subst(interner) {
+        if canonical_subst
+            .0
+            .value
+            .is_identity_subst(self.solver.interner())
+        {
             // In this case, we didn't learn *anything* definitively. So now, we
             // go one last time through the positive obligations, this time
             // applying even *tentative* inference suggestions, so that we can
@@ -540,7 +548,9 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
                         universes,
                         solution,
                     } = self.prove(&goal, minimums).unwrap();
-                    if let Some(constrained_subst) = solution.constrained_subst() {
+                    if let Some(constrained_subst) =
+                        solution.constrained_subst(self.solver.interner())
+                    {
                         self.apply_solution(free_vars, universes, constrained_subst);
                         return Ok(Solution::Ambig(Guidance::Suggested(canonical_subst.0)));
                     }

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -176,10 +176,13 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
         let ProgramClauseImplication {
             consequence,
             conditions,
+            constraints,
             priority: _,
         } = fulfill
             .infer
             .instantiate_binders_existentially(fulfill.solver.interner(), clause);
+
+        fulfill.constraints.extend(constraints);
 
         debug!("the subst is {:?}", fulfill.subst);
 

--- a/chalk-solve/src/recursive/lib.rs
+++ b/chalk-solve/src/recursive/lib.rs
@@ -1,6 +1,8 @@
 use super::search_graph::DepthFirstNumber;
 use chalk_ir::interner::Interner;
-use chalk_ir::{Canonical, ConstrainedSubst, Goal, InEnvironment, Substitution, UCanonical};
+use chalk_ir::{
+    Canonical, ConstrainedSubst, Constraints, Goal, InEnvironment, Substitution, UCanonical,
+};
 use std::fmt;
 use tracing::debug;
 
@@ -118,14 +120,14 @@ impl<I: Interner> Solution<I> {
     }
 
     /// Extract a constrained substitution from this solution, even if ambiguous.
-    pub(crate) fn constrained_subst(&self) -> Option<Canonical<ConstrainedSubst<I>>> {
+    pub(crate) fn constrained_subst(&self, interner: &I) -> Option<Canonical<ConstrainedSubst<I>>> {
         match *self {
             Solution::Unique(ref constrained) => Some(constrained.clone()),
             Solution::Ambig(Guidance::Definite(ref canonical))
             | Solution::Ambig(Guidance::Suggested(ref canonical)) => {
                 let value = ConstrainedSubst {
                     subst: canonical.value.clone(),
-                    constraints: vec![],
+                    constraints: Constraints::empty(interner),
                 };
                 Some(Canonical {
                     value,

--- a/chalk-solve/src/recursive/solve.rs
+++ b/chalk-solve/src/recursive/solve.rs
@@ -10,8 +10,8 @@ use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::Visit;
 use chalk_ir::zip::Zip;
 use chalk_ir::{
-    Binders, Canonical, ClausePriority, DomainGoal, Environment, Fallible, Floundered, GenericArg,
-    Goal, GoalData, InEnvironment, NoSolution, ProgramClause, ProgramClauseData,
+    Binders, Canonical, ClausePriority, Constraint, DomainGoal, Environment, Fallible, Floundered,
+    GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClause, ProgramClauseData,
     ProgramClauseImplication, Substitution, UCanonical, UniverseMap,
 };
 use std::fmt::Debug;
@@ -279,12 +279,15 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
         environment: &Environment<I>,
         a: &T,
         b: &T,
-    ) -> Fallible<Vec<InEnvironment<Goal<I>>>>
+    ) -> Fallible<(
+        Vec<InEnvironment<Goal<I>>>,
+        Vec<InEnvironment<Constraint<I>>>,
+    )>
     where
         T: ?Sized + Zip<I>,
     {
         let res = self.infer.unify(interner, environment, a, b)?;
-        Ok(res.goals)
+        Ok((res.goals, res.constraints))
     }
 
     fn instantiate_canonical<T>(&mut self, interner: &I, bound: &Canonical<T>) -> T::Result

--- a/chalk-solve/src/recursive/solve.rs
+++ b/chalk-solve/src/recursive/solve.rs
@@ -10,8 +10,8 @@ use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::Visit;
 use chalk_ir::zip::Zip;
 use chalk_ir::{
-    Binders, Canonical, ClausePriority, Constraint, DomainGoal, Environment, Fallible, Floundered,
-    GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClause, ProgramClauseData,
+    Binders, Canonical, ClausePriority, DomainGoal, Environment, Fallible, Floundered, GenericArg,
+    Goal, GoalData, InEnvironment, NoSolution, ProgramClause, ProgramClauseData,
     ProgramClauseImplication, Substitution, UCanonical, UniverseMap,
 };
 use std::fmt::Debug;
@@ -280,15 +280,12 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
         environment: &Environment<I>,
         a: &T,
         b: &T,
-    ) -> Fallible<(
-        Vec<InEnvironment<Goal<I>>>,
-        Vec<InEnvironment<Constraint<I>>>,
-    )>
+    ) -> Fallible<Vec<InEnvironment<Goal<I>>>>
     where
         T: ?Sized + Zip<I>,
     {
         let res = self.infer.unify(interner, environment, a, b)?;
-        Ok((res.goals, res.constraints))
+        Ok(res.goals)
     }
 
     fn instantiate_canonical<T>(&mut self, interner: &I, bound: &Canonical<T>) -> T::Result

--- a/chalk-solve/src/recursive/solve.rs
+++ b/chalk-solve/src/recursive/solve.rs
@@ -35,6 +35,7 @@ pub(super) trait SolveIteration<I: Interner>: SolveDatabase<I> {
     /// Executes one iteration of the recursive solver, computing the current
     /// solution to the given canonical goal. This is used as part of a loop in
     /// the case of cyclic goals.
+    #[instrument(level = "debug", skip(self))]
     fn solve_iteration(
         &mut self,
         canonical_goal: &UCanonicalGoal<I>,

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -1,4 +1,5 @@
 use crate::RustIrDatabase;
+use chalk_derive::HasInterner;
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
 use std::fmt;
@@ -20,7 +21,7 @@ mod slg;
 pub(crate) mod truncate;
 
 /// A (possible) solution for a proposed goal.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, HasInterner)]
 pub enum Solution<I: Interner> {
     /// The goal indeed holds, and there is a unique value for all existential
     /// variables. In this case, we also record a set of lifetime constraints

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -177,7 +177,7 @@ impl<'me, I: Interner> context::ContextOps<I, SlgContext<I>> for SlgContextOps<'
     ) -> (
         TruncatingInferenceTable<I>,
         Substitution<I>,
-        Vec<InEnvironment<Constraint<I>>>,
+        Constraints<I>,
         Vec<InEnvironment<Goal<I>>>,
     ) {
         let (
@@ -207,7 +207,7 @@ impl<'me, I: Interner> context::ContextOps<I, SlgContext<I>> for SlgContextOps<'
                 self.program.interner(),
                 &ConstrainedSubst {
                     subst,
-                    constraints: vec![],
+                    constraints: Constraints::empty(self.program.interner()),
                 },
             )
             .quantified
@@ -299,7 +299,7 @@ impl<I: Interner> context::UnificationOps<I, SlgContext<I>> for TruncatingInfere
         &mut self,
         interner: &I,
         subst: Substitution<I>,
-        constraints: Vec<InEnvironment<Constraint<I>>>,
+        constraints: Constraints<I>,
     ) -> Canonical<ConstrainedSubst<I>> {
         self.infer
             .canonicalize(interner, &ConstrainedSubst { subst, constraints })
@@ -310,7 +310,7 @@ impl<I: Interner> context::UnificationOps<I, SlgContext<I>> for TruncatingInfere
         &mut self,
         interner: &I,
         subst: Substitution<I>,
-        constraints: Vec<InEnvironment<Constraint<I>>>,
+        constraints: Constraints<I>,
         delayed_subgoals: Vec<InEnvironment<Goal<I>>>,
     ) -> Canonical<AnswerSubst<I>> {
         self.infer

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -359,7 +359,6 @@ fn into_ex_clause<I: Interner>(
             .casted(interner)
             .map(Literal::Positive),
     );
-    ex_clause.constraints.extend(result.constraints);
 }
 
 trait SubstitutionExt<I: Interner> {

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -359,6 +359,7 @@ fn into_ex_clause<I: Interner>(
             .casted(interner)
             .map(Literal::Positive),
     );
+    ex_clause.constraints.extend(result.constraints);
 }
 
 trait SubstitutionExt<I: Interner> {

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -95,7 +95,7 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
         let mut ex_clause = ExClause {
             subst: subst.clone(),
             ambiguous: false,
-            constraints: Constraints::empty(interner),
+            constraints: vec![],
             subgoals: vec![],
             delayed_subgoals: vec![],
             answer_time: TimeStamp::default(),
@@ -105,14 +105,9 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
         // Add the subgoals/region-constraints that unification gave us.
         slg::into_ex_clause(interner, unification_result, &mut ex_clause);
 
-        ex_clause.constraints = Constraints::from(
-            interner,
-            ex_clause
-                .constraints
-                .as_slice(interner)
-                .into_iter()
-                .chain(constraints.as_slice(interner)),
-        );
+        ex_clause
+            .constraints
+            .extend(constraints.as_slice(interner).to_owned());
 
         // Add the `conditions` from the program clause into the result too.
         ex_clause
@@ -241,14 +236,9 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
             &answer_table_goal.value,
             selected_goal,
         )?;
-        ex_clause.constraints = Constraints::from(
-            interner,
-            ex_clause
-                .constraints
-                .as_slice(interner)
-                .into_iter()
-                .chain(answer_constraints.as_slice(interner)),
-        );
+        ex_clause
+            .constraints
+            .extend(answer_constraints.as_slice(interner).to_vec());
         // at that point we should only have goals that stemmed
         // from non trivial self cycles
         ex_clause.delayed_subgoals.extend(delayed_subgoals);

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -95,7 +95,7 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
         let mut ex_clause = ExClause {
             subst: subst.clone(),
             ambiguous: false,
-            constraints: vec![],
+            constraints: Constraints::empty(interner),
             subgoals: vec![],
             delayed_subgoals: vec![],
             answer_time: TimeStamp::default(),
@@ -105,7 +105,14 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
         // Add the subgoals/region-constraints that unification gave us.
         slg::into_ex_clause(interner, unification_result, &mut ex_clause);
 
-        ex_clause.constraints.extend(constraints);
+        ex_clause.constraints = Constraints::from(
+            interner,
+            ex_clause
+                .constraints
+                .as_slice(interner)
+                .into_iter()
+                .chain(constraints.as_slice(interner)),
+        );
 
         // Add the `conditions` from the program clause into the result too.
         ex_clause
@@ -234,7 +241,14 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
             &answer_table_goal.value,
             selected_goal,
         )?;
-        ex_clause.constraints.extend(answer_constraints);
+        ex_clause.constraints = Constraints::from(
+            interner,
+            ex_clause
+                .constraints
+                .as_slice(interner)
+                .into_iter()
+                .chain(answer_constraints.as_slice(interner)),
+        );
         // at that point we should only have goals that stemmed
         // from non trivial self cycles
         ex_clause.delayed_subgoals.extend(delayed_subgoals);

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -76,6 +76,7 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
         let ProgramClauseImplication {
             consequence,
             conditions,
+            constraints,
             priority: _,
         } = {
             let ProgramClauseData(implication) = clause.data(interner);
@@ -83,7 +84,7 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
             self.infer
                 .instantiate_binders_existentially(interner, implication)
         };
-        debug!(?consequence, ?conditions);
+        debug!(?consequence, ?conditions, ?constraints);
 
         // Unify the selected literal Li with C'.
         let unification_result = self
@@ -103,6 +104,8 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
 
         // Add the subgoals/region-constraints that unification gave us.
         slg::into_ex_clause(interner, unification_result, &mut ex_clause);
+
+        ex_clause.constraints.extend(constraints);
 
         // Add the `conditions` from the program clause into the result too.
         ex_clause

--- a/tests/logging_db/util.rs
+++ b/tests/logging_db/util.rs
@@ -58,7 +58,7 @@ pub fn logging_db_output_sufficient(
                 match expected {
                     TestGoal::Aggregated(expected) => {
                         let result = solver.solve(&wrapped, &peeled_goal);
-                        assert_result(result, expected);
+                        assert_result(result, expected, db.interner());
                     }
                     _ => panic!("only aggregated test goals supported for logger goals"),
                 }
@@ -99,7 +99,7 @@ pub fn logging_db_output_sufficient(
             match expected {
                 TestGoal::Aggregated(expected) => {
                     let result = solver.solve(&db, &peeled_goal);
-                    assert_result(result, expected);
+                    assert_result(result, expected, db.interner());
                 }
                 _ => panic!("only aggregated test goals supported for logger goals"),
             }

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -259,8 +259,8 @@ fn basic_region_constraint_from_positive_impl() {
             forall<'a, 'b, T> { Ref<'a, 'b, T>: Foo }
         } yields_all[SolverChoice::slg(3, None)] {
             "substitution [], lifetime constraints [\
-            InEnvironment { environment: Env([]), goal: '!1_1: '!1_0 }, \
-            InEnvironment { environment: Env([]), goal: '!1_0: '!1_1 }\
+            InEnvironment { environment: Env([]), goal: '!1_0: '!1_1 }, \
+            InEnvironment { environment: Env([]), goal: '!1_1: '!1_0 } \
             ]"
         }
     }

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -799,10 +799,10 @@ fn normalize_under_binder_multi() {
         } yields_all {
             "substitution [?0 := I32], lifetime constraints []",
             "for<?U0,?U0> { substitution [?0 := (Deref::Item)<Ref<'^0.0, I32>, '^0.1>], lifetime constraints [\
-            InEnvironment { environment: Env([]), goal: '^0.1: '!1_0 }, \
-            InEnvironment { environment: Env([]), goal: '!1_0: '^0.1 }, \
             InEnvironment { environment: Env([]), goal: '^0.0: '!1_0 }, \
-            InEnvironment { environment: Env([]), goal: '!1_0: '^0.0 }] }"
+            InEnvironment { environment: Env([]), goal: '!1_0: '^0.0 }, \
+            InEnvironment { environment: Env([]), goal: '^0.1: '!1_0 }, \
+            InEnvironment { environment: Env([]), goal: '!1_0: '^0.1 }] }"
         }
 
         goal {

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -799,10 +799,10 @@ fn normalize_under_binder_multi() {
         } yields_all {
             "substitution [?0 := I32], lifetime constraints []",
             "for<?U0,?U0> { substitution [?0 := (Deref::Item)<Ref<'^0.0, I32>, '^0.1>], lifetime constraints [\
-            InEnvironment { environment: Env([]), goal: '^0.0: '!1_0 }, \
-            InEnvironment { environment: Env([]), goal: '!1_0: '^0.0 }, \
+            InEnvironment { environment: Env([]), goal: '!1_0: '^0.1 }, \
             InEnvironment { environment: Env([]), goal: '^0.1: '!1_0 }, \
-            InEnvironment { environment: Env([]), goal: '!1_0: '^0.1 }] }"
+            InEnvironment { environment: Env([]), goal: '!1_0: '^0.0 }, \
+            InEnvironment { environment: Env([]), goal: '^0.0: '!1_0 }] }"
         }
 
         goal {


### PR DESCRIPTION
Closes #508

This PR attempts the refactoring proposed in #508, which is to incorporate region constraints into program clauses.

I haven't been able to find a good way to simplify unification with this approach, which is a bit of a downside compared to the current approach.