### PR TITLE
Add default `RustIrDatabase::*_name` impls

### DIFF
--- a/chalk-integration/src/interner.rs
+++ b/chalk-integration/src/interner.rs
@@ -2,9 +2,9 @@ use crate::tls;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::{
     AdtId, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKind, CanonicalVarKinds, ConstData,
-    Constraint, Goals, InEnvironment, Lifetime, OpaqueTy, OpaqueTyId, ProgramClauseImplication,
-    ProgramClauses, ProjectionTy, QuantifiedWhereClauses, SeparatorTraitRef, Substitution, TraitId,
-    Ty, VariableKind, VariableKinds,
+    Constraint, FnDefId, Goals, InEnvironment, Lifetime, OpaqueTy, OpaqueTyId,
+    ProgramClauseImplication, ProgramClauses, ProjectionTy, QuantifiedWhereClauses,
+    SeparatorTraitRef, Substitution, TraitId, Ty, VariableKind, VariableKinds,
 };
 use chalk_ir::{
     GenericArg, GenericArgData, Goal, GoalData, LifetimeData, ProgramClause, ProgramClauseData,
@@ -85,6 +85,10 @@ impl Interner for ChalkIr {
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
         tls::with_current_program(|prog| Some(prog?.debug_opaque_ty_id(id, fmt)))
+    }
+
+    fn debug_fn_def_id(id: FnDefId<Self>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
+        tls::with_current_program(|prog| Some(prog?.debug_fn_def_id(id, fmt)))
     }
 
     fn debug_alias(alias: &AliasTy<ChalkIr>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -485,31 +485,17 @@ impl RustIrDatabase<ChalkIr> for Program {
         substs.clone()
     }
 
-    fn trait_name(&self, trait_id: TraitId<ChalkIr>) -> String {
-        self.trait_kinds.get(&trait_id).unwrap().name.to_string()
-    }
-
-    fn adt_name(&self, struct_id: AdtId<ChalkIr>) -> String {
-        self.adt_kinds.get(&struct_id).unwrap().name.to_string()
-    }
-
+    // The default implementation for `RustIrDatabase::assoc_type_name` outputs
+    // the name in the format `(Trait::AssocTypeName)`, which is reformatted to
+    // `_Trait__AssocTypeName_`. This doesn't match the input names, which is
+    // normally acceptable, but causes the re-parse tests for the .chalk syntax
+    // writer to fail. This is because they use the `Eq` implementation on
+    // Program, which checks for name equality.
     fn assoc_type_name(&self, assoc_type_id: AssocTypeId<ChalkIr>) -> String {
         self.associated_ty_data
             .get(&assoc_type_id)
             .unwrap()
             .name
             .to_string()
-    }
-
-    fn opaque_type_name(&self, opaque_ty_id: OpaqueTyId<ChalkIr>) -> String {
-        self.opaque_ty_kinds
-            .get(&opaque_ty_id)
-            .unwrap()
-            .name
-            .to_string()
-    }
-
-    fn fn_def_name(&self, fn_def_id: FnDefId<ChalkIr>) -> String {
-        self.fn_def_kinds.get(&fn_def_id).unwrap().name.to_string()
     }
 }

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -139,7 +139,7 @@ impl tls::DebugContext for Program {
         if let Some(d) = self.associated_ty_data.get(&assoc_type_id) {
             write!(fmt, "({:?}::{})", d.trait_id, d.name)
         } else {
-            fmt.debug_struct("InvalidItemId")
+            fmt.debug_struct("InvalidAssocTypeId")
                 .field("index", &assoc_type_id.0)
                 .finish()
         }
@@ -153,8 +153,22 @@ impl tls::DebugContext for Program {
         if let Some(k) = self.opaque_ty_kinds.get(&opaque_ty_id) {
             write!(fmt, "{}", k.name)
         } else {
-            fmt.debug_struct("InvalidItemId")
+            fmt.debug_struct("InvalidOpaqueTyId")
                 .field("index", &opaque_ty_id.0)
+                .finish()
+        }
+    }
+
+    fn debug_fn_def_id(
+        &self,
+        fn_def_id: FnDefId<ChalkIr>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> Result<(), fmt::Error> {
+        if let Some(k) = self.fn_def_kinds.get(&fn_def_id) {
+            write!(fmt, "{}", k.name)
+        } else {
+            fmt.debug_struct("InvalidFnDefId")
+                .field("index", &fn_def_id.0)
                 .finish()
         }
     }

--- a/chalk-integration/src/tls.rs
+++ b/chalk-integration/src/tls.rs
@@ -1,7 +1,7 @@
 use crate::interner::ChalkIr;
 use chalk_ir::{
     debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, CanonicalVarKinds,
-    GenericArg, Goal, Goals, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause,
+    FnDefId, GenericArg, Goal, Goals, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause,
     ProgramClauseImplication, ProgramClauses, ProjectionTy, QuantifiedWhereClauses, Substitution,
     TraitId, Ty, VariableKinds,
 };
@@ -35,6 +35,12 @@ pub trait DebugContext {
     fn debug_opaque_ty_id(
         &self,
         id: OpaqueTyId<ChalkIr>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> Result<(), fmt::Error>;
+
+    fn debug_fn_def_id(
+        &self,
+        fn_def_id: FnDefId<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 

--- a/chalk-solve/src/display.rs
+++ b/chalk-solve/src/display.rs
@@ -22,6 +22,7 @@ mod ty;
 
 pub use self::render_trait::*;
 pub use self::state::*;
+pub use self::utils::sanitize_debug_name;
 
 use self::utils::as_display;
 

--- a/chalk-solve/src/display/utils.rs
+++ b/chalk-solve/src/display/utils.rs
@@ -47,8 +47,5 @@ pub fn sanitize_debug_name(func: impl Fn(&mut Formatter<'_>) -> Option<Result>) 
     }
 
     // now the actual sanitization
-    debug_out
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect()
+    debug_out.replace(|c: char| !c.is_ascii_alphanumeric(), "_")
 }

--- a/chalk-solve/src/display/utils.rs
+++ b/chalk-solve/src/display/utils.rs
@@ -23,3 +23,32 @@ macro_rules! write_joined_non_empty_list {
         }
     }};
 }
+
+/// Processes a name given by an [`Interner`][chalk_ir::Interner] debug
+/// method into something usable by the `display` module.
+///
+/// This is specifically useful when implementing
+/// [`RustIrDatabase`][crate::RustIrDatabase] `name_*` methods.
+pub fn sanitize_debug_name(func: impl Fn(&mut Formatter<'_>) -> Option<Result>) -> String {
+    use std::fmt::Write;
+
+    // First, write the debug method contents to a String.
+    let mut debug_out = String::new();
+    // ignore if the result is `None`, as we can just as easily tell by looking
+    // to see if anything was written to `debug_out`.
+    write!(
+        debug_out,
+        "{}",
+        as_display(|fmt| { func(fmt).unwrap_or(Ok(())) })
+    )
+    .expect("expected writing to a String to succeed");
+    if debug_out.is_empty() {
+        return "Unknown".to_owned();
+    }
+
+    // now the actual sanitization
+    debug_out
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -21,6 +21,25 @@ pub mod solve;
 pub mod split;
 pub mod wf;
 
+/// Trait representing access to a database of rust types.
+///
+/// # `*_name` methods
+///
+/// This trait has a number of `*_name` methods with default implementations.
+/// These are used in the implementation for [`LoggingRustIrDatabase`], so that
+/// when printing `.chalk` files equivalent to the data used, we can use real
+/// names.
+///
+/// The default implementations simply fall back to calling [`Interner`] debug
+/// methods, and printing `"UnknownN"` (where `N` is the demultiplexing integer)
+/// if those methods return `None`.
+///
+/// The [`display::sanitize_debug_name`] utility is used in the default
+/// implementations, and might be useful when providing custom implementations.
+///
+/// [`LoggingRustIrDatabase`]: crate::logging_db::LoggingRustIrDatabase
+/// [`display::sanitize_debug_name`]: crate::display::sanitize_debug_name
+/// [`Interner`]: Interner
 pub trait RustIrDatabase<I: Interner>: Debug {
     /// Returns any "custom program clauses" that do not derive from
     /// Rust IR. Used only in testing the underlying solver.
@@ -144,21 +163,35 @@ pub trait RustIrDatabase<I: Interner>: Debug {
         substs: &Substitution<I>,
     ) -> Substitution<I>;
 
-    /// Retrieves a trait's original name. No uniqueness guarantees.
-    /// TODO: remove this, use only interner debug methods
-    fn trait_name(&self, trait_id: TraitId<I>) -> String;
+    /// Retrieves a trait's original name. No uniqueness guarantees, but must
+    /// a valid Rust identifier.
+    fn trait_name(&self, trait_id: TraitId<I>) -> String {
+        crate::display::sanitize_debug_name(|f| I::debug_trait_id(trait_id, f))
+    }
 
-    /// Retrieves a struct's original name. No uniqueness guarantees.
-    fn adt_name(&self, struct_id: AdtId<I>) -> String;
+    /// Retrieves a struct's original name. No uniqueness guarantees, but must
+    /// a valid Rust identifier.
+    fn adt_name(&self, adt_id: AdtId<I>) -> String {
+        crate::display::sanitize_debug_name(|f| I::debug_adt_id(adt_id, f))
+    }
 
-    /// Retrieves the name of an associated type.
-    fn assoc_type_name(&self, assoc_ty_id: AssocTypeId<I>) -> String;
+    /// Retrieves the name of an associated type. No uniqueness guarantees, but must
+    /// a valid Rust identifier.
+    fn assoc_type_name(&self, assoc_ty_id: AssocTypeId<I>) -> String {
+        crate::display::sanitize_debug_name(|f| I::debug_assoc_type_id(assoc_ty_id, f))
+    }
 
-    /// Retrieves the name of an opaque type.
-    fn opaque_type_name(&self, opaque_ty_id: OpaqueTyId<I>) -> String;
+    /// Retrieves the name of an opaque type. No uniqueness guarantees, but must
+    /// a valid Rust identifier.
+    fn opaque_type_name(&self, opaque_ty_id: OpaqueTyId<I>) -> String {
+        crate::display::sanitize_debug_name(|f| I::debug_opaque_ty_id(opaque_ty_id, f))
+    }
 
-    /// Retrieves the name of a function definition
-    fn fn_def_name(&self, fn_def_id: FnDefId<I>) -> String;
+    /// Retrieves the name of a function definition. No uniqueness guarantees, but must
+    /// a valid Rust identifier.
+    fn fn_def_name(&self, fn_def_id: FnDefId<I>) -> String {
+        crate::display::sanitize_debug_name(|f| I::debug_fn_def_id(fn_def_id, f))
+    }
 }
 
 pub use clauses::program_clauses_for_env;

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(rust_2018_idioms)]
 
+use crate::display::sanitize_debug_name;
 use crate::rust_ir::*;
 use chalk_ir::interner::Interner;
 
@@ -166,31 +167,31 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// Retrieves a trait's original name. No uniqueness guarantees, but must
     /// a valid Rust identifier.
     fn trait_name(&self, trait_id: TraitId<I>) -> String {
-        crate::display::sanitize_debug_name(|f| I::debug_trait_id(trait_id, f))
+        sanitize_debug_name(|f| I::debug_trait_id(trait_id, f))
     }
 
     /// Retrieves a struct's original name. No uniqueness guarantees, but must
     /// a valid Rust identifier.
     fn adt_name(&self, adt_id: AdtId<I>) -> String {
-        crate::display::sanitize_debug_name(|f| I::debug_adt_id(adt_id, f))
+        sanitize_debug_name(|f| I::debug_adt_id(adt_id, f))
     }
 
     /// Retrieves the name of an associated type. No uniqueness guarantees, but must
     /// a valid Rust identifier.
     fn assoc_type_name(&self, assoc_ty_id: AssocTypeId<I>) -> String {
-        crate::display::sanitize_debug_name(|f| I::debug_assoc_type_id(assoc_ty_id, f))
+        sanitize_debug_name(|f| I::debug_assoc_type_id(assoc_ty_id, f))
     }
 
     /// Retrieves the name of an opaque type. No uniqueness guarantees, but must
     /// a valid Rust identifier.
     fn opaque_type_name(&self, opaque_ty_id: OpaqueTyId<I>) -> String {
-        crate::display::sanitize_debug_name(|f| I::debug_opaque_ty_id(opaque_ty_id, f))
+        sanitize_debug_name(|f| I::debug_opaque_ty_id(opaque_ty_id, f))
     }
 
     /// Retrieves the name of a function definition. No uniqueness guarantees, but must
     /// a valid Rust identifier.
     fn fn_def_name(&self, fn_def_id: FnDefId<I>) -> String {
-        crate::display::sanitize_debug_name(|f| I::debug_fn_def_id(fn_def_id, f))
+        sanitize_debug_name(|f| I::debug_fn_def_id(fn_def_id, f))
     }
 }
 

--- a/tests/integration/panic.rs
+++ b/tests/integration/panic.rs
@@ -225,26 +225,6 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
     ) -> Substitution<ChalkIr> {
         unimplemented!()
     }
-
-    fn trait_name(&self, trait_id: TraitId<ChalkIr>) -> String {
-        unimplemented!()
-    }
-
-    fn adt_name(&self, struct_id: AdtId<ChalkIr>) -> String {
-        unimplemented!()
-    }
-
-    fn assoc_type_name(&self, assoc_ty_id: AssocTypeId<ChalkIr>) -> String {
-        unimplemented!()
-    }
-
-    fn opaque_type_name(&self, opaque_ty_id: OpaqueTyId<ChalkIr>) -> String {
-        unimplemented!()
-    }
-
-    fn fn_def_name(&self, fn_def_id: FnDefId<ChalkIr>) -> String {
-        unimplemented!()
-    }
 }
 
 fn prepare_goal() -> UCanonical<InEnvironment<Goal<ChalkIr>>> {

--- a/tests/logging_db/util.rs
+++ b/tests/logging_db/util.rs
@@ -40,10 +40,10 @@ pub fn logging_db_output_sufficient(
 
         let program = db.program_ir().unwrap();
         let wrapped = LoggingRustIrDatabase::<_, Program, _>::new(program.clone());
-        for (goal_text, solver_choice, expected) in goals.clone() {
-            let mut solver: SolverImpl = solver_choice.into();
+        chalk_integration::tls::set_current_program(&program, || {
+            for (goal_text, solver_choice, expected) in goals.clone() {
+                let mut solver: SolverImpl = solver_choice.into();
 
-            chalk_integration::tls::set_current_program(&program, || {
                 println!("----------------------------------------------------------------------");
                 println!("---- first run on original test code ---------------------------------");
                 println!("goal {}", goal_text);
@@ -63,10 +63,10 @@ pub fn logging_db_output_sufficient(
                     }
                     _ => panic!("only aggregated test goals supported for logger goals"),
                 }
-            });
-        }
+            }
 
-        wrapped.to_string()
+            wrapped.to_string()
+        })
     };
 
     println!("----------------------------------------------------------------------");


### PR DESCRIPTION
This adds default implementations for `RustIrDatabase::*_name` methods. They use `Interner::debug_*` methods, and sanitize the output by replacing all non-alphanumeric-ascii chars with `_`.

This also removes all custom implementations of these methods, except the one for `Program::assoc_type_name`. We've kept that one, as the default impl ends up returning `_TraitName__AssocName_`, and for display tests, we need it to be exactly `AssocName`.

We've discussed the justification for this in [the .chalk file writer zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/.2Echalk.20file.20writer), and [the first .chalk file writer pull request](https://github.com/rust-lang/chalk/pull/430). But for anyone reading this, it boils down to the fact that we don't want an to impose an undue burden on `RustIrDatabase` implementors, especially for a debug tool. Rustc integration shouldn't have to accommodate `LoggingRustIrDatabase`.