### PR TITLE
Refactor and flesh out Fn pointers

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1199,6 +1199,8 @@ impl LowerFnDefn for FnDefn {
             id: fn_def_id,
             abi: self.abi.lower()?,
             binders,
+            safety: ast_safety_to_chalk_safety(self.safety),
+            variadic: self.variadic,
         })
     }
 }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1638,6 +1638,7 @@ impl LowerTy for Ty {
                 types,
                 abi,
                 safety,
+                variadic,
             } => {
                 let quantified_env = env.introduce(lifetime_names.iter().map(|id| {
                     chalk_ir::WithKind::new(chalk_ir::VariableKind::Lifetime, id.str.clone())
@@ -1653,6 +1654,7 @@ impl LowerTy for Ty {
                     substitution: Substitution::from_iter(interner, lowered_tys),
                     abi: abi.lower()?,
                     safety: ast_safety_to_chalk_safety(*safety),
+                    variadic: *variadic,
                 };
                 Ok(chalk_ir::TyData::Function(function).intern(interner))
             }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1637,6 +1637,7 @@ impl LowerTy for Ty {
                 lifetime_names,
                 types,
                 abi,
+                safety,
             } => {
                 let quantified_env = env.introduce(lifetime_names.iter().map(|id| {
                     chalk_ir::WithKind::new(chalk_ir::VariableKind::Lifetime, id.str.clone())
@@ -1651,6 +1652,7 @@ impl LowerTy for Ty {
                     num_binders: lifetime_names.len(),
                     substitution: Substitution::from_iter(interner, lowered_tys),
                     abi: abi.lower()?,
+                    safety: ast_safety_to_chalk_safety(*safety),
                 };
                 Ok(chalk_ir::TyData::Function(function).intern(interner))
             }
@@ -2181,5 +2183,12 @@ fn ast_mutability_to_chalk_mutability(mutability: Mutability) -> chalk_ir::Mutab
     match mutability {
         Mutability::Mut => chalk_ir::Mutability::Mut,
         Mutability::Not => chalk_ir::Mutability::Not,
+    }
+}
+
+fn ast_safety_to_chalk_safety(safety: Safety) -> chalk_ir::Safety {
+    match safety {
+        Safety::Safe => chalk_ir::Safety::Safe,
+        Safety::Unsafe => chalk_ir::Safety::Unsafe,
     }
 }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1636,6 +1636,7 @@ impl LowerTy for Ty {
             Ty::ForAll {
                 lifetime_names,
                 types,
+                abi,
             } => {
                 let quantified_env = env.introduce(lifetime_names.iter().map(|id| {
                     chalk_ir::WithKind::new(chalk_ir::VariableKind::Lifetime, id.str.clone())
@@ -1649,6 +1650,7 @@ impl LowerTy for Ty {
                 let function = chalk_ir::FnPointer {
                     num_binders: lifetime_names.len(),
                     substitution: Substitution::from_iter(interner, lowered_tys),
+                    abi: abi.lower()?,
                 };
                 Ok(chalk_ir::TyData::Function(function).intern(interner))
             }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1646,7 +1646,7 @@ impl LowerTy for Ty {
                     lowered_tys.push(ty.lower(&quantified_env)?.cast(interner));
                 }
 
-                let function = chalk_ir::Fn {
+                let function = chalk_ir::FnPointer {
                     num_binders: lifetime_names.len(),
                     substitution: Substitution::from_iter(interner, lowered_tys),
                 };

--- a/chalk-integration/src/test_macros.rs
+++ b/chalk-integration/src/test_macros.rs
@@ -13,12 +13,15 @@ macro_rules! ty {
     };
 
     (function $n:tt $($arg:tt)*) => {
-        chalk_ir::TyData::Function(chalk_ir::Fn {
+        chalk_ir::TyData::Function(chalk_ir::FnPointer {
             num_binders: $n,
             substitution: chalk_ir::Substitution::from_iter(
                 &chalk_integration::interner::ChalkIr,
                 vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             ),
+            safety: chalk_ir::Safety::Safe,
+            abi: <chalk_integration::interner::ChalkIr as chalk_ir::interner::Interner>::FnAbi::Rust,
+            variadic: false,
         }).intern(&chalk_integration::interner::ChalkIr)
     };
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -238,8 +238,9 @@ impl<I: Interner> Debug for FnPointer<I> {
         let FnPointer {
             num_binders,
             substitution,
+            abi,
         } = self;
-        write!(fmt, "for<{}> {:?}", num_binders, substitution)
+        write!(fmt, "{:?} for<{}> {:?}", abi, num_binders, substitution)
     }
 }
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -239,8 +239,13 @@ impl<I: Interner> Debug for FnPointer<I> {
             num_binders,
             substitution,
             abi,
+            safety,
         } = self;
-        write!(fmt, "{:?} for<{}> {:?}", abi, num_binders, substitution)
+        write!(
+            fmt,
+            "for<{}> {:?} {:?} {:?}",
+            num_binders, safety, abi, substitution
+        )
     }
 }
 

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -240,6 +240,7 @@ impl<I: Interner> Debug for FnPointer<I> {
             substitution,
             abi,
             safety,
+            variadic: _,
         } = self;
         write!(
             fmt,

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -232,10 +232,10 @@ impl Debug for InferenceVar {
     }
 }
 
-impl<I: Interner> Debug for Fn<I> {
+impl<I: Interner> Debug for FnPointer<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         // FIXME -- we should introduce some names or something here
-        let Fn {
+        let FnPointer {
             num_binders,
             substitution,
         } = self;

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -20,10 +20,12 @@ impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for FnPointer<I> {
         let FnPointer {
             num_binders,
             substitution,
+            abi,
         } = self;
         Ok(FnPointer {
             num_binders: *num_binders,
             substitution: substitution.fold_with(folder, outer_binder.shifted_in())?,
+            abi: TI::transfer_abi(*abi),
         })
     }
 }

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -22,12 +22,14 @@ impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for FnPointer<I> {
             substitution,
             abi,
             safety,
+            variadic,
         } = self;
         Ok(FnPointer {
             num_binders: *num_binders,
             substitution: substitution.fold_with(folder, outer_binder.shifted_in())?,
             abi: TI::transfer_abi(*abi),
             safety: *safety,
+            variadic: *variadic,
         })
     }
 }

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -21,11 +21,13 @@ impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for FnPointer<I> {
             num_binders,
             substitution,
             abi,
+            safety,
         } = self;
         Ok(FnPointer {
             num_binders: *num_binders,
             substitution: substitution.fold_with(folder, outer_binder.shifted_in())?,
             abi: TI::transfer_abi(*abi),
+            safety: *safety,
         })
     }
 }

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -6,8 +6,8 @@
 use crate::interner::TargetInterner;
 use crate::*;
 
-impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for Fn<I> {
-    type Result = Fn<TI>;
+impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for FnPointer<I> {
+    type Result = FnPointer<TI>;
     fn fold_with<'i>(
         &self,
         folder: &mut dyn Folder<'i, I, TI>,
@@ -17,11 +17,11 @@ impl<I: Interner, TI: TargetInterner<I>> Fold<I, TI> for Fn<I> {
         I: 'i,
         TI: 'i,
     {
-        let Fn {
+        let FnPointer {
             num_binders,
             substitution,
         } = self;
-        Ok(Fn {
+        Ok(FnPointer {
             num_binders: *num_binders,
             substitution: substitution.fold_with(folder, outer_binder.shifted_in())?,
         })

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -267,6 +267,7 @@ copy_fold!(FloatTy);
 copy_fold!(Scalar);
 copy_fold!(ClausePriority);
 copy_fold!(Mutability);
+copy_fold!(Safety);
 
 #[doc(hidden)]
 #[macro_export]

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -633,6 +633,9 @@ pub trait TargetInterner<I: Interner>: Interner {
         &self,
         const_evaluated: &I::InternedConcreteConst,
     ) -> Self::InternedConcreteConst;
+
+    /// Transfer function ABI to the target interner.
+    fn transfer_abi(abi: I::FnAbi) -> Self::FnAbi;
 }
 
 impl<I: Interner> TargetInterner<I> for I {
@@ -661,6 +664,10 @@ impl<I: Interner> TargetInterner<I> for I {
         const_evaluated: &I::InternedConcreteConst,
     ) -> Self::InternedConcreteConst {
         const_evaluated.clone()
+    }
+
+    fn transfer_abi(abi: I::FnAbi) -> Self::FnAbi {
+        abi
     }
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -862,6 +862,7 @@ impl InferenceVar {
 #[allow(missing_docs)]
 pub struct FnPointer<I: Interner> {
     pub num_binders: usize,
+    pub abi: I::FnAbi,
     pub substitution: Substitution<I>,
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -503,7 +503,7 @@ pub enum TyData<I: Interner> {
     /// Note that "higher-ranked" types (starting with `for<>`) are either
     /// function types or dyn types, and do not appear otherwise in Rust
     /// surface syntax.
-    Function(Fn<I>),
+    Function(FnPointer<I>),
 
     /// References the binding at the given depth. The index is a [de
     /// Bruijn index], so it counts back through the in-scope binders.
@@ -860,12 +860,12 @@ impl InferenceVar {
 /// and we use deBruijn indices within `self.ty`
 #[derive(Clone, PartialEq, Eq, Hash, HasInterner)]
 #[allow(missing_docs)]
-pub struct Fn<I: Interner> {
+pub struct FnPointer<I: Interner> {
     pub num_binders: usize,
     pub substitution: Substitution<I>,
 }
 
-impl<I: Interner> Copy for Fn<I> where I::InternedSubstitution: Copy {}
+impl<I: Interner> Copy for FnPointer<I> where I::InternedSubstitution: Copy {}
 
 /// Constants.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasInterner)]

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -873,6 +873,7 @@ pub struct FnPointer<I: Interner> {
     pub num_binders: usize,
     pub abi: I::FnAbi,
     pub safety: Safety,
+    pub variadic: bool,
     pub substitution: Substitution<I>,
 }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -193,6 +193,15 @@ pub enum Scalar {
     Float(FloatTy),
 }
 
+/// Whether a function is safe or not.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Safety {
+    /// Safe
+    Safe,
+    /// Unsafe
+    Unsafe,
+}
+
 /// Whether a type is mutable or not.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Mutability {
@@ -863,6 +872,7 @@ impl InferenceVar {
 pub struct FnPointer<I: Interner> {
     pub num_binders: usize,
     pub abi: I::FnAbi,
+    pub safety: Safety,
     pub substitution: Substitution<I>,
 }
 

--- a/chalk-ir/src/visit/binder_impls.rs
+++ b/chalk-ir/src/visit/binder_impls.rs
@@ -4,9 +4,9 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::interner::HasInterner;
-use crate::{Binders, Canonical, DebruijnIndex, Fn, Interner, Visit, VisitResult, Visitor};
+use crate::{Binders, Canonical, DebruijnIndex, FnPointer, Interner, Visit, VisitResult, Visitor};
 
-impl<I: Interner> Visit<I> for Fn<I> {
+impl<I: Interner> Visit<I> for FnPointer<I> {
     fn visit_with<'i, R: VisitResult>(
         &self,
         visitor: &mut dyn Visitor<'i, I, Result = R>,

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -7,8 +7,8 @@
 use crate::{
     AdtId, AssocTypeId, ClausePriority, ClosureId, Constraints, DebruijnIndex, FloatTy, FnDefId,
     GenericArg, Goals, ImplId, IntTy, Interner, Mutability, OpaqueTyId, PlaceholderIndex,
-    ProgramClause, ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Scalar, Substitution,
-    SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
+    ProgramClause, ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Safety, Scalar,
+    Substitution, SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult, Visitor,
 };
 use std::{marker::PhantomData, sync::Arc};
 
@@ -211,6 +211,7 @@ const_visit!(UintTy);
 const_visit!(IntTy);
 const_visit!(FloatTy);
 const_visit!(Mutability);
+const_visit!(Safety);
 
 #[doc(hidden)]
 #[macro_export]

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -74,6 +74,8 @@ pub struct FnDefn {
     pub argument_types: Vec<Ty>,
     pub return_type: Ty,
     pub abi: FnAbi,
+    pub safety: Safety,
+    pub variadic: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -259,6 +259,7 @@ pub enum Ty {
         lifetime_names: Vec<Identifier>,
         types: Vec<Box<Ty>>,
         abi: FnAbi,
+        safety: Safety,
     },
     Tuple {
         types: Vec<Box<Ty>>,
@@ -325,6 +326,18 @@ pub enum ScalarType {
 pub enum Mutability {
     Mut,
     Not,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Safety {
+    Safe,
+    Unsafe,
+}
+
+impl Default for Safety {
+    fn default() -> Self {
+        Self::Safe
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -260,6 +260,7 @@ pub enum Ty {
         types: Vec<Box<Ty>>,
         abi: FnAbi,
         safety: Safety,
+        variadic: bool,
     },
     Tuple {
         types: Vec<Box<Ty>>,

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -258,6 +258,7 @@ pub enum Ty {
     ForAll {
         lifetime_names: Vec<Identifier>,
         types: Vec<Box<Ty>>,
+        abi: FnAbi,
     },
     Tuple {
         types: Vec<Box<Ty>>,

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -140,28 +140,31 @@ FnReturn: Ty = {
 };
 
 FnDefn: FnDefn = {
-    <var:Variadic?> <safety:Safety?> <abi:FnAbi?> "fn" <n:Id> <p:Angle<VariableKind>>"(" <args:FnArgs> ")"
+    <safety:Safety?> <abi:FnAbi?> "fn" <n:Id> <p:Angle<VariableKind>>"(" <args:FnArgs> ")"
         <ret_ty:FnReturn?> <w:QuantifiedWhereClauses> ";" => FnDefn
     {
         name: n,
         variable_kinds: p,
         where_clauses: w,
-        argument_types: args,
+        variadic: args.is_variadic(),
+        argument_types: args.to_tys(),
         return_type: ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() }),
         abi: abi.unwrap_or_default(),
         safety: safety.unwrap_or_default(),
-        variadic: var.unwrap_or(false),
     }
 };
 
 FnAbi: FnAbi = "extern" "\"" <id:Id> "\"" => FnAbi(id.str);
 
-FnArg: Ty = {
-    Id ":" <arg_ty: Ty> => arg_ty
+FnArg: FnArg = {
+    Id ":" "..." => FnArg::Variadic,
+    Id ":" <arg_ty: Ty> => FnArg::NonVariadic(arg_ty),
 };
 
-FnArgs: Vec<Ty> = {
-    <Comma<FnArg>>
+FnArgs: FnArgs = {
+    <Comma<FnArg>> =>? FnArgs::from_vec(<>).map_err(|e| lalrpop_util::ParseError::User {
+        error: e,
+    })
 };
 
 ClosureDefn: ClosureDefn = {
@@ -183,7 +186,7 @@ ClosureSelf: ClosureKind = {
 }
 
 ClosureArgs: Vec<Ty> = {
-    "," <args:FnArgs> => args,
+    "," <args:FnArgs> => args.to_tys(),
 }
 
 TraitDefn: TraitDefn = {
@@ -317,20 +320,28 @@ Safety: Safety = {
     "unsafe" => Safety::Unsafe,
 };
 
-Variadic: bool = {
-    "variadic" => true,
-}
+FnArgTy: FnArg = {
+    "..." => FnArg::Variadic,
+    <arg_ty: Ty> => FnArg::NonVariadic(arg_ty),
+};
+
+FnArgTys: FnArgs = {
+    <Comma<FnArgTy>> =>? FnArgs::from_vec(<>).map_err(|e| lalrpop_util::ParseError::User {
+        error: e,
+    })
+};
 
 TyWithoutId: Ty = {
-    <l:ForLifetimes?> <var:Variadic?> <safety:Safety?> <abi:FnAbi?> "fn" "(" <types:Comma<Ty>> ")" <ret_ty:FnReturn?> => Ty::ForAll {
+    <l:ForLifetimes?> <safety:Safety?> <abi:FnAbi?> "fn" "(" <types:FnArgTys> ")" <ret_ty:FnReturn?> => Ty::ForAll {
         lifetime_names: l.unwrap_or_default(),
+        variadic: types.is_variadic(),
         types: types
+                   .to_tys()
                    .into_iter()
                    .chain(std::iter::once(ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() })))
                    .map(Box::new).collect(),
         safety: safety.unwrap_or_default(),
         abi: abi.unwrap_or_default(),
-        variadic: var.unwrap_or(false)
     },
     <ScalarType> => Ty::Scalar { ty: <> },
     "str" => Ty::Str,

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -315,15 +315,20 @@ Safety: Safety = {
     "unsafe" => Safety::Unsafe,
 };
 
+Variadic: bool = {
+    "variadic" => true,
+}
+
 TyWithoutId: Ty = {
-    <l:ForLifetimes?> <safety:Safety?> <abi:FnAbi?> "fn" "(" <types:Comma<Ty>> ")" <ret_ty:FnReturn?> => Ty::ForAll {
+    <l:ForLifetimes?> <var:Variadic?> <safety:Safety?> <abi:FnAbi?> "fn" "(" <types:Comma<Ty>> ")" <ret_ty:FnReturn?> => Ty::ForAll {
         lifetime_names: l.unwrap_or_default(),
         types: types
                    .into_iter()
                    .chain(std::iter::once(ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() })))
                    .map(Box::new).collect(),
         safety: safety.unwrap_or_default(),
-        abi: abi.unwrap_or_default()
+        abi: abi.unwrap_or_default(),
+        variadic: var.unwrap_or(false)
     },
     <ScalarType> => Ty::Scalar { ty: <> },
     "str" => Ty::Str,

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -312,12 +312,13 @@ pub Ty: Ty = {
 };
 
 TyWithoutId: Ty = {
-    <l:ForLifetimes?> "fn" "(" <types:Comma<Ty>> ")" <ret_ty:FnReturn?> => Ty::ForAll {
+    <l:ForLifetimes?> <abi:FnAbi?> "fn" "(" <types:Comma<Ty>> ")" <ret_ty:FnReturn?> => Ty::ForAll {
         lifetime_names: l.unwrap_or_default(),
         types: types
                    .into_iter()
                    .chain(std::iter::once(ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() })))
-                   .map(Box::new).collect()
+                   .map(Box::new).collect(),
+        abi: abi.unwrap_or_default()
     },
     <ScalarType> => Ty::Scalar { ty: <> },
     "str" => Ty::Str,

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -311,13 +311,18 @@ pub Ty: Ty = {
     TyWithoutId,
 };
 
+Safety: Safety = {
+    "unsafe" => Safety::Unsafe,
+};
+
 TyWithoutId: Ty = {
-    <l:ForLifetimes?> <abi:FnAbi?> "fn" "(" <types:Comma<Ty>> ")" <ret_ty:FnReturn?> => Ty::ForAll {
+    <l:ForLifetimes?> <safety:Safety?> <abi:FnAbi?> "fn" "(" <types:Comma<Ty>> ")" <ret_ty:FnReturn?> => Ty::ForAll {
         lifetime_names: l.unwrap_or_default(),
         types: types
                    .into_iter()
                    .chain(std::iter::once(ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() })))
                    .map(Box::new).collect(),
+        safety: safety.unwrap_or_default(),
         abi: abi.unwrap_or_default()
     },
     <ScalarType> => Ty::Scalar { ty: <> },

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -140,7 +140,7 @@ FnReturn: Ty = {
 };
 
 FnDefn: FnDefn = {
-    <abi:FnAbi?> "fn" <n:Id> <p:Angle<VariableKind>>"(" <args:FnArgs> ")"
+    <var:Variadic?> <safety:Safety?> <abi:FnAbi?> "fn" <n:Id> <p:Angle<VariableKind>>"(" <args:FnArgs> ")"
         <ret_ty:FnReturn?> <w:QuantifiedWhereClauses> ";" => FnDefn
     {
         name: n,
@@ -149,6 +149,8 @@ FnDefn: FnDefn = {
         argument_types: args,
         return_type: ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() }),
         abi: abi.unwrap_or_default(),
+        safety: safety.unwrap_or_default(),
+        variadic: var.unwrap_or(false),
     }
 };
 

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -4,8 +4,8 @@ use crate::rust_ir::{ClosureKind, FnDefInputsAndOutputDatum, WellKnownTrait};
 use crate::{Interner, RustIrDatabase, TraitRef};
 use chalk_ir::cast::Cast;
 use chalk_ir::{
-    AliasTy, ApplicationTy, Binders, Floundered, Normalize, ProjectionTy, Substitution, TraitId,
-    Ty, TyData, TypeName, VariableKinds,
+    AliasTy, ApplicationTy, Binders, Floundered, Normalize, ProjectionTy, Safety, Substitution,
+    TraitId, Ty, TyData, TypeName, VariableKinds,
 };
 
 fn push_clauses<I: Interner>(
@@ -138,7 +138,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
             }
             _ => Ok(()),
         },
-        TyData::Function(fn_val) => {
+        TyData::Function(fn_val) if fn_val.safety == Safety::Safe => {
             let (binders, orig_sub) = fn_val.into_binders_and_value(interner);
             let bound_ref = Binders::new(VariableKinds::from_iter(interner, binders), orig_sub);
             builder.push_binders(&bound_ref, |builder, orig_sub| {

--- a/chalk-solve/src/display/ty.rs
+++ b/chalk-solve/src/display/ty.rs
@@ -90,7 +90,7 @@ impl<I: Interner> RenderAsRust<I> for OpaqueTy<I> {
     }
 }
 
-impl<I: Interner> RenderAsRust<I> for Fn<I> {
+impl<I: Interner> RenderAsRust<I> for FnPointer<I> {
     fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         let interner = s.db.interner();
         let s = &s.add_debrujin_index(None);

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl<'a, I> IntoBindersAndValue<'a, I> for &'a Fn<I>
+impl<'a, I> IntoBindersAndValue<'a, I> for &'a FnPointer<I>
 where
     I: Interner,
 {

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -129,7 +129,11 @@ impl<'t, I: Interner> Unifier<'t, I> {
 
             // Unifying `forall<X> { T }` with some other forall type `forall<X> { U }`
             (&TyData::Function(ref fn1), &TyData::Function(ref fn2)) => {
-                self.unify_binders(fn1, fn2)
+                if fn1.abi == fn2.abi {
+                    self.unify_binders(fn1, fn2)
+                } else {
+                    Err(NoSolution)
+                }
             }
 
             // This would correspond to unifying a `fn` type with a non-fn

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -129,7 +129,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
 
             // Unifying `forall<X> { T }` with some other forall type `forall<X> { U }`
             (&TyData::Function(ref fn1), &TyData::Function(ref fn2)) => {
-                if fn1.abi == fn2.abi && fn1.safety == fn2.safety {
+                if fn1.abi == fn2.abi && fn1.safety == fn2.safety && fn1.variadic == fn2.variadic {
                     self.unify_binders(fn1, fn2)
                 } else {
                     Err(NoSolution)

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -129,7 +129,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
 
             // Unifying `forall<X> { T }` with some other forall type `forall<X> { U }`
             (&TyData::Function(ref fn1), &TyData::Function(ref fn2)) => {
-                if fn1.abi == fn2.abi {
+                if fn1.abi == fn2.abi && fn1.safety == fn2.safety {
                     self.unify_binders(fn1, fn2)
                 } else {
                     Err(NoSolution)

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -9,8 +9,8 @@ use chalk_ir::interner::{Interner, TargetInterner};
 use chalk_ir::{
     visit::{Visit, VisitResult},
     AdtId, AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, FnDefId, GenericArg, ImplId,
-    OpaqueTyId, ProjectionTy, QuantifiedWhereClause, Substitution, ToGenericArg, TraitId, TraitRef,
-    Ty, TyData, TypeName, VariableKind, WhereClause, WithKind,
+    OpaqueTyId, ProjectionTy, QuantifiedWhereClause, Safety, Substitution, ToGenericArg, TraitId,
+    TraitRef, Ty, TyData, TypeName, VariableKind, WhereClause, WithKind,
 };
 use std::iter;
 
@@ -145,6 +145,8 @@ pub struct AdtRepr {
 pub struct FnDefDatum<I: Interner> {
     pub id: FnDefId<I>,
     pub abi: I::FnAbi,
+    pub safety: Safety,
+    pub variadic: bool,
     pub binders: Binders<FnDefDatumBound<I>>,
 }
 

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -731,15 +731,15 @@ fn extern_functions() {
 fn unsafe_variadic_functions() {
     lowering_success! {
         program {
-            unsafe fn foo();
-            variadic unsafe fn bar();
+            unsafe fn foo(_: u8);
+            unsafe fn bar(_: u8, _: ...);
             unsafe extern "C" fn baz();
         }
     }
     lowering_success! {
         program {
-            variadic fn foo();
-            variadic extern "C" fn bar();
+            fn foo(_: u8, _: ...);
+            extern "C" fn bar(_: u8, _: ...);
         }
     }
 }

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -728,6 +728,23 @@ fn extern_functions() {
 }
 
 #[test]
+fn unsafe_variadic_functions() {
+    lowering_success! {
+        program {
+            unsafe fn foo();
+            variadic unsafe fn bar();
+            unsafe extern "C" fn baz();
+        }
+    }
+    lowering_success! {
+        program {
+            variadic fn foo();
+            variadic extern "C" fn bar();
+        }
+    }
+}
+
+#[test]
 fn closures() {
     lowering_success! {
         program {

--- a/tests/test/builtin_impls/fn_family.rs
+++ b/tests/test/builtin_impls/fn_family.rs
@@ -43,6 +43,25 @@ fn function_implement_fn_traits() {
             "Unique; substitution [], lifetime constraints []"
         }
 
+        // Make sure unsafe function pointers don't implement FnOnce
+        goal {
+            unsafe fn(u8): FnOnce<(u8,)>
+        } yields {
+            "No possible solution"
+        }
+        // Same as above but for FnMut
+        goal {
+            unsafe fn(u8): FnMut<(u8,)>
+        } yields {
+            "No possible solution"
+        }
+        // Same as above but for Fn
+        goal {
+            unsafe fn(u8): Fn<(u8,)>
+        } yields {
+            "No possible solution"
+        }
+
         // Function pointres implicity return `()` when no return
         // type is specified - make sure that normalization understands
         // this

--- a/tests/test/unify.rs
+++ b/tests/test/unify.rs
@@ -80,13 +80,29 @@ fn forall_equality() {
         }
 
         goal {
+            // Function pointers with different ABIs should not be equal.
             for<'a, 'b> extern "Rust" fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> extern "C" fn(Ref<'c, Ref<'d, Unit>>)>
         } yields {
             "No possible solution"
         }
 
         goal {
+            // Function pointers with identical ABIs should be equal.
             for<'a, 'b> extern "Rust" fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> extern "Rust" fn(Ref<'c, Ref<'d, Unit>>)>
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            // Function pointers with different safety should not be equal.
+            for<'a, 'b> unsafe fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> fn(Ref<'c, Ref<'d, Unit>>)>
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            // Function pointers with identical safety should be equal.
+            for<'a, 'b> unsafe fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> unsafe fn(Ref<'c, Ref<'d, Unit>>)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }

--- a/tests/test/unify.rs
+++ b/tests/test/unify.rs
@@ -109,14 +109,14 @@ fn forall_equality() {
 
         goal {
             // Variadic function pointers should not be equal to non-variadic fn pointers.
-            variadic fn(): Eq<fn()>
+            fn(u8, ...): Eq<fn(u8)>
         } yields {
             "No possible solution"
         }
 
         goal {
             // Variadic function pointers should be equal to variadic fn pointers.
-            variadic fn(): Eq<variadic fn()>
+            fn(u8, ...): Eq<fn(u8, ...)>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }

--- a/tests/test/unify.rs
+++ b/tests/test/unify.rs
@@ -78,6 +78,18 @@ fn forall_equality() {
             InEnvironment { environment: Env([]), goal: '!2_0: '!2_1 }, \
             InEnvironment { environment: Env([]), goal: '!2_1: '!2_0 }]"
         }
+
+        goal {
+            for<'a, 'b> extern "Rust" fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> extern "C" fn(Ref<'c, Ref<'d, Unit>>)>
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            for<'a, 'b> extern "Rust" fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> extern "Rust" fn(Ref<'c, Ref<'d, Unit>>)>
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
     }
 }
 

--- a/tests/test/unify.rs
+++ b/tests/test/unify.rs
@@ -81,28 +81,42 @@ fn forall_equality() {
 
         goal {
             // Function pointers with different ABIs should not be equal.
-            for<'a, 'b> extern "Rust" fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> extern "C" fn(Ref<'c, Ref<'d, Unit>>)>
+            extern "Rust" fn(): Eq<extern "C" fn()>
         } yields {
             "No possible solution"
         }
 
         goal {
             // Function pointers with identical ABIs should be equal.
-            for<'a, 'b> extern "Rust" fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> extern "Rust" fn(Ref<'c, Ref<'d, Unit>>)>
+            extern "Rust" fn(): Eq<extern "Rust" fn()>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }
 
         goal {
             // Function pointers with different safety should not be equal.
-            for<'a, 'b> unsafe fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> fn(Ref<'c, Ref<'d, Unit>>)>
+            unsafe fn(): Eq<fn()>
         } yields {
             "No possible solution"
         }
 
         goal {
             // Function pointers with identical safety should be equal.
-            for<'a, 'b> unsafe fn(Ref<'a, Ref<'b, Unit>>): Eq<for<'c, 'd> unsafe fn(Ref<'c, Ref<'d, Unit>>)>
+            unsafe fn(): Eq<unsafe fn()>
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            // Variadic function pointers should not be equal to non-variadic fn pointers.
+            variadic fn(): Eq<fn()>
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            // Variadic function pointers should be equal to variadic fn pointers.
+            variadic fn(): Eq<variadic fn()>
         } yields {
             "Unique; substitution [], lifetime constraints []"
         }


### PR DESCRIPTION
Closes #507.

This PR does a few things:
- Renames `Fn` -> `FnPointer`
- Adds ABI to `FnPointer`
- Adds support for unsafe functions to both `FnPointer` and `FnDef`
- Adds a variadic flag to both `FnPointer` and `FnDef` (cc [this comment](https://github.com/rust-lang/chalk/issues/507#issuecomment-658289067))