### PR TITLE
Allow printing lifetime placeholders

### DIFF
--- a/chalk-solve/src/display/ty.rs
+++ b/chalk-solve/src/display/ty.rs
@@ -269,7 +269,7 @@ impl<I: Interner> RenderAsRust<I> for LifetimeData<I> {
             LifetimeData::InferenceVar(_) => write!(f, "'_"),
             // Note: placeholders should not occur in programs, but are currently used by
             // rust-analyzer, because lifetimes are not implemented yet.
-            LifetimeData::Placeholder(ix) => write!(f, "_placeholder_{}_{}", ix.ui.counter, ix.idx),
+            LifetimeData::Placeholder(ix) => write!(f, "'_placeholder_{}_{}", ix.ui.counter, ix.idx),
             // Matching the void ensures at compile time that this code is
             // unreachable
             LifetimeData::Phantom(void, _) => match *void {},

--- a/chalk-solve/src/display/ty.rs
+++ b/chalk-solve/src/display/ty.rs
@@ -267,9 +267,9 @@ impl<I: Interner> RenderAsRust<I> for LifetimeData<I> {
         match self {
             LifetimeData::BoundVar(v) => write!(f, "'{}", s.display_bound_var(v)),
             LifetimeData::InferenceVar(_) => write!(f, "'_"),
-            LifetimeData::Placeholder(_) => unreachable!(
-                "cannot print placeholder variables; these should only be in goals not programs"
-            ),
+            // Note: placeholders should not occur in programs, but are currently used by
+            // rust-analyzer, because lifetimes are not implemented yet.
+            LifetimeData::Placeholder(ix) => write!(f, "_placeholder_{}_{}", ix.ui.counter, ix.idx),
             // Matching the void ensures at compile time that this code is
             // unreachable
             LifetimeData::Phantom(void, _) => match *void {},


### PR DESCRIPTION
rust-analyzer currently doesn't implement lifetimes, but inserts placeholders instead: https://github.com/rust-analyzer/rust-analyzer/blob/9f754e0518e7f2860891079a117a3e4bc6f4a8fd/crates/ra_hir_ty/src/traits/chalk/mapping.rs#L141

To avoid crashing when displaying programs coming from rust-analyzer, we should just write out the placeholder for now.