### PR TITLE
Fix associated type bindings in dyn types

### DIFF
--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -309,6 +309,13 @@ fn program_clauses_that_could_match<I: Interner>(
                     _ => {}
                 }
 
+                // If the self type is a `dyn trait` type, generate program-clauses
+                // for any associated type bindings it contains.
+                // FIXME: see the fixme for the analogous code for Implemented goals.
+                if let TyData::Dyn(_) = trait_self_ty.data(interner) {
+                    dyn_ty::build_dyn_self_ty_clauses(db, builder, trait_self_ty.clone())
+                }
+
                 db.associated_ty_data(proj.associated_ty_id)
                     .to_program_clauses(builder)
             }

--- a/tests/test/existential_types.rs
+++ b/tests/test/existential_types.rs
@@ -399,3 +399,25 @@ fn dyn_lifetime_bound() {
         }
     }
 }
+
+#[test]
+fn dyn_associated_type_binding() {
+    test! {
+        program {
+            trait FnOnce<Args> { type Output; }
+        }
+
+        goal {
+            exists<T> {
+                forall<'static> {
+                    <dyn FnOnce<(), Output = i32> + 'static as FnOnce<()>>::Output = T
+                }
+            }
+        } yields[SolverChoice::recursive()] {
+            "Unique; substitution [?0 := Int(I32)], lifetime constraints []"
+        } yields[SolverChoice::slg_default()] {
+            // #234
+            "Ambiguous"
+        }
+    }
+}


### PR DESCRIPTION
For a type like `dyn FnOnce<(), Output = i32>`, the `AliasEq` clause for the output type was not actually generated when we were looking for `AliasEq` clauses.