### PR TITLE
Don't flounder on int/float vars

### DIFF
--- a/chalk-engine/src/slg.rs
+++ b/chalk-engine/src/slg.rs
@@ -98,7 +98,12 @@ impl<'me, I: Interner> context::ContextOps<I, SlgContext<I>> for SlgContextOps<'
         goal: &DomainGoal<I>,
         _infer: &mut TruncatingInferenceTable<I>,
     ) -> Result<Vec<ProgramClause<I>>, Floundered> {
-        let clauses: Vec<_> = program_clauses_for_goal(self.program, environment, goal)?;
+        let clauses: Vec<_> = program_clauses_for_goal(
+            self.program,
+            environment,
+            goal,
+            &CanonicalVarKinds::empty(self.program.interner()),
+        )?;
 
         Ok(clauses)
     }

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -7,9 +7,9 @@ use crate::{
     tls, SolverChoice,
 };
 use chalk_ir::{
-    AdtId, AssocTypeId, Binders, Canonical, ClosureId, ConstrainedSubst, Environment, FnDefId,
-    GenericArg, Goal, ImplId, InEnvironment, OpaqueTyId, ProgramClause, ProgramClauses,
-    Substitution, TraitId, Ty, UCanonical,
+    AdtId, AssocTypeId, Binders, Canonical, CanonicalVarKinds, ClosureId, ConstrainedSubst,
+    Environment, FnDefId, GenericArg, Goal, ImplId, InEnvironment, OpaqueTyId, ProgramClause,
+    ProgramClauses, Substitution, TraitId, Ty, UCanonical,
 };
 use chalk_solve::rust_ir::{
     AdtDatum, AdtRepr, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ClosureKind,
@@ -124,10 +124,11 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         &self,
         trait_id: TraitId<ChalkIr>,
         generic_args: &[GenericArg<ChalkIr>],
+        binders: &CanonicalVarKinds<ChalkIr>,
     ) -> Vec<ImplId<ChalkIr>> {
         self.program_ir()
             .unwrap()
-            .impls_for_trait(trait_id, generic_args)
+            .impls_for_trait(trait_id, generic_args, binders)
     }
 
     fn local_impls_to_coherence_check(&self, trait_id: TraitId<ChalkIr>) -> Vec<ImplId<ChalkIr>> {

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -3,9 +3,10 @@ use crate::{tls, Identifier, TypeKind};
 use chalk_ir::could_match::CouldMatch;
 use chalk_ir::debug::Angle;
 use chalk_ir::{
-    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, Binders, ClosureId,
-    FnDefId, GenericArg, Goal, Goals, ImplId, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause,
-    ProgramClauseImplication, ProgramClauses, ProjectionTy, Substitution, TraitId, Ty,
+    debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, Binders,
+    CanonicalVarKinds, ClosureId, FnDefId, GenericArg, Goal, Goals, ImplId, Lifetime, OpaqueTy,
+    OpaqueTyId, ProgramClause, ProgramClauseImplication, ProgramClauses, ProjectionTy,
+    Substitution, TraitId, Ty,
 };
 use chalk_solve::rust_ir::{
     AdtDatum, AdtRepr, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ClosureKind,
@@ -374,6 +375,7 @@ impl RustIrDatabase<ChalkIr> for Program {
         &self,
         trait_id: TraitId<ChalkIr>,
         parameters: &[GenericArg<ChalkIr>],
+        _binders: &CanonicalVarKinds<ChalkIr>,
     ) -> Vec<ImplId<ChalkIr>> {
         let interner = self.interner();
         self.impl_data

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -394,10 +394,10 @@ impl<I: Interner> Ty<I> {
         }
     }
 
-    /// Returns true if this is a `BoundVar` or `InferenceVar`.
-    pub fn is_var(&self, interner: &I) -> bool {
+    /// Returns true if this is a `BoundVar` or an `InferenceVar` of `TyKind::General`.
+    pub fn is_general_var(&self, interner: &I) -> bool {
         match self.data(interner) {
-            TyData::BoundVar(_) | TyData::InferenceVar(_, _) => true,
+            TyData::BoundVar(_) | TyData::InferenceVar(_, TyKind::General) => true,
             _ => false,
         }
     }

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -395,9 +395,15 @@ impl<I: Interner> Ty<I> {
     }
 
     /// Returns true if this is a `BoundVar` or an `InferenceVar` of `TyKind::General`.
-    pub fn is_general_var(&self, interner: &I) -> bool {
+    pub fn is_general_var(&self, interner: &I, binders: &CanonicalVarKinds<I>) -> bool {
         match self.data(interner) {
-            TyData::BoundVar(_) | TyData::InferenceVar(_, TyKind::General) => true,
+            TyData::BoundVar(bv)
+                if bv.debruijn == DebruijnIndex::INNERMOST
+                    && binders.at(interner, bv.index).kind == VariableKind::Ty(TyKind::General) =>
+            {
+                true
+            }
+            TyData::InferenceVar(_, TyKind::General) => true,
             _ => false,
         }
     }

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -69,12 +69,10 @@ pub(super) trait SolveIteration<I: Interner>: SolveDatabase<I> {
                 // or from the lowered program, which includes fallback
                 // clauses. We try each approach in turn:
 
-                let InEnvironment { environment, goal } = &canonical_goal.canonical.value;
-
                 let (prog_solution, prog_prio) = {
                     debug_span!("prog_clauses");
 
-                    let prog_clauses = self.program_clauses_for_goal(environment, &goal);
+                    let prog_clauses = self.program_clauses_for_goal(&canonical_goal);
                     match prog_clauses {
                         Ok(clauses) => self.solve_from_clauses(&canonical_goal, clauses, minimums),
                         Err(Floundered) => {
@@ -202,10 +200,14 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
 
     fn program_clauses_for_goal(
         &self,
-        environment: &Environment<I>,
-        goal: &DomainGoal<I>,
+        canonical_goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
     ) -> Result<Vec<ProgramClause<I>>, Floundered> {
-        program_clauses_for_goal(self.db(), environment, goal)
+        program_clauses_for_goal(
+            self.db(),
+            &canonical_goal.canonical.value.environment,
+            &canonical_goal.canonical.value.goal,
+            &canonical_goal.canonical.binders,
+        )
     }
 }
 

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -243,6 +243,7 @@ fn program_clauses_that_could_match<I: Interner>(
             for impl_id in db.impls_for_trait(
                 trait_ref.trait_id,
                 trait_ref.substitution.as_slice(interner),
+                binders,
             ) {
                 db.impl_datum(impl_id).to_program_clauses(builder);
             }
@@ -415,6 +416,7 @@ fn program_clauses_that_could_match<I: Interner>(
                     builder,
                     trait_id,
                     trait_parameters,
+                    binders,
                 );
 
                 push_clauses_for_compatible_normalize(
@@ -509,8 +511,12 @@ fn push_program_clauses_for_associated_type_values_in_impls_of<I: Interner>(
     builder: &mut ClauseBuilder<'_, I>,
     trait_id: TraitId<I>,
     trait_parameters: &[GenericArg<I>],
+    binders: &CanonicalVarKinds<I>,
 ) {
-    for impl_id in builder.db.impls_for_trait(trait_id, trait_parameters) {
+    for impl_id in builder
+        .db
+        .impls_for_trait(trait_id, trait_parameters, binders)
+    {
         let impl_datum = builder.db.impl_datum(impl_id);
         if !impl_datum.is_positive() {
             continue;

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -176,12 +176,13 @@ pub fn program_clauses_for_goal<'db, I: Interner>(
     db: &'db dyn RustIrDatabase<I>,
     environment: &Environment<I>,
     goal: &DomainGoal<I>,
+    binders: &CanonicalVarKinds<I>,
 ) -> Result<Vec<ProgramClause<I>>, Floundered> {
     let interner = db.interner();
 
     let custom_clauses = db.custom_clauses().into_iter();
-    let clauses_that_could_match =
-        program_clauses_that_could_match(db, environment, goal).map(|cl| cl.into_iter())?;
+    let clauses_that_could_match = program_clauses_that_could_match(db, environment, goal, binders)
+        .map(|cl| cl.into_iter())?;
 
     let clauses: Vec<ProgramClause<I>> = custom_clauses
         .chain(clauses_that_could_match)
@@ -207,6 +208,11 @@ fn program_clauses_that_could_match<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     environment: &Environment<I>,
     goal: &DomainGoal<I>,
+    // FIXME: These are the binders for `goal`. We're passing them separately
+    // because `goal` is not necessarily canonicalized: The recursive solver
+    // passes the canonical goal; the SLG solver instantiates the goal first.
+    // (See #568.)
+    binders: &CanonicalVarKinds<I>,
 ) -> Result<Vec<ProgramClause<I>>, Floundered> {
     let interner = db.interner();
     let mut clauses: Vec<ProgramClause<I>> = vec![];
@@ -225,7 +231,7 @@ fn program_clauses_that_could_match<I: Interner>(
                     if trait_datum.is_auto_trait() {
                         push_auto_trait_impls_opaque(builder, trait_id, opaque_ty.opaque_ty_id)
                     }
-                } else if self_ty.is_general_var(interner) {
+                } else if self_ty.is_general_var(interner, binders) {
                     return Err(Floundered);
                 }
             }
@@ -393,7 +399,9 @@ fn program_clauses_that_could_match<I: Interner>(
                 // Flounder if the self-type is unknown and the trait is non-enumerable.
                 //
                 // e.g., Normalize(<?X as Iterator>::Item = u32)
-                if (self_ty.is_general_var(interner)) && trait_datum.is_non_enumerable_trait() {
+                if (self_ty.is_general_var(interner, binders))
+                    && trait_datum.is_non_enumerable_trait()
+                {
                     return Err(Floundered);
                 }
 

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -225,9 +225,7 @@ fn program_clauses_that_could_match<I: Interner>(
                     if trait_datum.is_auto_trait() {
                         push_auto_trait_impls_opaque(builder, trait_id, opaque_ty.opaque_ty_id)
                     }
-                } else if self_ty.bound_var(interner).is_some()
-                    || self_ty.inference_var(interner).is_some()
-                {
+                } else if self_ty.is_general_var(interner) {
                     return Err(Floundered);
                 }
             }
@@ -395,7 +393,7 @@ fn program_clauses_that_could_match<I: Interner>(
                 // Flounder if the self-type is unknown and the trait is non-enumerable.
                 //
                 // e.g., Normalize(<?X as Iterator>::Item = u32)
-                if (self_ty.is_var(interner)) && trait_datum.is_non_enumerable_trait() {
+                if (self_ty.is_general_var(interner)) && trait_datum.is_non_enumerable_trait() {
                     return Err(Floundered);
                 }
 

--- a/chalk-solve/src/display/stub.rs
+++ b/chalk-solve/src/display/stub.rs
@@ -9,7 +9,9 @@ use crate::{
     },
     RustIrDatabase,
 };
-use chalk_ir::{interner::Interner, ApplicationTy, Binders, TypeName, VariableKinds};
+use chalk_ir::{
+    interner::Interner, ApplicationTy, Binders, CanonicalVarKinds, TypeName, VariableKinds,
+};
 
 #[derive(Debug)]
 pub struct StubWrapper<'a, DB> {
@@ -136,6 +138,7 @@ impl<I: Interner, DB: RustIrDatabase<I>> RustIrDatabase<I> for StubWrapper<'_, D
         &self,
         _trait_id: chalk_ir::TraitId<I>,
         _parameters: &[chalk_ir::GenericArg<I>],
+        _binders: &CanonicalVarKinds<I>,
     ) -> Vec<chalk_ir::ImplId<I>> {
         // We panic here because the returned ids may not be collected,
         // resulting in unresolvable names.

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -62,8 +62,15 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// apply. The parameters are provided as a "hint" to help the
     /// implementor do less work, but can be completely ignored if
     /// desired.
-    fn impls_for_trait(&self, trait_id: TraitId<I>, parameters: &[GenericArg<I>])
-        -> Vec<ImplId<I>>;
+    ///
+    /// The `binders` are for the `parameters`; if the recursive solver is used,
+    /// the parameters can contain bound variables referring to these binders.
+    fn impls_for_trait(
+        &self,
+        trait_id: TraitId<I>,
+        parameters: &[GenericArg<I>],
+        binders: &CanonicalVarKinds<I>,
+    ) -> Vec<ImplId<I>>;
 
     /// Returns the impls that require coherence checking. This is not the
     /// full set of impls that exist:

--- a/chalk-solve/src/logging_db.rs
+++ b/chalk-solve/src/logging_db.rs
@@ -150,9 +150,13 @@ where
         &self,
         trait_id: TraitId<I>,
         parameters: &[chalk_ir::GenericArg<I>],
+        binders: &CanonicalVarKinds<I>,
     ) -> Vec<ImplId<I>> {
         self.record(trait_id);
-        let impl_ids = self.db.borrow().impls_for_trait(trait_id, parameters);
+        let impl_ids = self
+            .db
+            .borrow()
+            .impls_for_trait(trait_id, parameters, binders);
         self.record_all(impl_ids.iter().copied());
         impl_ids
     }
@@ -368,8 +372,11 @@ where
         &self,
         trait_id: TraitId<I>,
         parameters: &[chalk_ir::GenericArg<I>],
+        binders: &CanonicalVarKinds<I>,
     ) -> Vec<ImplId<I>> {
-        self.db.borrow().impls_for_trait(trait_id, parameters)
+        self.db
+            .borrow()
+            .impls_for_trait(trait_id, parameters, binders)
     }
 
     fn local_impls_to_coherence_check(&self, trait_id: TraitId<I>) -> Vec<ImplId<I>> {

--- a/tests/integration/panic.rs
+++ b/tests/integration/panic.rs
@@ -145,6 +145,7 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
         &self,
         trait_id: TraitId<ChalkIr>,
         parameters: &[GenericArg<ChalkIr>],
+        binders: &CanonicalVarKinds<ChalkIr>,
     ) -> Vec<ImplId<ChalkIr>> {
         if let PanickingMethod::ImplsForTrait = self.panicking_method {
             panic!("impls_for_trait panic");

--- a/tests/test/numerics.rs
+++ b/tests/test/numerics.rs
@@ -39,6 +39,9 @@ fn integer_index() {
 fn integer_kind_trait() {
     test! {
         program {
+            // this should even work for non-enumerable traits, because we don't
+            // need to enumerate *all* impls for this!
+            #[non_enumerable]
             trait Foo {}
             struct Bar {}
 
@@ -61,6 +64,7 @@ fn integer_kind_trait() {
 fn float_kind_trait() {
     test! {
         program {
+            #[non_enumerable]
             trait Foo {}
             struct Bar {}
 


### PR DESCRIPTION
If the self type in our goal is e.g. an int var, we don't need to flounder even if the trait is non-enumerable because the search can still be restricted to a few types (rustc can do this already).

This works with the SLG solver, but the recursive solver passes goals to the program clauses code before instantiating them, and from just the BoundVars we can't tell their kind. Maybe we need to change the recursive solver to instantiate first after all? @nikomatsakis any ideas / suggestions?