### PR TITLE
Reduce boilerplate for interned sequence types

### DIFF
--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    Canonical, ConstrainedSubst, Floundered, Goal, GoalData, InEnvironment, NoSolution,
+    Canonical, ConstrainedSubst, Floundered, Goal, GoalData, InEnvironment, NoSolution, Sequence,
     Substitution, UCanonical, UniverseMap,
 };
 use tracing::{debug, debug_span, info, instrument};

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -4,7 +4,7 @@ use crate::{ExClause, Literal, TimeStamp};
 
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    Environment, Fallible, Goal, GoalData, InEnvironment, QuantifierKind, Substitution,
+    Environment, Fallible, Goal, GoalData, InEnvironment, QuantifierKind, Sequence, Substitution,
 };
 use tracing::debug;
 

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -3,7 +3,8 @@ use chalk_ir::cast::{Cast, Caster};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::{
     self, AdtId, AssocTypeId, BoundVar, ClausePriority, ClosureId, DebruijnIndex, FnDefId, ImplId,
-    OpaqueTyId, QuantifiedWhereClauses, Substitution, ToGenericArg, TraitId, TyKind,
+    OpaqueTyId, QuantifiedWhereClauses, Sequence, Substitution, ToGenericArg, TraitId, TyKind,
+    VariableKinds,
 };
 use chalk_parse::ast::*;
 use chalk_solve::rust_ir::{
@@ -298,7 +299,10 @@ impl<'k> Env<'k> {
         let binders: Vec<_> = binders.into_iter().collect();
         let env = self.introduce(binders.iter().cloned())?;
         Ok(chalk_ir::Binders::new(
-            chalk_ir::VariableKinds::from(interner, binders.iter().map(|v| v.kind.clone())),
+            <VariableKinds<_> as Sequence<_>>::from(
+                interner,
+                binders.iter().map(|v| v.kind.clone()),
+            ),
             op(&env)?,
         ))
     }
@@ -464,7 +468,7 @@ impl LowerProgram for Program {
                     let upvars = empty_env.in_binders(defn.all_parameters(), |env| {
                         let upvar_tys: LowerResult<Vec<chalk_ir::Ty<ChalkIr>>> =
                             defn.upvars.iter().map(|ty| ty.lower(&env)).collect();
-                        let substitution = chalk_ir::Substitution::from(
+                        let substitution = <chalk_ir::Substitution<_> as Sequence<_>>::from(
                             &ChalkIr,
                             upvar_tys?.into_iter().map(|ty| ty.cast(&ChalkIr)),
                         );
@@ -860,7 +864,10 @@ impl LowerTypeKind for StructDefn {
             sort: TypeSort::Struct,
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
-                chalk_ir::VariableKinds::from(interner, self.all_parameters().anonymize()),
+                <VariableKinds<_> as Sequence<_>>::from(
+                    interner,
+                    self.all_parameters().anonymize(),
+                ),
                 crate::Unit,
             ),
         })
@@ -874,7 +881,10 @@ impl LowerTypeKind for FnDefn {
             sort: TypeSort::FnDef,
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
-                chalk_ir::VariableKinds::from(interner, self.all_parameters().anonymize()),
+                <VariableKinds<_> as Sequence<_>>::from(
+                    interner,
+                    self.all_parameters().anonymize(),
+                ),
                 crate::Unit,
             ),
         })
@@ -894,7 +904,10 @@ impl LowerTypeKind for ClosureDefn {
             sort: TypeSort::Closure,
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
-                chalk_ir::VariableKinds::from(interner, self.all_parameters().anonymize()),
+                <VariableKinds<_> as Sequence<_>>::from(
+                    interner,
+                    self.all_parameters().anonymize(),
+                ),
                 crate::Unit,
             ),
         })
@@ -916,7 +929,7 @@ impl LowerTypeKind for TraitDefn {
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
                 // for the purposes of the *type*, ignore `Self`:
-                chalk_ir::VariableKinds::from(interner, binders.anonymize()),
+                <VariableKinds<_> as Sequence<_>>::from(interner, binders.anonymize()),
                 crate::Unit,
             ),
         })
@@ -931,7 +944,7 @@ impl LowerTypeKind for OpaqueTyDefn {
             sort: TypeSort::Opaque,
             name: self.identifier.str.clone(),
             binders: chalk_ir::Binders::new(
-                chalk_ir::VariableKinds::from(interner, binders.anonymize()),
+                <VariableKinds<_> as Sequence<_>>::from(interner, binders.anonymize()),
                 crate::Unit,
             ),
         })
@@ -1508,7 +1521,7 @@ impl LowerProjectionTy for ProjectionTy {
 
         Ok(chalk_ir::ProjectionTy {
             associated_ty_id: lookup.id,
-            substitution: chalk_ir::Substitution::from(interner, args),
+            substitution: <chalk_ir::Substitution<_> as Sequence<_>>::from(interner, args),
         })
     }
 }
