### PR TITLE
Upgrade salsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,9 +512,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
+checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
 
 [[package]]
 name = "lock_api"
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
 ]
@@ -825,9 +825,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "salsa"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ca1c656054666a642affbbc86ab95ed7541125a89f032483d34ee56c0f5390"
+checksum = "885b4b99dde959decc84e85dd943bd140b4aabd62db2f8206ef5270f77ec20b9"
 dependencies = [
  "crossbeam-utils",
  "indexmap",
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "salsa-macros"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038a09b6271446f1123f142fe7e5bef6d4687c4cf82e6986be574c2af3745530"
+checksum = "2c280ac85b15ac214b86ac4b407626a48e6a1c4f90769a582fec74aa57942b9f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -943,9 +943,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
+checksum = "fb7f4c519df8c117855e19dd8cc851e89eb746fe7a73f0157e0d95fdec5369b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
+checksum = "dbdf4ccd1652592b01286a5dbe1e2a77d78afaa34beadd9872a5f7396f92aaa9"
 dependencies = [
  "cfg-if",
  "tracing-attributes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bench = []
 docopt = "1.1.0"
 itertools = "0.9.0"
 rustyline = "6.2.0"
-salsa = "0.14.0"
+salsa = "0.15.0"
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/chalk-integration/Cargo.toml
+++ b/chalk-integration/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 string_cache = "0.8.0"
-salsa = "0.14.0"
+salsa = "0.15.0"
 tracing = "0.1"
 
 chalk-derive = { version = "0.19.0-dev.0", path = "../chalk-derive" }

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -17,22 +17,16 @@ use chalk_solve::rust_ir::{
 };
 use chalk_solve::{RustIrDatabase, Solution, Solver, SubstitutionResult};
 use salsa::Database;
+use std::fmt;
 use std::sync::Arc;
 
 #[salsa::database(Lowering)]
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct ChalkDatabase {
-    runtime: salsa::Runtime<ChalkDatabase>,
+    storage: salsa::Storage<Self>,
 }
 
-impl Database for ChalkDatabase {
-    fn salsa_runtime(&self) -> &salsa::Runtime<ChalkDatabase> {
-        &self.runtime
-    }
-    fn salsa_runtime_mut(&mut self) -> &mut salsa::Runtime<ChalkDatabase> {
-        &mut self.runtime
-    }
-}
+impl Database for ChalkDatabase {}
 
 impl ChalkDatabase {
     pub fn with(program_text: &str, solver_choice: SolverChoice) -> Self {
@@ -220,5 +214,11 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
 
     fn fn_def_name(&self, fn_def_id: FnDefId<ChalkIr>) -> String {
         self.program_ir().unwrap().fn_def_name(fn_def_id)
+    }
+}
+
+impl fmt::Debug for ChalkDatabase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ChalkDatabase {{ }}")
     }
 }


### PR DESCRIPTION
The update was *mostly* painless, but there were a few queries where we needed to go from `LoweringDatabase` -> `RustIrDatabase` which posed a bit of an issue. This worked fine with generics, but now salsa passes a trait object to queries (and trait object upcasting isn't a thing yet) so I had to use a bit of a workaround.