### PR TITLE
Use tracing-tree for logging / clean up debug output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,8 +180,6 @@ dependencies = [
  "salsa 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-subscriber 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,11 +47,11 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -242,6 +250,7 @@ dependencies = [
  "rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-subscriber 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-tree 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -428,6 +437,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,7 +468,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii-canvas 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -651,6 +668,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,14 +783,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "redox_termios"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,7 +859,7 @@ dependencies = [
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8parse 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1040,13 +1058,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "termion"
-version = "1.5.1"
+name = "termcolor"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1133,6 +1149,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tree"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quanta 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,7 +1174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1190,6 +1220,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,10 +1235,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum ascii-canvas 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8eb72df928aafb99fe5d37b383f2fe25bd2a765e3e5f7c365916b6f2463a29"
-"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
@@ -1239,6 +1278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
@@ -1266,6 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+"checksum quanta 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f7a1905379198075914bc93d32a5465c40474f90a078bb13439cb00c547bcc"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3906503e80ac6cbcacb2c2973fa8e473f24d7e2747c8c92bb230c2441cad96b5"
@@ -1278,7 +1319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
-"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
 "checksum regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 "checksum regex-automata 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
@@ -1311,7 +1351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 "checksum tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
@@ -1320,9 +1360,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 "checksum tracing-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
 "checksum tracing-subscriber 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1d53c40489aa69c9aed21ff483f26886ca8403df33bdc2d2f87c60c1617826d2"
+"checksum tracing-tree 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "de2e9d8af3b86f89e4cc934b20132ea3577bdf06b745808e2e8666d2418ee4c4"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
-"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
@@ -1330,4 +1371,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,6 @@ rustyline = "6.0.0"
 salsa = "0.10.0"
 serde = "1.0"
 serde_derive = "1.0"
-tracing-subscriber = "0.2"
-tracing = "0.1"
 
 chalk-derive = { version = "0.16.0-dev.0", path = "chalk-derive" }
 chalk-engine = { version = "0.16.0-dev.0", path = "chalk-engine" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ salsa = "0.10.0"
 serde = "1.0"
 serde_derive = "1.0"
 tracing-subscriber = "0.2"
+tracing = "0.1"
 
 chalk-derive = { version = "0.16.0-dev.0", path = "chalk-derive" }
 chalk-engine = { version = "0.16.0-dev.0", path = "chalk-engine" }
@@ -36,4 +37,3 @@ chalk-integration = { version = "0.16.0-dev.0", path = "chalk-integration" }
 diff = "0.1"
 pretty_assertions = "0.6.1"
 regex = "1"
-tracing = "0.1"

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -6,7 +6,6 @@ use crate::{TableIndex, TimeStamp};
 
 use chalk_ir::interner::Interner;
 use chalk_ir::{Goal, InEnvironment, Substitution, UCanonical};
-use tracing::debug;
 
 pub struct Forest<I: Interner, C: Context<I>> {
     pub(crate) tables: Tables<I>,
@@ -76,7 +75,7 @@ impl<'me, I: Interner, C: Context<I>, CO: ContextOps<I, C>> AnswerStream<I>
                 .root_answer(self.context, self.table, self.answer)
             {
                 Ok(answer) => {
-                    debug!("Answer: {:?}", &answer);
+                    // debug!("Answer: {:?}", &answer);
                     return AnswerResult::Answer(answer);
                 }
 

--- a/chalk-engine/src/forest.rs
+++ b/chalk-engine/src/forest.rs
@@ -6,6 +6,7 @@ use crate::{TableIndex, TimeStamp};
 
 use chalk_ir::interner::Interner;
 use chalk_ir::{Goal, InEnvironment, Substitution, UCanonical};
+use tracing::debug;
 
 pub struct Forest<I: Interner, C: Context<I>> {
     pub(crate) tables: Tables<I>,
@@ -75,7 +76,7 @@ impl<'me, I: Interner, C: Context<I>, CO: ContextOps<I, C>> AnswerStream<I>
                 .root_answer(self.context, self.table, self.answer)
             {
                 Ok(answer) => {
-                    // debug!("Answer: {:?}", &answer);
+                    debug!(answer = ?(&answer));
                     return AnswerResult::Answer(answer);
                 }
 

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -196,8 +196,7 @@ impl<I: Interner, C: Context<I>> Forest<I, C> {
             }
         };
 
-        debug!("ucanonical_subgoal={:?}", ucanonical_subgoal);
-        debug!("universe_map={:?}", universe_map);
+        debug!(?ucanonical_subgoal, ?universe_map);
 
         let table = self.get_or_create_table_for_ucanonical_goal(context, ucanonical_subgoal);
 
@@ -218,14 +217,14 @@ impl<I: Interner, C: Context<I>> Forest<I, C> {
         goal: UCanonical<InEnvironment<Goal<I>>>,
     ) -> TableIndex {
         if let Some(table) = self.tables.index_of(&goal) {
-            debug!("found existing table {:?}", table);
+            debug!(?table, "found existing table");
             return table;
         }
 
         info!(
-            "creating new table {:?} and goal {:#?}",
-            self.tables.next_index(),
-            goal
+            table = ?self.tables.next_index(),
+            "creating new table with goal = {:#?}",
+            goal,
         );
         let table = Self::build_table(context, self.tables.next_index(), goal);
         self.tables.insert(table)
@@ -279,6 +278,7 @@ impl<I: Interner, C: Context<I>> Forest<I, C> {
                     }
                     Err(Floundered) => {
                         debug!(
+                            table = ?table_idx,
                             "Marking table {:?} as floundered! (failed to create program clauses)",
                             table_idx
                         );
@@ -300,8 +300,8 @@ impl<I: Interner, C: Context<I>> Forest<I, C> {
                     Self::simplify_goal(context, &mut infer, subst, environment, goal)
                 {
                     info!(
-                        "pushing initial strand with ex-clause: {:#?}",
-                        infer.debug_ex_clause(context.interner(), &ex_clause),
+                        ex_clause = ?infer.debug_ex_clause(context.interner(), &ex_clause),
+                        "pushing initial strand"
                     );
                     let strand = Strand {
                         infer,
@@ -503,7 +503,7 @@ impl<'forest, I: Interner, C: Context<I> + 'forest, CO: ContextOps<I, C> + 'fore
             });
             match next_strand {
                 Some(mut strand) => {
-                    debug!("next strand: {:#?}", strand);
+                    debug!("starting next strand = {:#?}", strand);
 
                     strand.last_pursued_time = clock;
                     match self.select_subgoal(&mut strand) {
@@ -715,7 +715,7 @@ impl<'forest, I: Interner, C: Context<I> + 'forest, CO: ContextOps<I, C> + 'fore
                 // We want to disproval the subgoal, but we
                 // have an unconditional answer for the subgoal,
                 // therefore we have failed to disprove it.
-                debug!("Marking Strand as ambiguous because answer to (negative) subgoal was ambiguous");
+                debug!(?strand, "Marking Strand as ambiguous because answer to (negative) subgoal was ambiguous");
                 strand.ex_clause.ambiguous = true;
 
                 // Strand is ambigious.
@@ -879,7 +879,9 @@ impl<'forest, I: Interner, C: Context<I> + 'forest, CO: ContextOps<I, C> + 'fore
         } = *strand.selected_subgoal.as_ref().unwrap();
 
         debug!(
-            "table selection {:?} with goal: {:#?}",
+            ?subgoal_table,
+            goal = ?self.forest.tables[subgoal_table].table_goal,
+            "table selection {:?} with goal: {:?}",
             subgoal_table, self.forest.tables[subgoal_table].table_goal
         );
 
@@ -894,12 +896,12 @@ impl<'forest, I: Interner, C: Context<I> + 'forest, CO: ContextOps<I, C> + 'fore
             // We need to check if we can merge it into the current `Strand`.
             match self.merge_answer_into_strand(&mut strand) {
                 Err(e) => {
-                    debug!("could not merge into current strand");
+                    debug!(?strand, "could not merge into current strand");
                     drop(strand);
                     return Err(e);
                 }
                 Ok(_) => {
-                    debug!("merged answer into current strand");
+                    debug!(?strand, "merged answer into current strand");
                     self.stack.top().active_strand = Some(strand);
                     return Ok(());
                 }
@@ -1410,10 +1412,7 @@ impl<'forest, I: Interner, C: Context<I> + 'forest, CO: ContextOps<I, C> + 'fore
             constraints,
             filtered_delayed_subgoals,
         );
-        debug!(
-            "answer: table={:?}, subst={:?}, floundered={:?}",
-            table, subst, floundered
-        );
+        debug!(?table, ?subst, ?floundered, "found answer");
 
         let answer = Answer { subst, ambiguous };
 
@@ -1528,7 +1527,7 @@ impl<'forest, I: Interner, C: Context<I> + 'forest, CO: ContextOps<I, C> + 'fore
             floundered_literal,
             floundered_time,
         });
-        debug!("flounder_subgoal: ex_clause={:#?}", ex_clause);
+        debug!(?ex_clause);
     }
 
     /// True if all the tables on the stack starting from `depth` and

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -157,8 +157,8 @@ impl<I: Interner> Table<I> {
         };
 
         info!(
-            "new answer to table with goal {:?}: answer={:?}",
-            self.table_goal, answer,
+            goal = ?self.table_goal, ?answer,
+            "new answer to table",
         );
         if !added {
             return None;

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1795,7 +1795,7 @@ impl LowerImpl for Impl {
         let polarity = self.polarity.lower();
         let binders = empty_env.in_binders(self.all_parameters(), |env| {
             let trait_ref = self.trait_ref.lower(env)?;
-            debug!("trait_ref = {:?}", trait_ref);
+            debug!(?trait_ref);
 
             if !polarity.is_positive() && !self.assoc_ty_values.is_empty() {
                 Err(RustIrError::NegativeImplAssociatedValues(
@@ -1804,7 +1804,7 @@ impl LowerImpl for Impl {
             }
 
             let where_clauses = self.lower_where_clauses(&env)?;
-            debug!("where_clauses = {:?}", trait_ref);
+            debug!(where_clauses = ?trait_ref);
             Ok(rust_ir::ImplDatumBound {
                 trait_ref,
                 where_clauses,
@@ -1820,7 +1820,7 @@ impl LowerImpl for Impl {
             .map(|atv| associated_ty_value_ids[&(impl_id, atv.name.str.clone())])
             .collect();
 
-        debug!("associated_ty_value_ids = {:?}", associated_ty_value_ids);
+        debug!(?associated_ty_value_ids);
 
         Ok(rust_ir::ImplDatum {
             polarity,
@@ -1917,7 +1917,7 @@ impl LowerTrait for TraitDefn {
             well_known: self.well_known.map(|t| t.lower()),
         };
 
-        debug!("trait_datum={:?}", trait_datum);
+        debug!(?trait_datum);
 
         Ok(trait_datum)
     }

--- a/chalk-solve/Cargo.toml
+++ b/chalk-solve/Cargo.toml
@@ -15,6 +15,7 @@ itertools = "0.9.0"
 petgraph = "0.5.0"
 tracing = "0.1"
 tracing-subscriber = "0.2"
+tracing-tree = "0.1.1"
 rustc-hash = { version = "1.0.0" }
 
 chalk-derive = { version = "0.16.0-dev.0", path = "../chalk-derive" }

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -190,7 +190,7 @@ pub(crate) fn program_clauses_for_goal<'db, I: Interner>(
         .filter(|c| c.could_match(interner, goal))
         .collect();
 
-    debug!("vec = {:#?}", clauses);
+    debug!(?clauses);
 
     Ok(clauses)
 }
@@ -477,11 +477,11 @@ fn push_program_clauses_for_associated_type_values_in_impls_of<I: Interner>(
             continue;
         }
 
-        debug!("impl_id = {:?}", impl_id);
+        debug!(?impl_id);
 
         for &atv_id in &impl_datum.associated_ty_value_ids {
             let atv = builder.db.associated_ty_value(atv_id);
-            debug!("atv_id = {:?} atv = {:#?}", atv_id, atv);
+            debug!(?atv_id, ?atv);
             atv.to_program_clauses(builder);
         }
     }

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -139,7 +139,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
         );
 
         let value = binders.substitute(self.interner(), &self.parameters[old_len..]);
-        debug!("push_binders: value={:?}", value);
+        debug!(?value);
         let res = op(self, value);
 
         self.binders.truncate(old_len);

--- a/chalk-solve/src/coherence/orphan.rs
+++ b/chalk-solve/src/coherence/orphan.rs
@@ -21,7 +21,7 @@ pub fn perform_orphan_check<I: Interner>(
     impl_id: ImplId<I>,
 ) -> Result<(), CoherenceError<I>> {
     let impl_datum = db.impl_datum(impl_id);
-    debug!("impl_datum={:#?}", impl_datum);
+    debug!(?impl_datum);
 
     let impl_allowed: Goal<I> = impl_datum
         .binders

--- a/chalk-solve/src/infer.rs
+++ b/chalk-solve/src/infer.rs
@@ -76,7 +76,7 @@ impl<I: Interner> InferenceTable<I> {
     pub(crate) fn new_universe(&mut self) -> UniverseIndex {
         let u = self.max_universe.next();
         self.max_universe = u;
-        debug!("new_universe: {:?}", u);
+        debug!("created new universe: {:?}", u);
         u
     }
 
@@ -86,7 +86,7 @@ impl<I: Interner> InferenceTable<I> {
     pub(crate) fn new_variable(&mut self, ui: UniverseIndex) -> EnaVariable<I> {
         let var = self.unify.new_key(InferenceValue::Unbound(ui));
         self.vars.push(var);
-        debug!("new_variable: var={:?} ui={:?}", var, ui);
+        debug!(?var, ?ui, "created new variable");
         var
     }
 

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -1,3 +1,4 @@
+use crate::debug_span;
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::fold::{Fold, Folder};
 use chalk_ir::interner::{HasInterner, Interner};
@@ -31,7 +32,7 @@ impl<I: Interner> InferenceTable<I> {
         T: Fold<I>,
         T::Result: HasInterner<Interner = I>,
     {
-        debug!("canonicalize({:#?})", value);
+        debug_span!("canonicalize", "{:#?}", value);
         let mut q = Canonicalizer {
             table: self,
             free_vars: Vec::new(),
@@ -174,7 +175,7 @@ where
                     ParameterEnaVariable::new(VariableKind::Ty(kind), self.table.unify.find(var));
 
                 let bound_var = BoundVar::new(DebruijnIndex::INNERMOST, self.add(free_var));
-                debug!("not yet unified: position={:?}", bound_var);
+                debug!(position=?bound_var, "not yet unified");
                 Ok(TyData::BoundVar(bound_var.shifted_in_from(outer_binder)).intern(interner))
             }
         }
@@ -198,7 +199,7 @@ where
                 let free_var =
                     ParameterEnaVariable::new(VariableKind::Lifetime, self.table.unify.find(var));
                 let bound_var = BoundVar::new(DebruijnIndex::INNERMOST, self.add(free_var));
-                debug!("not yet unified: position={:?}", bound_var);
+                debug!(position=?bound_var, "not yet unified");
                 Ok(
                     LifetimeData::BoundVar(bound_var.shifted_in_from(outer_binder))
                         .intern(interner),
@@ -228,7 +229,7 @@ where
                     self.table.unify.find(var),
                 );
                 let bound_var = BoundVar::new(DebruijnIndex::INNERMOST, self.add(free_var));
-                debug!("not yet unified: position={:?}", bound_var);
+                debug!(position = ?bound_var, "not yet unified");
                 Ok(bound_var
                     .shifted_in_from(outer_binder)
                     .to_const(interner, ty.clone()))

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,8 +1,8 @@
+use crate::debug_span;
 use chalk_ir::fold::{Fold, Folder};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::{Visit, Visitor};
 use chalk_ir::*;
-use tracing::debug;
 
 use super::InferenceTable;
 
@@ -16,7 +16,7 @@ impl<I: Interner> InferenceTable<I> {
         T: HasInterner<Interner = I> + Fold<I> + Visit<I>,
         T::Result: HasInterner<Interner = I>,
     {
-        debug!("u_canonicalize({:#?})", value0);
+        debug_span!("u_canonicalize", "{:#?}", value0);
 
         // First, find all the universes that appear in `value`.
         let mut universes = UniverseMap::new();
@@ -169,8 +169,7 @@ impl UniverseMapExt for UniverseMap {
         T::Result: HasInterner<Interner = I>,
         I: Interner,
     {
-        debug!("map_from_canonical(value={:?})", canonical_value);
-        debug!("map_from_canonical: universes = {:?}", self.universes);
+        debug_span!("map_from_canonical", ?canonical_value, universes = ?self.universes);
 
         let binders = canonical_value
             .binders

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -80,7 +80,6 @@ impl<'t, I: Interner> Unifier<'t, I> {
         let b = n_b.as_ref().unwrap_or(b);
 
         debug_span!("unify_ty_ty", ?a, ?b);
-        // let _s = span.enter();
 
         match (a.data(interner), b.data(interner)) {
             // Unifying two inference variables: unify them in the underlying
@@ -185,8 +184,8 @@ impl<'t, I: Interner> Unifier<'t, I> {
     }
 
     /// Unify two inference variables
+    #[instrument(level = "debug", skip(self))]
     fn unify_var_var(&mut self, a: InferenceVar, b: InferenceVar) -> Fallible<()> {
-        debug!("unify_var_var({:?}, {:?})", a, b);
         let var1 = EnaVariable::from(a);
         let var2 = EnaVariable::from(b);
         Ok(self
@@ -200,16 +199,13 @@ impl<'t, I: Interner> Unifier<'t, I> {
     /// (type kind is not `General`). For example, unify a `TyKind::General`
     /// inference variable with a `TyKind::Integer` variable, resulting in the
     /// general inference variable narrowing to an integer variable.
+
+    #[instrument(level = "debug", skip(self))]
     fn unify_general_var_specific_ty(
         &mut self,
         general_var: InferenceVar,
         specific_ty: Ty<I>,
     ) -> Fallible<()> {
-        debug!(
-            "unify_general_var_specific_var({:?}, {:?})",
-            general_var, specific_ty
-        );
-
         self.table
             .unify
             .unify_var_value(
@@ -221,6 +217,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn unify_binders<'a, T, R>(
         &mut self,
         a: impl IntoBindersAndValue<'a, I, Value = T> + Copy + Debug,
@@ -238,7 +235,6 @@ impl<'t, I: Interner> Unifier<'t, I> {
         // for<'a...> exists<'b...> T == U &&
         // for<'b...> exists<'a...> T == U
 
-        debug!("unify_binders({:?}, {:?})", a, b);
         let interner = self.interner;
 
         {
@@ -301,7 +297,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
             .unify
             .unify_var_value(var, InferenceValue::from_ty(interner, ty1.clone()))
             .unwrap();
-        debug!("unify_var_ty: var {:?} set to {:?}", var, ty1);
+        debug!("var {:?} set to {:?}", var, ty1);
 
         Ok(())
     }
@@ -320,10 +316,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
             (&LifetimeData::InferenceVar(var_a), &LifetimeData::InferenceVar(var_b)) => {
                 let var_a = EnaVariable::from(var_a);
                 let var_b = EnaVariable::from(var_b);
-                debug!(
-                    "unify_lifetime_lifetime: var_a={:?} var_b={:?}",
-                    var_a, var_b
-                );
+                debug!(?var_a, ?var_b);
                 self.table.unify.unify_var_var(var_a, var_b).unwrap();
                 Ok(())
             }
@@ -365,10 +358,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
         let var = EnaVariable::from(var);
         let var_ui = self.table.universe_of_unbound_var(var);
         if var_ui.can_see(value_ui) {
-            debug!(
-                "unify_lifetime_var: {:?} in {:?} can see {:?}; unifying",
-                var, var_ui, value_ui
-            );
+            debug!("{:?} in {:?} can see {:?}; unifying", var, var_ui, value_ui);
             self.table
                 .unify
                 .unify_var_value(
@@ -379,7 +369,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
             Ok(())
         } else {
             debug!(
-                "unify_lifetime_var: {:?} in {:?} cannot see {:?}; pushing constraint",
+                "{:?} in {:?} cannot see {:?}; pushing constraint",
                 var, var_ui, value_ui
             );
             Ok(self.push_lifetime_eq_subgoal(a.clone(), b.clone()))
@@ -411,7 +401,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
             // Unifying two inference variables: unify them in the underlying
             // ena table.
             (&ConstValue::InferenceVar(var1), &ConstValue::InferenceVar(var2)) => {
-                // debug!("unify_ty_ty: unify_var_var({:?}, {:?})", var1, var2);
+                debug!(?var1, ?var2, "unify_ty_ty");
                 let var1 = EnaVariable::from(var1);
                 let var2 = EnaVariable::from(var2);
                 Ok(self
@@ -424,14 +414,13 @@ impl<'t, I: Interner> Unifier<'t, I> {
             // Unifying an inference variables with a non-inference variable.
             (&ConstValue::InferenceVar(var), &ConstValue::Concrete(_))
             | (&ConstValue::InferenceVar(var), &ConstValue::Placeholder(_)) => {
-                debug!("unify_var_ty(var={:?}, ty={:?})", var, b);
+                debug!(?var, ty=?b, "unify_var_ty");
                 self.unify_var_const(var, b)
             }
 
             (&ConstValue::Concrete(_), &ConstValue::InferenceVar(var))
             | (&ConstValue::Placeholder(_), &ConstValue::InferenceVar(var)) => {
-                debug!("unify_var_ty(var={:?}, ty={:?})", var, a);
-
+                debug!(?var, ty=?a, "unify_var_ty");
                 self.unify_var_const(var, a)
             }
 
@@ -457,9 +446,8 @@ impl<'t, I: Interner> Unifier<'t, I> {
         }
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn unify_var_const(&mut self, var: InferenceVar, c: &Const<I>) -> Fallible<()> {
-        debug!("unify_var_const(var={:?}, c={:?})", var, c);
-
         let interner = self.interner;
         let var = EnaVariable::from(var);
 

--- a/chalk-solve/src/logging.rs
+++ b/chalk-solve/src/logging.rs
@@ -7,6 +7,6 @@ pub fn with_tracing_logs<T>(action: impl FnOnce() -> T) -> T {
     let filter = EnvFilter::from_env("CHALK_DEBUG");
     let subscriber = Registry::default()
         .with(filter)
-        .with(HierarchicalLayer::new(4));
+        .with(HierarchicalLayer::new(2));
     tracing::subscriber::with_default(subscriber, action)
 }

--- a/chalk-solve/src/logging.rs
+++ b/chalk-solve/src/logging.rs
@@ -1,13 +1,12 @@
-use tracing_subscriber::{EnvFilter, FmtSubscriber};
+use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+use tracing_tree::HierarchicalLayer;
 
 /// Run an action with a tracing log subscriber. The logging level is loaded
 /// from `CHALK_DEBUG`.
 pub fn with_tracing_logs<T>(action: impl FnOnce() -> T) -> T {
     let filter = EnvFilter::from_env("CHALK_DEBUG");
-    let subscriber = FmtSubscriber::builder()
-        .with_env_filter(filter)
-        .with_ansi(false)
-        .without_time()
-        .finish();
+    let subscriber = Registry::default()
+        .with(filter)
+        .with(HierarchicalLayer::new(4));
     tracing::subscriber::with_default(subscriber, action)
 }

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -13,7 +13,7 @@ use chalk_ir::{
 };
 use rustc_hash::FxHashSet;
 use std::fmt::Debug;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 enum Outcome {
     Complete,
@@ -270,12 +270,12 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
 
     /// Create obligations for the given goal in the given environment. This may
     /// ultimately create any number of obligations.
+    #[instrument(level = "debug", skip(self))]
     pub(super) fn push_goal(
         &mut self,
         environment: &Environment<I>,
         goal: Goal<I>,
     ) -> Fallible<()> {
-        debug!("push_goal({:?}, {:?})", goal, environment);
         let interner = self.interner();
         match goal.data(interner) {
             GoalData::Quantified(QuantifierKind::ForAll, subgoal) => {

--- a/chalk-solve/src/recursive/solve.rs
+++ b/chalk-solve/src/recursive/solve.rs
@@ -81,7 +81,7 @@ pub(super) trait SolveIteration<I: Interner>: SolveDatabase<I> {
                         }
                     }
                 };
-                debug!("prog_solution={:?}", prog_solution);
+                debug!(?prog_solution);
 
                 (prog_solution, prog_prio)
             }
@@ -148,7 +148,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
             let res = self.solve_via_implication(canonical_goal, implication, minimums);
 
             if let (Ok(solution), priority) = res {
-                debug!("ok: solution={:?} prio={:?}", solution, priority);
+                debug!(?solution, ?priority, "Ok");
                 cur_solution = Some(match cur_solution {
                     None => (solution, priority),
                     Some((cur, cur_priority)) => combine::with_priorities(
@@ -161,7 +161,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
                     ),
                 });
             } else {
-                debug!("error");
+                debug!("Error");
             }
         }
         cur_solution.map_or((Err(NoSolution), ClausePriority::High), |(s, p)| (Ok(s), p))

--- a/chalk-solve/src/solve/slg/resolvent.rs
+++ b/chalk-solve/src/solve/slg/resolvent.rs
@@ -83,8 +83,7 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
             self.infer
                 .instantiate_binders_existentially(interner, implication)
         };
-        debug!("consequence = {:?}", consequence);
-        debug!("conditions = {:?}", conditions);
+        debug!(?consequence, ?conditions);
 
         // Unify the selected literal Li with C'.
         let unification_result = self
@@ -205,10 +204,7 @@ impl<I: Interner> context::ResolventOps<I, SlgContext<I>> for TruncatingInferenc
         answer_table_goal: &Canonical<InEnvironment<Goal<I>>>,
         canonical_answer_subst: &Canonical<AnswerSubst<I>>,
     ) -> Fallible<()> {
-        debug!(
-            "selected_goal={:?}",
-            self.infer.normalize_deep(interner, selected_goal)
-        );
+        debug!(selected_goal = ?self.infer.normalize_deep(interner, selected_goal));
 
         // C' is now `answer`. No variables in common with G.
         let AnswerSubst {

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -135,7 +135,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
             self.split_associated_ty_value_parameters(&parameters, associated_ty_value);
         let trait_ref = {
             let opaque_ty_ref = impl_datum.binders.map_ref(|b| &b.trait_ref);
-            debug!("opaque_ty_ref: {:?}", opaque_ty_ref);
+            debug!(?opaque_ty_ref);
             opaque_ty_ref.substitute(interner, impl_parameters)
         };
 
@@ -155,9 +155,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
             substitution: projection_substitution,
         };
 
-        debug!("impl_parameters: {:?}", impl_parameters);
-        debug!("trait_ref: {:?}", trait_ref);
-        debug!("projection: {:?}", projection);
+        debug!(?impl_parameters, ?trait_ref, ?projection);
 
         (impl_parameters, projection)
     }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -280,7 +280,7 @@ fn impl_header_wf_goal<I: Interner>(
 
                 // Things to prove well-formed: input types of the where-clauses, projection types
                 // appearing in the header, associated type values, and of course the trait ref.
-                debug!("verify_trait_impl: input_types={:?}", types);
+                debug!(input_types=?types);
                 let goals = types
                     .into_iter()
                     .map(|ty| ty.well_formed().cast(interner))

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,10 @@ use chalk_integration::interner::ChalkIr;
 use chalk_integration::lowering::*;
 use chalk_integration::query::LoweringDatabase;
 use chalk_solve::ext::*;
+use chalk_solve::logging;
 use chalk_solve::{RustIrDatabase, SolverChoice};
 use docopt::Docopt;
 use rustyline::error::ReadlineError;
-use tracing_subscriber::filter::EnvFilter;
-use tracing_subscriber::FmtSubscriber;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -298,17 +297,13 @@ impl Args {
 
 fn main() {
     use std::io::Write;
-    let filter = EnvFilter::from_env("CHALK_DEBUG");
-    FmtSubscriber::builder()
-        .with_env_filter(filter)
-        .without_time()
-        .init();
-
-    ::std::process::exit(match run() {
-        Ok(_) => 0,
-        Err(ref e) => {
-            write!(&mut ::std::io::stderr(), "{}", e).expect("Error writing to stderr");
-            1
-        }
+    logging::with_tracing_logs(|| {
+        ::std::process::exit(match run() {
+            Ok(_) => 0,
+            Err(ref e) => {
+                write!(&mut ::std::io::stderr(), "{}", e).expect("Error writing to stderr");
+                1
+            }
+        })
     });
 }

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 
+use crate::test_util::assert_same;
 use chalk_integration::db::ChalkDatabase;
 use chalk_integration::interner::ChalkIr;
 use chalk_integration::lowering::LowerGoal;
@@ -8,8 +9,6 @@ use chalk_solve::ext::*;
 use chalk_solve::logging::with_tracing_logs;
 use chalk_solve::RustIrDatabase;
 use chalk_solve::{Solution, SolverChoice};
-
-use crate::test_util::assert_same;
 
 #[cfg(feature = "bench")]
 mod bench;


### PR DESCRIPTION
This PR makes it so we use the `tracing-tree` crate for logging output. This adds indentation to the logs, and generally makes the logging output much more readable compared to the current state. 

I also cleaned up many of the logging calls to properly use the `tracing` macros (e.g. create a new span when entering a function instead of just emitting an event).