@@ -1543,7 +1556,7 @@ impl LowerTy for Ty {
                         Atom::from(FIXME_SELF),
                     )),
                     |env| {
-                        Ok(QuantifiedWhereClauses::from(
+                        Ok(<QuantifiedWhereClauses<_> as Sequence<_>>::from(
                             interner,
                             bounds.lower(env)?.iter().flat_map(|qil| {
                                 qil.into_where_clauses(
@@ -1630,7 +1643,7 @@ impl LowerTy for Ty {
 
                 let function = chalk_ir::Fn {
                     num_binders: lifetime_names.len(),
-                    substitution: Substitution::from(interner, lowered_tys),
+                    substitution: <Substitution<_> as Sequence<_>>::from(interner, lowered_tys),
                 };
                 Ok(chalk_ir::TyData::Function(function).intern(interner))
             }
@@ -1651,7 +1664,7 @@ impl LowerTy for Ty {
 
             Ty::Array { ty, len } => Ok(chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
                 name: chalk_ir::TypeName::Array,
-                substitution: chalk_ir::Substitution::from(
+                substitution: <chalk_ir::Substitution<_> as Sequence<_>>::from(
                     interner,
                     &[
                         ty.lower(env)?.cast(interner),
@@ -1689,7 +1702,7 @@ impl LowerTy for Ty {
                 name: chalk_ir::TypeName::Ref(ast_mutability_to_chalk_mutability(
                     mutability.clone(),
                 )),
-                substitution: chalk_ir::Substitution::from(
+                substitution: <chalk_ir::Substitution<_> as Sequence<_>>::from(
                     interner,
                     &[
                         lifetime.lower(env)?.cast(interner),

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -299,7 +299,7 @@ impl<'k> Env<'k> {
         let binders: Vec<_> = binders.into_iter().collect();
         let env = self.introduce(binders.iter().cloned())?;
         Ok(chalk_ir::Binders::new(
-            <VariableKinds<_> as Sequence<_>>::from(
+            VariableKinds::from_iter(
                 interner,
                 binders.iter().map(|v| v.kind.clone()),
             ),
@@ -468,7 +468,7 @@ impl LowerProgram for Program {
                     let upvars = empty_env.in_binders(defn.all_parameters(), |env| {
                         let upvar_tys: LowerResult<Vec<chalk_ir::Ty<ChalkIr>>> =
                             defn.upvars.iter().map(|ty| ty.lower(&env)).collect();
-                        let substitution = <chalk_ir::Substitution<_> as Sequence<_>>::from(
+                        let substitution = chalk_ir::Substitution::from_iter(
                             &ChalkIr,
                             upvar_tys?.into_iter().map(|ty| ty.cast(&ChalkIr)),
                         );
@@ -864,7 +864,7 @@ impl LowerTypeKind for StructDefn {
             sort: TypeSort::Struct,
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
-                <VariableKinds<_> as Sequence<_>>::from(
+                VariableKinds::from_iter(
                     interner,
                     self.all_parameters().anonymize(),
                 ),
@@ -881,7 +881,7 @@ impl LowerTypeKind for FnDefn {
             sort: TypeSort::FnDef,
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
-                <VariableKinds<_> as Sequence<_>>::from(
+                VariableKinds::from_iter(
                     interner,
                     self.all_parameters().anonymize(),
                 ),
@@ -904,7 +904,7 @@ impl LowerTypeKind for ClosureDefn {
             sort: TypeSort::Closure,
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
-                <VariableKinds<_> as Sequence<_>>::from(
+                VariableKinds::from_iter(
                     interner,
                     self.all_parameters().anonymize(),
                 ),
@@ -929,7 +929,7 @@ impl LowerTypeKind for TraitDefn {
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
                 // for the purposes of the *type*, ignore `Self`:
-                <VariableKinds<_> as Sequence<_>>::from(interner, binders.anonymize()),
+                VariableKinds::from_iter(interner, binders.anonymize()),
                 crate::Unit,
             ),
         })
@@ -944,7 +944,7 @@ impl LowerTypeKind for OpaqueTyDefn {
             sort: TypeSort::Opaque,
             name: self.identifier.str.clone(),
             binders: chalk_ir::Binders::new(
-                <VariableKinds<_> as Sequence<_>>::from(interner, binders.anonymize()),
+                VariableKinds::from_iter(interner, binders.anonymize()),
                 crate::Unit,
             ),
         })
@@ -1521,7 +1521,7 @@ impl LowerProjectionTy for ProjectionTy {
 
         Ok(chalk_ir::ProjectionTy {
             associated_ty_id: lookup.id,
-            substitution: <chalk_ir::Substitution<_> as Sequence<_>>::from(interner, args),
+            substitution: chalk_ir::Substitution::from_iter(interner, args),
         })
     }
 }
@@ -1556,7 +1556,7 @@ impl LowerTy for Ty {
                         Atom::from(FIXME_SELF),
                     )),
                     |env| {
-                        Ok(<QuantifiedWhereClauses<_> as Sequence<_>>::from(
+                        Ok(QuantifiedWhereClauses::from_iter(
                             interner,
                             bounds.lower(env)?.iter().flat_map(|qil| {
                                 qil.into_where_clauses(
@@ -1643,7 +1643,7 @@ impl LowerTy for Ty {
 
                 let function = chalk_ir::Fn {
                     num_binders: lifetime_names.len(),
-                    substitution: <Substitution<_> as Sequence<_>>::from(interner, lowered_tys),
+                    substitution: Substitution::from_iter(interner, lowered_tys),
                 };
                 Ok(chalk_ir::TyData::Function(function).intern(interner))
             }
@@ -1664,7 +1664,7 @@ impl LowerTy for Ty {
 
             Ty::Array { ty, len } => Ok(chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
                 name: chalk_ir::TypeName::Array,
-                substitution: <chalk_ir::Substitution<_> as Sequence<_>>::from(
+                substitution: chalk_ir::Substitution::from_iter(
                     interner,
                     &[
                         ty.lower(env)?.cast(interner),
@@ -1702,7 +1702,7 @@ impl LowerTy for Ty {
                 name: chalk_ir::TypeName::Ref(ast_mutability_to_chalk_mutability(
                     mutability.clone(),
                 )),
-                substitution: <chalk_ir::Substitution<_> as Sequence<_>>::from(
+                substitution: chalk_ir::Substitution::from_iter(
                     interner,
                     &[
                         lifetime.lower(env)?.cast(interner),

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -299,10 +299,7 @@ impl<'k> Env<'k> {
         let binders: Vec<_> = binders.into_iter().collect();
         let env = self.introduce(binders.iter().cloned())?;
         Ok(chalk_ir::Binders::new(
-            VariableKinds::from_iter(
-                interner,
-                binders.iter().map(|v| v.kind.clone()),
-            ),
+            VariableKinds::from_iter(interner, binders.iter().map(|v| v.kind.clone())),
             op(&env)?,
         ))
     }
@@ -864,10 +861,7 @@ impl LowerTypeKind for StructDefn {
             sort: TypeSort::Struct,
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
-                VariableKinds::from_iter(
-                    interner,
-                    self.all_parameters().anonymize(),
-                ),
+                VariableKinds::from_iter(interner, self.all_parameters().anonymize()),
                 crate::Unit,
             ),
         })
@@ -881,10 +875,7 @@ impl LowerTypeKind for FnDefn {
             sort: TypeSort::FnDef,
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
-                VariableKinds::from_iter(
-                    interner,
-                    self.all_parameters().anonymize(),
-                ),
+                VariableKinds::from_iter(interner, self.all_parameters().anonymize()),
                 crate::Unit,
             ),
         })
@@ -904,10 +895,7 @@ impl LowerTypeKind for ClosureDefn {
             sort: TypeSort::Closure,
             name: self.name.str.clone(),
             binders: chalk_ir::Binders::new(
-                VariableKinds::from_iter(
-                    interner,
-                    self.all_parameters().anonymize(),
-                ),
+                VariableKinds::from_iter(interner, self.all_parameters().anonymize()),
                 crate::Unit,
             ),
         })

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -5,7 +5,7 @@ use chalk_ir::debug::Angle;
 use chalk_ir::{
     debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, Binders, ClosureId,
     FnDefId, GenericArg, Goal, Goals, ImplId, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause,
-    ProgramClauseImplication, ProgramClauses, ProjectionTy, Substitution, TraitId, Ty,
+    ProgramClauseImplication, ProgramClauses, ProjectionTy, Sequence, Substitution, TraitId, Ty,
 };
 use chalk_solve::rust_ir::{
     AdtDatum, AdtRepr, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ClosureKind,

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -87,7 +87,9 @@ reflexive_impl!(for(I: Interner) Goal<I>);
 reflexive_impl!(for(I: Interner) WhereClause<I>);
 reflexive_impl!(for(I: Interner) ProgramClause<I>);
 reflexive_impl!(for(I: Interner) QuantifiedWhereClause<I>);
+reflexive_impl!(for(I: Interner) VariableKind<I>);
 reflexive_impl!(for(I: Interner) VariableKinds<I>);
+reflexive_impl!(for(I: Interner) CanonicalVarKind<I>);
 reflexive_impl!(for(I: Interner) CanonicalVarKinds<I>);
 reflexive_impl!(for(I: Interner) Constraint<I>);
 

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -526,7 +526,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Create an "interned" program clauses from `data`. This is not
     /// normally invoked directly; instead, you invoke
-    /// `<ProgramClauses<_> as Sequence<_>>::from` (which will ultimately call this
+    /// `ProgramClauses::from_iter` (which will ultimately call this
     /// method).
     fn intern_program_clauses<E>(
         &self,
@@ -541,7 +541,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Create an "interned" quantified where clauses from `data`. This is not
     /// normally invoked directly; instead, you invoke
-    /// `QuantifiedWhereClauses::from` (which will ultimately call this
+    /// `QuantifiedWhereClauses::from_iter` (which will ultimately call this
     /// method).
     fn intern_quantified_where_clauses<E>(
         &self,
@@ -557,7 +557,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Create an "interned" parameter kinds from `data`. This is not
     /// normally invoked directly; instead, you invoke
-    /// `<VariableKinds<_> as Sequence<_>>::from` (which will ultimately call this
+    /// `VariableKinds::from_iter` (which will ultimately call this
     /// method).
     fn intern_generic_arg_kinds<E>(
         &self,
@@ -573,7 +573,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Create "interned" variable kinds with universe index from `data`. This is not
     /// normally invoked directly; instead, you invoke
-    /// `<CanonicalVarKinds<_> as Sequence<_>>::from` (which will ultimately call this
+    /// `CanonicalVarKinds::from_iter` (which will ultimately call this
     /// method).
     fn intern_canonical_var_kinds<E>(
         &self,
@@ -589,7 +589,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Create "interned" constraints from `data`. This is not
     /// normally invoked dirctly; instead, you invoke
-    /// `Constraints::from` (which will ultimately call this
+    /// `Constraints::from_iter` (which will ultimately call this
     /// method).
     fn intern_constraints<E>(
         &self,

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -526,7 +526,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Create an "interned" program clauses from `data`. This is not
     /// normally invoked directly; instead, you invoke
-    /// `ProgramClauses::from` (which will ultimately call this
+    /// `<ProgramClauses<_> as Sequence<_>>::from` (which will ultimately call this
     /// method).
     fn intern_program_clauses<E>(
         &self,
@@ -557,7 +557,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Create an "interned" parameter kinds from `data`. This is not
     /// normally invoked directly; instead, you invoke
-    /// `VariableKinds::from` (which will ultimately call this
+    /// `<VariableKinds<_> as Sequence<_>>::from` (which will ultimately call this
     /// method).
     fn intern_generic_arg_kinds<E>(
         &self,
@@ -573,7 +573,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Create "interned" variable kinds with universe index from `data`. This is not
     /// normally invoked directly; instead, you invoke
-    /// `CanonicalVarKinds::from` (which will ultimately call this
+    /// `<CanonicalVarKinds<_> as Sequence<_>>::from` (which will ultimately call this
     /// method).
     fn intern_canonical_var_kinds<E>(
         &self,

--- a/chalk-ir/src/visit/binder_impls.rs
+++ b/chalk-ir/src/visit/binder_impls.rs
@@ -4,7 +4,9 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::interner::HasInterner;
-use crate::{Binders, Canonical, DebruijnIndex, Fn, Interner, Visit, VisitResult, Visitor};
+use crate::{
+    Binders, Canonical, DebruijnIndex, Fn, Interner, Sequence, Visit, VisitResult, Visitor,
+};
 
 impl<I: Interner> Visit<I> for Fn<I> {
     fn visit_with<'i, R: VisitResult>(

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -7,8 +7,8 @@
 use crate::{
     AdtId, AssocTypeId, ClausePriority, ClosureId, Constraints, DebruijnIndex, FloatTy, FnDefId,
     GenericArg, Goals, ImplId, IntTy, Interner, Mutability, OpaqueTyId, PlaceholderIndex,
-    ProgramClause, ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution,
-    SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
+    ProgramClause, ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Sequence,
+    Substitution, SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
 };
 use std::{marker::PhantomData, sync::Arc};
 

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -624,5 +624,5 @@ pub fn program_clauses_for_env<'db, I: Interner>(
         );
     }
 
-    <ProgramClauses<_> as Sequence<_>>::from(db.interner(), closure)
+    ProgramClauses::from_iter(db.interner(), closure)
 }

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -624,5 +624,5 @@ pub fn program_clauses_for_env<'db, I: Interner>(
         );
     }
 
-    ProgramClauses::from(db.interner(), closure)
+    <ProgramClauses<_> as Sequence<_>>::from(db.interner(), closure)
 }

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -84,8 +84,8 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
         let interner = self.db.interner();
         let clause = ProgramClauseImplication {
             consequence: consequence.cast(interner),
-            conditions: <Goals<_> as Sequence<_>>::from(interner, conditions),
-            constraints: <Constraints<_> as Sequence<_>>::from(interner, constraints),
+            conditions: Goals::from_iter(interner, conditions),
+            constraints: Constraints::from_iter(interner, constraints),
             priority,
         };
 
@@ -98,7 +98,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
 
         self.clauses.push(
             ProgramClauseData(Binders::new(
-                <VariableKinds<_> as Sequence<_>>::from(interner, self.binders.clone()),
+                VariableKinds::from_iter(interner, self.binders.clone()),
                 clause,
             ))
             .intern(interner),
@@ -115,7 +115,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
     /// Accesses the placeholders for the current list of parameters in scope,
     /// in the form of a `Substitution`.
     pub fn substitution_in_scope(&self) -> Substitution<I> {
-        <Substitution<_> as Sequence<_>>::from(
+        Substitution::from_iter(
             self.db.interner(),
             self.placeholders_in_scope().iter().cloned(),
         )

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -84,8 +84,8 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
         let interner = self.db.interner();
         let clause = ProgramClauseImplication {
             consequence: consequence.cast(interner),
-            conditions: Goals::from(interner, conditions),
-            constraints: Constraints::from(interner, constraints),
+            conditions: <Goals<_> as Sequence<_>>::from(interner, conditions),
+            constraints: <Constraints<_> as Sequence<_>>::from(interner, constraints),
             priority,
         };
 
@@ -98,7 +98,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
 
         self.clauses.push(
             ProgramClauseData(Binders::new(
-                VariableKinds::from(interner, self.binders.clone()),
+                <VariableKinds<_> as Sequence<_>>::from(interner, self.binders.clone()),
                 clause,
             ))
             .intern(interner),
@@ -115,7 +115,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
     /// Accesses the placeholders for the current list of parameters in scope,
     /// in the form of a `Substitution`.
     pub fn substitution_in_scope(&self) -> Substitution<I> {
-        Substitution::from(
+        <Substitution<_> as Sequence<_>>::from(
             self.db.interner(),
             self.placeholders_in_scope().iter().cloned(),
         )

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -1,6 +1,6 @@
 use super::{builder::ClauseBuilder, generalize};
 use crate::{Interner, RustIrDatabase, TraitRef, WellKnownTrait};
-use chalk_ir::{Floundered, Substitution, Ty};
+use chalk_ir::{Floundered, Sequence, Substitution, Ty};
 
 mod clone;
 mod copy;

--- a/chalk-solve/src/clauses/builtin_traits/copy.rs
+++ b/chalk-solve/src/clauses/builtin_traits/copy.rs
@@ -1,7 +1,7 @@
 use crate::clauses::builtin_traits::needs_impl_for_tys;
 use crate::clauses::ClauseBuilder;
 use crate::{Interner, RustIrDatabase, TraitRef};
-use chalk_ir::{ApplicationTy, Substitution, TyData, TypeName};
+use chalk_ir::{ApplicationTy, Sequence, Substitution, TyData, TypeName};
 use std::iter;
 
 fn push_tuple_copy_conditions<I: Interner>(

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -23,10 +23,8 @@ fn push_clauses<I: Interner>(
         substitution: arg_sub,
     })
     .intern(interner);
-    let substitution = Substitution::from_iter(
-        interner,
-        &[self_ty.cast(interner), tupled.cast(interner)],
-    );
+    let substitution =
+        Substitution::from_iter(interner, &[self_ty.cast(interner), tupled.cast(interner)]);
     builder.push_fact(TraitRef {
         trait_id,
         substitution: substitution.clone(),
@@ -142,10 +140,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
         },
         TyData::Function(fn_val) => {
             let (binders, orig_sub) = fn_val.into_binders_and_value(interner);
-            let bound_ref = Binders::new(
-                VariableKinds::from_iter(interner, binders),
-                orig_sub,
-            );
+            let bound_ref = Binders::new(VariableKinds::from_iter(interner, binders), orig_sub);
             builder.push_binders(&bound_ref, |builder, orig_sub| {
                 // The last parameter represents the function return type
                 let (arg_sub, fn_output_ty) = orig_sub

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -23,7 +23,7 @@ fn push_clauses<I: Interner>(
         substitution: arg_sub,
     })
     .intern(interner);
-    let substitution = <Substitution<_> as Sequence<_>>::from(
+    let substitution = Substitution::from_iter(
         interner,
         &[self_ty.cast(interner), tupled.cast(interner)],
     );
@@ -70,7 +70,7 @@ fn push_clauses_for_apply<I: Interner>(
             .iter()
             .cloned()
             .map(|ty| ty.cast(interner));
-        let arg_sub = <Substitution<_> as Sequence<_>>::from(interner, arg_sub);
+        let arg_sub = Substitution::from_iter(interner, arg_sub);
         let output_ty = inputs_and_output.return_type;
 
         push_clauses(
@@ -143,7 +143,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
         TyData::Function(fn_val) => {
             let (binders, orig_sub) = fn_val.into_binders_and_value(interner);
             let bound_ref = Binders::new(
-                <VariableKinds<_> as Sequence<_>>::from(interner, binders),
+                VariableKinds::from_iter(interner, binders),
                 orig_sub,
             );
             builder.push_binders(&bound_ref, |builder, orig_sub| {
@@ -151,7 +151,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
                 let (arg_sub, fn_output_ty) = orig_sub
                     .as_slice(interner)
                     .split_at(orig_sub.len(interner) - 1);
-                let arg_sub = <Substitution<_> as Sequence<_>>::from(interner, arg_sub);
+                let arg_sub = Substitution::from_iter(interner, arg_sub);
                 let output_ty = fn_output_ty[0].assert_ty_ref(interner).clone();
 
                 push_clauses(

--- a/chalk-solve/src/clauses/builtin_traits/sized.rs
+++ b/chalk-solve/src/clauses/builtin_traits/sized.rs
@@ -3,7 +3,7 @@ use std::iter;
 use crate::clauses::builtin_traits::needs_impl_for_tys;
 use crate::clauses::ClauseBuilder;
 use crate::{Interner, RustIrDatabase, TraitRef};
-use chalk_ir::{AdtId, ApplicationTy, Substitution, TyData, TypeName};
+use chalk_ir::{AdtId, ApplicationTy, Sequence, Substitution, TyData, TypeName};
 
 fn push_adt_sized_conditions<I: Interner>(
     db: &dyn RustIrDatabase<I>,

--- a/chalk-solve/src/clauses/builtin_traits/unsize.rs
+++ b/chalk-solve/src/clauses/builtin_traits/unsize.rs
@@ -239,7 +239,7 @@ pub fn add_unsize_program_clauses<I: Interner>(
             // should be equal to target type.
             let new_source_ty = TyData::Dyn(DynTy {
                 bounds: bounds_a.map_ref(|bounds| {
-                    <QuantifiedWhereClauses<_> as Sequence<_>>::from(
+                    QuantifiedWhereClauses::from_iter(
                         interner,
                         bounds.iter(interner).filter(|bound| {
                             let trait_id = match bound.trait_id() {
@@ -398,7 +398,7 @@ pub fn add_unsize_program_clauses<I: Interner>(
             //
             // In order for the coercion to be valid, target struct and
             // struct with this newly constructed substitution applied to it should be equal.
-            let substitution = <Substitution<_> as Sequence<_>>::from(
+            let substitution = Substitution::from_iter(
                 interner,
                 parameters_a.iter().enumerate().map(|(i, p)| {
                     if unsize_parameter_candidates.contains(&i) {
@@ -427,7 +427,7 @@ pub fn add_unsize_program_clauses<I: Interner>(
             // Check that `TailField<T>: Unsize<TailField<U>>`
             let last_field_unsizing_goal: Goal<I> = TraitRef {
                 trait_id: unsize_trait_id,
-                substitution: <Substitution<_> as Sequence<_>>::from(
+                substitution: Substitution::from_iter(
                     interner,
                     [source_tail_field, target_tail_field].iter().cloned(),
                 ),
@@ -463,7 +463,7 @@ pub fn add_unsize_program_clauses<I: Interner>(
             // last element is equal to the target.
             let new_tuple = ApplicationTy {
                 name: TypeName::Tuple(*arity),
-                substitution: <Substitution<_> as Sequence<_>>::from(
+                substitution: Substitution::from_iter(
                     interner,
                     substitution_a
                         .iter(interner)
@@ -483,7 +483,7 @@ pub fn add_unsize_program_clauses<I: Interner>(
             // Check that `T: Unsize<U>`
             let last_field_unsizing_goal: Goal<I> = TraitRef {
                 trait_id: unsize_trait_id,
-                substitution: <Substitution<_> as Sequence<_>>::from(
+                substitution: Substitution::from_iter(
                     interner,
                     [tail_ty_a, tail_ty_b].iter().cloned(),
                 ),

--- a/chalk-solve/src/clauses/dyn_ty.rs
+++ b/chalk-solve/src/clauses/dyn_ty.rs
@@ -3,8 +3,8 @@ use rustc_hash::FxHashSet;
 use super::{builder::ClauseBuilder, generalize};
 use crate::RustIrDatabase;
 use chalk_ir::{
-    cast::Cast, fold::shift::Shift, interner::Interner, Binders, BoundVar, DebruijnIndex, TraitId,
-    TraitRef, Ty, TyData, WhereClause,
+    cast::Cast, fold::shift::Shift, interner::Interner, Binders, BoundVar, DebruijnIndex, Sequence,
+    TraitId, TraitRef, Ty, TyData, WhereClause,
 };
 
 /// If the self type `S` of an `Implemented` goal is a `dyn trait` type, we wish

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -9,8 +9,8 @@
 use chalk_ir::{
     fold::{Fold, Folder},
     interner::{HasInterner, Interner},
-    Binders, BoundVar, DebruijnIndex, Fallible, Lifetime, LifetimeData, Ty, TyData, TyKind,
-    VariableKind, VariableKinds,
+    Binders, BoundVar, DebruijnIndex, Fallible, Lifetime, LifetimeData, Sequence, Ty, TyData,
+    TyKind, VariableKind, VariableKinds,
 };
 use rustc_hash::FxHashMap;
 
@@ -34,7 +34,10 @@ impl<I: Interner> Generalize<'_, I> {
         let value = value
             .fold_with(&mut generalize, DebruijnIndex::INNERMOST)
             .unwrap();
-        Binders::new(VariableKinds::from(interner, generalize.binders), value)
+        Binders::new(
+            <VariableKinds<_> as Sequence<_>>::from(interner, generalize.binders),
+            value,
+        )
     }
 }
 

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -35,7 +35,7 @@ impl<I: Interner> Generalize<'_, I> {
             .fold_with(&mut generalize, DebruijnIndex::INNERMOST)
             .unwrap();
         Binders::new(
-            <VariableKinds<_> as Sequence<_>>::from(interner, generalize.binders),
+            VariableKinds::from_iter(interner, generalize.binders),
             value,
         )
     }

--- a/chalk-solve/src/display/items.rs
+++ b/chalk-solve/src/display/items.rs
@@ -8,6 +8,7 @@ use std::fmt::{Formatter, Result};
 use crate::rust_ir::*;
 use crate::split::Split;
 use chalk_ir::interner::Interner;
+use chalk_ir::Sequence;
 use itertools::Itertools;
 
 use super::{

--- a/chalk-solve/src/display/stub.rs
+++ b/chalk-solve/src/display/stub.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     RustIrDatabase,
 };
-use chalk_ir::{interner::Interner, ApplicationTy, Binders, TypeName, VariableKinds};
+use chalk_ir::{interner::Interner, ApplicationTy, Binders, Sequence, TypeName, VariableKinds};
 
 #[derive(Debug)]
 pub struct StubWrapper<'a, DB> {
@@ -119,7 +119,7 @@ impl<I: Interner, DB: RustIrDatabase<I>> RustIrDatabase<I> for StubWrapper<'_, D
         // did matter, it would have been recorded)
         chalk_ir::TyData::Apply(ApplicationTy {
             name: TypeName::Tuple(0),
-            substitution: chalk_ir::Substitution::from(
+            substitution: <chalk_ir::Substitution<_> as Sequence<_>>::from(
                 self.db.interner(),
                 Vec::<chalk_ir::GenericArg<_>>::new(),
             ),

--- a/chalk-solve/src/display/stub.rs
+++ b/chalk-solve/src/display/stub.rs
@@ -119,7 +119,7 @@ impl<I: Interner, DB: RustIrDatabase<I>> RustIrDatabase<I> for StubWrapper<'_, D
         // did matter, it would have been recorded)
         chalk_ir::TyData::Apply(ApplicationTy {
             name: TypeName::Tuple(0),
-            substitution: <chalk_ir::Substitution<_> as Sequence<_>>::from(
+            substitution: chalk_ir::Substitution::from_iter(
                 self.db.interner(),
                 Vec::<chalk_ir::GenericArg<_>>::new(),
             ),

--- a/chalk-solve/src/goal_builder.rs
+++ b/chalk-solve/src/goal_builder.rs
@@ -45,7 +45,7 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
         G: CastTo<Goal<I>>,
     {
         GoalData::Implies(
-            <ProgramClauses<_> as Sequence<_>>::from(self.interner(), clauses),
+            ProgramClauses::from_iter(self.interner(), clauses),
             goal(self).cast(self.interner()),
         )
         .intern(self.interner())
@@ -132,7 +132,7 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
         // actually an identity mapping, since this `forall` will be the innermost
         // debruijn binder and so forth, so there's no actual reason to
         // *do* the substitution, since it would effectively just be a clone.
-        let substitution: Substitution<I> = <Substitution<_> as Sequence<_>>::from(
+        let substitution = Substitution::from_iter(
             interner,
             binders
                 .binders

--- a/chalk-solve/src/goal_builder.rs
+++ b/chalk-solve/src/goal_builder.rs
@@ -45,7 +45,7 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
         G: CastTo<Goal<I>>,
     {
         GoalData::Implies(
-            ProgramClauses::from(self.interner(), clauses),
+            <ProgramClauses<_> as Sequence<_>>::from(self.interner(), clauses),
             goal(self).cast(self.interner()),
         )
         .intern(self.interner())
@@ -132,7 +132,7 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
         // actually an identity mapping, since this `forall` will be the innermost
         // debruijn binder and so forth, so there's no actual reason to
         // *do* the substitution, since it would effectively just be a clone.
-        let substitution: Substitution<I> = Substitution::from(
+        let substitution: Substitution<I> = <Substitution<_> as Sequence<_>>::from(
             interner,
             binders
                 .binders

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -82,7 +82,7 @@ impl<'q, I: Interner> Canonicalizer<'q, I> {
             interner,
             ..
         } = self;
-        <CanonicalVarKinds<_> as Sequence<_>>::from(
+        CanonicalVarKinds::from_iter(
             interner,
             free_vars
                 .into_iter()

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -82,7 +82,7 @@ impl<'q, I: Interner> Canonicalizer<'q, I> {
             interner,
             ..
         } = self;
-        CanonicalVarKinds::from(
+        <CanonicalVarKinds<_> as Sequence<_>>::from(
             interner,
             free_vars
                 .into_iter()

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -15,7 +15,7 @@ impl<I: Interner> InferenceTable<I> {
         interner: &I,
         binders: &[CanonicalVarKind<I>],
     ) -> Substitution<I> {
-        <Substitution<_> as Sequence<_>>::from(
+        Substitution::from_iter(
             interner,
             binders.iter().map(|kind| {
                 let param_infer_var = kind.map_ref(|&ui| self.new_variable(ui));

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -15,7 +15,7 @@ impl<I: Interner> InferenceTable<I> {
         interner: &I,
         binders: &[CanonicalVarKind<I>],
     ) -> Substitution<I> {
-        Substitution::from(
+        <Substitution<_> as Sequence<_>>::from(
             interner,
             binders.iter().map(|kind| {
                 let param_infer_var = kind.map_ref(|&ui| self.new_variable(ui));

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -181,7 +181,7 @@ fn quantify_simple() {
             .quantified,
         Canonical {
             value: ty!(apply (item 0) (bound 0) (bound 1) (bound 2)),
-            binders: CanonicalVarKinds::from(
+            binders: CanonicalVarKinds::from_iter(
                 interner,
                 vec![
                     CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U2),
@@ -222,7 +222,7 @@ fn quantify_bound() {
             .quantified,
         Canonical {
             value: ty!(apply (item 0) (apply (item 1) (bound 0) (bound 1)) (bound 2) (bound 0) (bound 1)),
-            binders: CanonicalVarKinds::from(
+            binders: CanonicalVarKinds::from_iter(
                 interner,
                 vec![
                     CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U1),
@@ -266,7 +266,7 @@ fn quantify_ty_under_binder() {
             .quantified,
         Canonical {
             value: ty!(function 3 (apply (item 0) (bound 1) (bound 1 0) (bound 1 0) (lifetime (bound 1 1)))),
-            binders: CanonicalVarKinds::from(
+            binders: CanonicalVarKinds::from_iter(
                 interner,
                 vec![
                     CanonicalVarKind::new(VariableKind::Ty(TyKind::General), U0),

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -46,7 +46,7 @@ impl<I: Interner> InferenceTable<I> {
                 DebruijnIndex::INNERMOST,
             )
             .unwrap();
-        let binders = CanonicalVarKinds::from(
+        let binders = <CanonicalVarKinds<_> as Sequence<_>>::from(
             interner,
             value0
                 .binders
@@ -188,7 +188,7 @@ impl UniverseMapExt for UniverseMap {
             .unwrap();
 
         Canonical {
-            binders: CanonicalVarKinds::from(interner, binders),
+            binders: <CanonicalVarKinds<_> as Sequence<_>>::from(interner, binders),
             value,
         }
     }

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -46,7 +46,7 @@ impl<I: Interner> InferenceTable<I> {
                 DebruijnIndex::INNERMOST,
             )
             .unwrap();
-        let binders = <CanonicalVarKinds<_> as Sequence<_>>::from(
+        let binders = CanonicalVarKinds::from_iter(
             interner,
             value0
                 .binders
@@ -188,7 +188,7 @@ impl UniverseMapExt for UniverseMap {
             .unwrap();
 
         Canonical {
-            binders: <CanonicalVarKinds<_> as Sequence<_>>::from(interner, binders),
+            binders: CanonicalVarKinds::from_iter(interner, binders),
             value,
         }
     }

--- a/chalk-solve/src/recursive.rs
+++ b/chalk-solve/src/recursive.rs
@@ -11,7 +11,7 @@ use self::solve::{SolveDatabase, SolveIteration};
 use self::stack::{Stack, StackDepth};
 use crate::{coinductive_goal::IsCoinductive, RustIrDatabase};
 use chalk_ir::interner::Interner;
-use chalk_ir::{Canonical, ConstrainedSubst, Constraints, Fallible};
+use chalk_ir::{Canonical, ConstrainedSubst, Constraints, Fallible, Sequence};
 use rustc_hash::FxHashMap;
 use tracing::{debug, info, instrument};
 

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -9,7 +9,7 @@ use chalk_ir::zip::Zip;
 use chalk_ir::{
     Binders, Canonical, ConstrainedSubst, Constraint, Constraints, DomainGoal, Environment, EqGoal,
     Fallible, GenericArg, Goal, GoalData, InEnvironment, NoSolution, ProgramClauseImplication,
-    QuantifierKind, Substitution, UCanonical, UniverseMap,
+    QuantifierKind, Sequence, Substitution, UCanonical, UniverseMap,
 };
 use rustc_hash::FxHashSet;
 use std::fmt::Debug;
@@ -504,7 +504,8 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
             // No obligations remain, so we have definitively solved our goals,
             // and the current inference state is the unique way to solve them.
 
-            let constraints = Constraints::from(self.interner(), self.constraints.clone());
+            let constraints =
+                <Constraints<_> as Sequence<_>>::from(self.interner(), self.constraints.clone());
             let constrained = self.infer.canonicalize(
                 self.solver.interner(),
                 &ConstrainedSubst {

--- a/chalk-solve/src/recursive/fulfill.rs
+++ b/chalk-solve/src/recursive/fulfill.rs
@@ -504,8 +504,7 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>, Infer: RecursiveInferenceTable<I
             // No obligations remain, so we have definitively solved our goals,
             // and the current inference state is the unique way to solve them.
 
-            let constraints =
-                <Constraints<_> as Sequence<_>>::from(self.interner(), self.constraints.clone());
+            let constraints = Constraints::from_iter(self.interner(), self.constraints.clone());
             let constrained = self.infer.canonicalize(
                 self.solver.interner(),
                 &ConstrainedSubst {

--- a/chalk-solve/src/recursive/lib.rs
+++ b/chalk-solve/src/recursive/lib.rs
@@ -1,7 +1,8 @@
 use super::search_graph::DepthFirstNumber;
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    Canonical, ConstrainedSubst, Constraints, Goal, InEnvironment, Substitution, UCanonical,
+    Canonical, ConstrainedSubst, Constraints, Goal, InEnvironment, Sequence, Substitution,
+    UCanonical,
 };
 use std::fmt;
 use tracing::debug;

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 //! Contains the definition for the "Rust IR" -- this is basically a "lowered"
 //! version of the AST, roughly corresponding to [the HIR] in the Rust
 //! compiler.

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -11,8 +11,8 @@ use chalk_ir::interner::{Interner, TargetInterner};
 use chalk_ir::{
     visit::{Visit, VisitResult},
     AdtId, AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, FnDefId, GenericArg, ImplId,
-    OpaqueTyId, ProjectionTy, QuantifiedWhereClause, Substitution, ToGenericArg, TraitId, TraitRef,
-    Ty, TyData, TypeName, VariableKind, WhereClause, WithKind,
+    OpaqueTyId, ProjectionTy, QuantifiedWhereClause, Sequence, Substitution, ToGenericArg, TraitId,
+    TraitRef, Ty, TyData, TypeName, VariableKind, WhereClause, WithKind,
 };
 use std::iter;
 
@@ -390,7 +390,7 @@ impl<I: Interner> TraitBound<I> {
     pub fn as_trait_ref(&self, interner: &I, self_ty: Ty<I>) -> TraitRef<I> {
         TraitRef {
             trait_id: self.trait_id,
-            substitution: Substitution::from(
+            substitution: <Substitution<_> as Sequence<_>>::from(
                 interner,
                 iter::once(self_ty.cast(interner)).chain(self.args_no_self.iter().cloned()),
             ),
@@ -413,7 +413,7 @@ impl<I: Interner> AliasEqBound<I> {
     fn into_where_clauses(&self, interner: &I, self_ty: Ty<I>) -> Vec<WhereClause<I>> {
         let trait_ref = self.trait_bound.as_trait_ref(interner, self_ty);
 
-        let substitution = Substitution::from(
+        let substitution = <Substitution<_> as Sequence<_>>::from(
             interner,
             self.parameters
                 .iter()
@@ -532,7 +532,7 @@ impl<I: Interner> AssociatedTyDatum<I> {
         let (binders, assoc_ty_datum) = self.binders.as_ref().into();
         // Create a list `P0...Pn` of references to the binders in
         // scope for this associated type:
-        let substitution = Substitution::from(
+        let substitution = <Substitution<_> as Sequence<_>>::from(
             interner,
             binders
                 .iter(interner)

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -388,7 +388,7 @@ impl<I: Interner> TraitBound<I> {
     pub fn as_trait_ref(&self, interner: &I, self_ty: Ty<I>) -> TraitRef<I> {
         TraitRef {
             trait_id: self.trait_id,
-            substitution: <Substitution<_> as Sequence<_>>::from(
+            substitution: Substitution::from_iter(
                 interner,
                 iter::once(self_ty.cast(interner)).chain(self.args_no_self.iter().cloned()),
             ),
@@ -411,7 +411,7 @@ impl<I: Interner> AliasEqBound<I> {
     fn into_where_clauses(&self, interner: &I, self_ty: Ty<I>) -> Vec<WhereClause<I>> {
         let trait_ref = self.trait_bound.as_trait_ref(interner, self_ty);
 
-        let substitution = <Substitution<_> as Sequence<_>>::from(
+        let substitution = Substitution::from_iter(
             interner,
             self.parameters
                 .iter()
@@ -530,7 +530,7 @@ impl<I: Interner> AssociatedTyDatum<I> {
         let (binders, assoc_ty_datum) = self.binders.as_ref().into();
         // Create a list `P0...Pn` of references to the binders in
         // scope for this associated type:
-        let substitution = <Substitution<_> as Sequence<_>>::from(
+        let substitution = Substitution::from_iter(
             interner,
             binders
                 .iter(interner)

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -311,7 +311,7 @@ impl<I: Interner> context::UnificationOps<I, SlgContext<I>> for TruncatingInfere
                 interner,
                 &ConstrainedSubst {
                     subst,
-                    constraints: Constraints::from(interner, constraints),
+                    constraints: <Constraints<_> as Sequence<_>>::from(interner, constraints),
                 },
             )
             .quantified
@@ -329,7 +329,7 @@ impl<I: Interner> context::UnificationOps<I, SlgContext<I>> for TruncatingInfere
                 interner,
                 &AnswerSubst {
                     subst,
-                    constraints: Constraints::from(interner, constraints),
+                    constraints: <Constraints<_> as Sequence<_>>::from(interner, constraints),
                     delayed_subgoals,
                 },
             )

--- a/chalk-solve/src/solve/slg.rs
+++ b/chalk-solve/src/solve/slg.rs
@@ -311,7 +311,7 @@ impl<I: Interner> context::UnificationOps<I, SlgContext<I>> for TruncatingInfere
                 interner,
                 &ConstrainedSubst {
                     subst,
-                    constraints: <Constraints<_> as Sequence<_>>::from(interner, constraints),
+                    constraints: Constraints::from_iter(interner, constraints),
                 },
             )
             .quantified
@@ -329,7 +329,7 @@ impl<I: Interner> context::UnificationOps<I, SlgContext<I>> for TruncatingInfere
                 interner,
                 &AnswerSubst {
                     subst,
-                    constraints: <Constraints<_> as Sequence<_>>::from(interner, constraints),
+                    constraints: Constraints::from_iter(interner, constraints),
                     delayed_subgoals,
                 },
             )

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -179,7 +179,7 @@ fn merge_into_guidance<I: Interner>(
         })
         .collect();
 
-    let aggr_subst = <Substitution<_> as Sequence<_>>::from(interner, aggr_generic_args);
+    let aggr_subst = Substitution::from_iter(interner, aggr_generic_args);
 
     infer.canonicalize(interner, &aggr_subst).quantified
 }
@@ -388,7 +388,7 @@ impl<I: Interner> AntiUnifier<'_, '_, I> {
             substitution2.len(interner)
         );
 
-        let substitution = <Substitution<_> as Sequence<_>>::from(
+        let substitution = Substitution::from_iter(
             interner,
             substitution1
                 .iter(interner)

--- a/chalk-solve/src/solve/slg/aggregate.rs
+++ b/chalk-solve/src/solve/slg/aggregate.rs
@@ -179,7 +179,7 @@ fn merge_into_guidance<I: Interner>(
         })
         .collect();
 
-    let aggr_subst = Substitution::from(interner, aggr_generic_args);
+    let aggr_subst = <Substitution<_> as Sequence<_>>::from(interner, aggr_generic_args);
 
     infer.canonicalize(interner, &aggr_subst).quantified
 }
@@ -388,7 +388,7 @@ impl<I: Interner> AntiUnifier<'_, '_, I> {
             substitution2.len(interner)
         );
 
-        let substitution = Substitution::from(
+        let substitution = <Substitution<_> as Sequence<_>>::from(
             interner,
             substitution1
                 .iter(interner)

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -53,7 +53,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
         let (associated_ty_data, trait_params, _) = self.split_projection(&projection);
         TraitRef {
             trait_id: associated_ty_data.trait_id,
-            substitution: Substitution::from(interner, trait_params),
+            substitution: <Substitution<_> as Sequence<_>>::from(interner, trait_params),
         }
     }
 
@@ -142,7 +142,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
         // Create the parameters for the projection -- in our example
         // above, this would be `['!a, Box<!T>]`, corresponding to
         // `<Box<!T> as Foo>::Item<'!a>`
-        let projection_substitution = Substitution::from(
+        let projection_substitution = <Substitution<_> as Sequence<_>>::from(
             interner,
             atv_parameters
                 .iter()

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -53,7 +53,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
         let (associated_ty_data, trait_params, _) = self.split_projection(&projection);
         TraitRef {
             trait_id: associated_ty_data.trait_id,
-            substitution: <Substitution<_> as Sequence<_>>::from(interner, trait_params),
+            substitution: Substitution::from_iter(interner, trait_params),
         }
     }
 
@@ -142,7 +142,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
         // Create the parameters for the projection -- in our example
         // above, this would be `['!a, Box<!T>]`, corresponding to
         // `<Box<!T> as Foo>::Item<'!a>`
-        let projection_substitution = <Substitution<_> as Sequence<_>>::from(
+        let projection_substitution = Substitution::from_iter(
             interner,
             atv_parameters
                 .iter()

--- a/chalk-solve/src/test_macros.rs
+++ b/chalk-solve/src/test_macros.rs
@@ -4,7 +4,7 @@ macro_rules! ty {
     (apply $n:tt $($arg:tt)*) => {
         chalk_ir::TyData::Apply(ApplicationTy {
             name: ty_name!($n),
-            substitution: chalk_ir::Substitution::from(
+            substitution: chalk_ir::Substitution::from_iter(
                 &chalk_integration::interner::ChalkIr,
                 vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             ),
@@ -14,7 +14,7 @@ macro_rules! ty {
     (function $n:tt $($arg:tt)*) => {
         chalk_ir::TyData::Function(Fn {
             num_binders: $n,
-            substitution: chalk_ir::Substitution::from(
+            substitution: chalk_ir::Substitution::from_iter(
                 &chalk_integration::interner::ChalkIr,
                 vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             ),
@@ -31,7 +31,7 @@ macro_rules! ty {
     (projection (item $n:tt) $($arg:tt)*) => {
             chalk_ir::AliasTy::Projection(chalk_ir::ProjectionTy  {
             associated_ty_id: AssocTypeId(chalk_integration::interner::RawId { index: $n }),
-            substitution: chalk_ir::Substitution::from(
+            substitution: chalk_ir::Substitution::from_iter(
                 &chalk_integration::interner::ChalkIr,
                 vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             ),

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -5,7 +5,7 @@ use chalk_integration::db::ChalkDatabase;
 use chalk_integration::interner::ChalkIr;
 use chalk_integration::lowering::LowerGoal;
 use chalk_integration::query::LoweringDatabase;
-use chalk_ir::Constraints;
+use chalk_ir::{Constraints, Sequence};
 use chalk_solve::ext::*;
 use chalk_solve::logging::with_tracing_logs;
 use chalk_solve::RustIrDatabase;
@@ -22,7 +22,7 @@ pub fn assert_result(mut result: Option<Solution<ChalkIr>>, expected: &str, inte
         Some(Solution::Unique(solution)) => {
             let mut sorted = solution.value.constraints.as_slice(interner).to_vec();
             sorted.sort_by_key(|c| format!("{:?}", c));
-            solution.value.constraints = Constraints::from(interner, sorted);
+            solution.value.constraints = Constraints::from_iter(interner, sorted);
         }
         _ => {}
     }


### PR DESCRIPTION
This is a first attempt at #550. It eliminates ~200 LOC from `chalk_ir/lib.rs`. This PR adds a new trait `Sequence`, which contains the duplicated logic. The downside of this is that it requires bringing the trait in scope in order to use the methods. The second downside is that we currently use a `from` method for creating sequence types, so when moved into a trait it creates a conflict with `From::from`. I chose to rename `from` to `from_iter` to avoid this, but suggestions are welcome.