### PR TITLE
Feature gate heavy `tracing` dependencies

### DIFF
--- a/chalk-solve/Cargo.toml
+++ b/chalk-solve/Cargo.toml
@@ -14,8 +14,8 @@ ena = "0.14.0"
 itertools = "0.9.0"
 petgraph = "0.5.0"
 tracing = "0.1"
-tracing-subscriber = "0.2"
-tracing-tree = "0.1.1"
+tracing-subscriber = { version = "0.2", optional = true }
+tracing-tree = { version = "0.1.1", optional = true }
 rustc-hash = { version = "1.0.0" }
 
 chalk-derive = { version = "0.16.0-dev.0", path = "../chalk-derive" }
@@ -26,7 +26,8 @@ chalk-ir = { version = "0.16.0-dev.0", path = "../chalk-ir" }
 chalk-integration = { path = "../chalk-integration" }
 
 [features]
-default = ["slg-solver", "recursive-solver"]
+default = ["slg-solver", "recursive-solver", "tracing-full"]
 
 slg-solver = ["chalk-engine"]
 recursive-solver = []
+tracing-full = ["tracing-subscriber", "tracing-tree"]

--- a/chalk-solve/src/logging.rs
+++ b/chalk-solve/src/logging.rs
@@ -1,12 +1,19 @@
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
-use tracing_tree::HierarchicalLayer;
-
 /// Run an action with a tracing log subscriber. The logging level is loaded
 /// from `CHALK_DEBUG`.
+#[cfg(feature = "tracing-full")]
 pub fn with_tracing_logs<T>(action: impl FnOnce() -> T) -> T {
+    use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+    use tracing_tree::HierarchicalLayer;
     let filter = EnvFilter::from_env("CHALK_DEBUG");
     let subscriber = Registry::default()
         .with(filter)
         .with(HierarchicalLayer::new(2));
     tracing::subscriber::with_default(subscriber, action)
+}
+
+/// Run an action with a tracing log subscriber. The logging level is loaded
+/// from `CHALK_DEBUG`.
+#[cfg(not(feature = "tracing-full"))]
+pub fn with_tracing_logs<T>(action: impl FnOnce() -> T) -> T {
+    action()
 }


### PR DESCRIPTION
There were some [concerns raised](https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/tracing-tree/near/202540840) about chalk's dependency on `tracing`, `tracing-subscriber`, and `tracing-tree`, particularly in how they might affect the compilation time and binary size of rust-analyzer.

This PR experimentally gates `tracing-subscriber`, `tracing-tree`, and the `attributes` feature of `tracing` behind a new feature `tracing-full`. The handling of the `instrument` attribute macro from `tracing` (which only works with the `attributes` feature enabled) is in particular a bit hacky. In order to avoid manually adding `cfg_attr` to each usage of the `instrument` macro, this PR creates a wrapper macro exported from `chalk-derive` which does so.