### PR TITLE
Don't fail CI if only nightly fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
     strategy:
       matrix:
         rust: [stable, nightly]


### PR DESCRIPTION
This way the check using stable Rust will still run even if nightly fails. This is motivated by the ICE on nightly recently, which currently causes the stable check to halt.