### PR TITLE
Create single Github actions job to gate bors on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,23 @@ jobs:
 
       - name: Build Chalk book
         run: cd book && ./mdbook build
+
+  end-success:
+    name: bors build finished
+    if: success()
+    runs-on: ubuntu-latest
+    needs: [test, fmt, mdbook-linkcheck]
+
+    steps:
+      - name: Mark the job as successful
+        run: exit 0
+
+  end-failure:
+    name: bors build finished
+    if: "!success()"
+    runs-on: ubuntu-latest
+    needs: [test, fmt, mdbook-linkcheck]
+
+    steps:
+      - name: Mark the job as a failure
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
     name: bors build finished
     if: success()
     runs-on: ubuntu-latest
-    needs: [test, fmt, mdbook-linkcheck]
+    needs: [test, fmt]
 
     steps:
       - name: Mark the job as successful
@@ -126,7 +126,7 @@ jobs:
     name: bors build finished
     if: "!success()"
     runs-on: ubuntu-latest
-    needs: [test, fmt, mdbook-linkcheck]
+    needs: [test, fmt]
 
     steps:
       - name: Mark the job as a failure


### PR DESCRIPTION
This is a preliminary step for getting bors integrated into the chalk repo.