### PR TITLE
.chalk syntax writer: Fix name de-duplication bug

### DIFF
--- a/chalk-solve/src/display.rs
+++ b/chalk-solve/src/display.rs
@@ -25,7 +25,7 @@ pub use self::state::*;
 
 use self::utils::as_display;
 
-fn write_item<F, I, T>(f: &mut F, ws: &WriterState<'_, I>, v: &T) -> Result
+fn write_item<F, I, T>(f: &mut F, ws: &InternalWriterState<'_, I>, v: &T) -> Result
 where
     F: std::fmt::Write + ?Sized,
     I: Interner,
@@ -64,7 +64,7 @@ where
     DB: RustIrDatabase<I>,
     T: IntoIterator<Item = RecordedItemId<I>>,
 {
-    let ws = &WriterState::new(db);
+    let ws = &InternalWriterState::new(db);
     for id in ids {
         match id {
             RecordedItemId::Impl(id) => {
@@ -110,11 +110,11 @@ where
 ///
 /// Shared between the `Trait` in `dyn Trait` and [`OpaqueTyDatum`] bounds.
 fn display_self_where_clauses_as_bounds<'a, I: Interner>(
-    s: &'a WriterState<'a, I>,
+    s: &'a InternalWriterState<'a, I>,
     bounds: &'a [QuantifiedWhereClause<I>],
 ) -> impl Display + 'a {
     as_display(move |f| {
-        let interner = s.db.interner();
+        let interner = s.db().interner();
         write!(
             f,
             "{}",
@@ -143,7 +143,7 @@ fn display_self_where_clauses_as_bounds<'a, I: Interner>(
                             WhereClause::AliasEq(alias_eq) => match &alias_eq.alias {
                                 AliasTy::Projection(projection_ty) => {
                                     let (assoc_ty_datum, trait_params, assoc_type_params) =
-                                        s.db.split_projection(&projection_ty);
+                                        s.db().split_projection(&projection_ty);
                                     display_trait_with_assoc_ty_value(
                                         s,
                                         assoc_ty_datum,
@@ -171,7 +171,7 @@ fn display_self_where_clauses_as_bounds<'a, I: Interner>(
 ///
 /// This is shared between where bounds, OpaqueTy, & dyn Trait.
 fn display_type_with_generics<'a, I: Interner>(
-    s: &'a WriterState<'a, I>,
+    s: &'a InternalWriterState<'a, I>,
     trait_name: impl RenderAsRust<I> + 'a,
     trait_params: impl IntoIterator<Item = &'a GenericArg<I>> + 'a,
 ) -> impl Display + 'a {
@@ -187,7 +187,7 @@ fn display_type_with_generics<'a, I: Interner>(
 ///
 /// This is shared between where bounds & dyn Trait.
 fn display_trait_with_assoc_ty_value<'a, I: Interner>(
-    s: &'a WriterState<'a, I>,
+    s: &'a InternalWriterState<'a, I>,
     assoc_ty_datum: Arc<AssociatedTyDatum<I>>,
     trait_params: &'a [GenericArg<I>],
     assoc_ty_params: &'a [GenericArg<I>],

--- a/chalk-solve/src/display/bounds.rs
+++ b/chalk-solve/src/display/bounds.rs
@@ -9,12 +9,12 @@ use itertools::Itertools;
 
 use super::{
     display_trait_with_assoc_ty_value, display_type_with_generics, render_trait::RenderAsRust,
-    state::WriterState,
+    state::InternalWriterState,
 };
 use crate::split::Split;
 
 impl<I: Interner> RenderAsRust<I> for InlineBound<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         match self {
             // Foo: Vec<T>
             InlineBound::TraitBound(trait_bound) => trait_bound.fmt(s, f),
@@ -25,16 +25,16 @@ impl<I: Interner> RenderAsRust<I> for InlineBound<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for TraitBound<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         display_type_with_generics(s, self.trait_id, &self.args_no_self).fmt(f)
     }
 }
 
 impl<I: Interner> RenderAsRust<I> for AliasEqBound<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         display_trait_with_assoc_ty_value(
             s,
-            s.db.associated_ty_data(self.associated_ty_id),
+            s.db().associated_ty_data(self.associated_ty_id),
             &self.trait_bound.args_no_self,
             &self.parameters,
             &self.value,
@@ -44,8 +44,8 @@ impl<I: Interner> RenderAsRust<I> for AliasEqBound<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for QuantifiedWhereClause<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
-        let interner = s.db.interner();
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+        let interner = s.db().interner();
         let s = &s.add_debrujin_index(None);
         if !self.binders.is_empty(interner) {
             write!(
@@ -59,8 +59,8 @@ impl<I: Interner> RenderAsRust<I> for QuantifiedWhereClause<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for QuantifiedInlineBound<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
-        let interner = s.db.interner();
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+        let interner = s.db().interner();
         let s = &s.add_debrujin_index(None);
         if !self.binders.is_empty(&interner) {
             write!(
@@ -74,7 +74,7 @@ impl<I: Interner> RenderAsRust<I> for QuantifiedInlineBound<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for Vec<QuantifiedWhereClause<I>> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         write!(
             f,
             "{}",
@@ -87,7 +87,7 @@ impl<I: Interner> RenderAsRust<I> for Vec<QuantifiedWhereClause<I>> {
 }
 
 impl<I: Interner> RenderAsRust<I> for WhereClause<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         match self {
             WhereClause::Implemented(trait_ref) => trait_ref.fmt(s, f),
             WhereClause::AliasEq(alias_eq) => alias_eq.fmt(s, f),
@@ -100,8 +100,8 @@ impl<I: Interner> RenderAsRust<I> for WhereClause<I> {
 /// This renders `TraitRef` as a clause in a where clause, as opposed to its
 /// usage in other places.
 impl<I: Interner> RenderAsRust<I> for TraitRef<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
-        let interner = s.db.interner();
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+        let interner = s.db().interner();
         write!(
             f,
             "{}: {}",
@@ -118,7 +118,7 @@ impl<I: Interner> RenderAsRust<I> for TraitRef<I> {
 /// This renders `AliasEq` as a clause in a where clause, as opposed to its
 /// usage in other places.
 impl<I: Interner> RenderAsRust<I> for AliasEq<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         // we have: X: Y<A1, A2, A3, Z<B1, B2, B3>=D>
         // B1, B2, B3, X, A1, A2, A3 are put into alias_eq.alias.substitution
         // D is alias_eq.ty
@@ -131,7 +131,7 @@ impl<I: Interner> RenderAsRust<I> for AliasEq<I> {
         match &self.alias {
             AliasTy::Projection(projection_ty) => {
                 let (assoc_ty_datum, trait_params, assoc_type_params) =
-                    s.db.split_projection(&projection_ty);
+                    s.db().split_projection(&projection_ty);
                 // An alternate form might be `<{} as {}<{}>>::{}<{}> = {}` (with same
                 // parameter ordering). This alternate form would require type equality
                 // constraints (https://github.com/rust-lang/rust/issues/20041).
@@ -154,14 +154,14 @@ impl<I: Interner> RenderAsRust<I> for AliasEq<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for LifetimeOutlives<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &mut Formatter<'_>) -> Result {
         // a': 'b
         write!(f, "{}: {}", self.a.display(s), self.b.display(s))
     }
 }
 
 impl<I: Interner> RenderAsRust<I> for TypeOutlives<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &mut Formatter<'_>) -> Result {
         // T: 'a
         write!(f, "{}: {}", self.ty.display(s), self.lifetime.display(s))
     }

--- a/chalk-solve/src/display/identifiers.rs
+++ b/chalk-solve/src/display/identifiers.rs
@@ -7,40 +7,44 @@ use std::fmt::{Formatter, Result};
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
 
-use super::{render_trait::RenderAsRust, state::WriterState};
+use super::{render_trait::RenderAsRust, state::InternalWriterState};
 
 impl<I: Interner> RenderAsRust<I> for AdtId<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         // TODO: use debug methods?
         write!(
             f,
             "{}",
-            s.alias_for_adt_id_name(self.0, s.db.adt_name(*self))
+            s.alias_for_adt_id_name(self.0, s.db().adt_name(*self))
         )
     }
 }
 
 impl<I: Interner> RenderAsRust<I> for TraitId<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
-        // TODO: use debug methods?
-        write!(f, "{}", s.alias_for_id_name(self.0, s.db.trait_name(*self)))
-    }
-}
-
-impl<I: Interner> RenderAsRust<I> for AssocTypeId<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
-        // TODO: use debug methods?
-        f.write_str(&s.db.assoc_type_name(*self))
-    }
-}
-
-impl<I: Interner> RenderAsRust<I> for OpaqueTyId<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         // TODO: use debug methods?
         write!(
             f,
             "{}",
-            s.alias_for_id_name(self.0, s.db.opaque_type_name(*self))
+            s.alias_for_id_name(self.0, s.db().trait_name(*self))
+        )
+    }
+}
+
+impl<I: Interner> RenderAsRust<I> for AssocTypeId<I> {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+        // TODO: use debug methods?
+        f.write_str(&s.db().assoc_type_name(*self))
+    }
+}
+
+impl<I: Interner> RenderAsRust<I> for OpaqueTyId<I> {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+        // TODO: use debug methods?
+        write!(
+            f,
+            "{}",
+            s.alias_for_id_name(self.0, s.db().opaque_type_name(*self))
         )
     }
 }

--- a/chalk-solve/src/display/identifiers.rs
+++ b/chalk-solve/src/display/identifiers.rs
@@ -34,7 +34,11 @@ impl<I: Interner> RenderAsRust<I> for TraitId<I> {
 impl<I: Interner> RenderAsRust<I> for AssocTypeId<I> {
     fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         // TODO: use debug methods?
-        f.write_str(&s.db().assoc_type_name(*self))
+        write!(
+            f,
+            "{}",
+            s.alias_for_id_name(self.0, s.db().assoc_type_name(*self))
+        )
     }
 }
 

--- a/chalk-solve/src/display/items.rs
+++ b/chalk-solve/src/display/items.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 
 use super::{
     display_self_where_clauses_as_bounds, display_type_with_generics, render_trait::RenderAsRust,
-    state::WriterState,
+    state::InternalWriterState,
 };
 
 /// Used in `AdtDatum` and `TraitDatum` to write n flags from a flags struct
@@ -64,7 +64,7 @@ macro_rules! write_flags {
 }
 
 impl<I: Interner> RenderAsRust<I> for AdtDatum<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         // When support for Self in structs is added, self_binding should be
         // changed to Some(0)
         let s = &s.add_debrujin_index(None);
@@ -83,7 +83,7 @@ impl<I: Interner> RenderAsRust<I> for AdtDatum<I> {
         );
 
         // repr
-        let repr = s.db.adt_repr(self.id);
+        let repr = s.db().adt_repr(self.id);
 
         write_flags!(
             f,
@@ -150,7 +150,7 @@ impl<I: Interner> RenderAsRust<I> for AdtDatum<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for Polarity {
-    fn fmt(&self, _s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, _s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         if !self.is_positive() {
             write!(f, "!")?;
         }
@@ -159,7 +159,7 @@ impl<I: Interner> RenderAsRust<I> for Polarity {
 }
 
 impl<I: Interner> RenderAsRust<I> for TraitDatum<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         let s = &s.add_debrujin_index(Some(0));
         let value = self.binders.skip_binders();
 
@@ -178,7 +178,7 @@ impl<I: Interner> RenderAsRust<I> for TraitDatum<I> {
         );
 
         // object safe
-        if s.db.is_object_safe(self.id) {
+        if s.db().is_object_safe(self.id) {
             writeln!(f, "#[object_safe]")?;
         }
 
@@ -217,7 +217,7 @@ impl<I: Interner> RenderAsRust<I> for TraitDatum<I> {
             f,
             "\n{}\n",
             self.associated_ty_ids.iter().map(|assoc_ty_id| {
-                let assoc_ty_data = s.db.associated_ty_data(*assoc_ty_id);
+                let assoc_ty_data = s.db().associated_ty_data(*assoc_ty_id);
                 format!("{}{}", s.indent(), (*assoc_ty_data).display(s))
             }),
             "\n"
@@ -228,8 +228,8 @@ impl<I: Interner> RenderAsRust<I> for TraitDatum<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for ImplDatum<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
-        let interner = s.db.interner();
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+        let interner = s.db().interner();
 
         let s = &s.add_debrujin_index(None);
         let binders = s.binder_var_display(&self.binders.binders);
@@ -288,7 +288,8 @@ impl<I: Interner> RenderAsRust<I> for ImplDatum<I> {
         {
             let s = &s.add_indent();
             let assoc_ty_values = self.associated_ty_value_ids.iter().map(|assoc_ty_value| {
-                s.db.associated_ty_value(*assoc_ty_value)
+                s.db()
+                    .associated_ty_value(*assoc_ty_value)
                     .display(s)
                     .to_string()
             });
@@ -300,7 +301,7 @@ impl<I: Interner> RenderAsRust<I> for ImplDatum<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for OpaqueTyDatum<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &mut Formatter<'_>) -> Result {
         let s = &s.add_debrujin_index(None);
         let bounds = self.bound.skip_binders();
         write!(f, "opaque type {}", self.opaque_ty_id.display(s))?;
@@ -317,14 +318,14 @@ impl<I: Interner> RenderAsRust<I> for OpaqueTyDatum<I> {
         write!(
             f,
             "{};",
-            s.db.hidden_opaque_type(self.opaque_ty_id).display(s)
+            s.db().hidden_opaque_type(self.opaque_ty_id).display(s)
         )?;
         Ok(())
     }
 }
 
 impl<I: Interner> RenderAsRust<I> for AssociatedTyDatum<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         // In lowering, a completely new empty environment is created for each
         // AssociatedTyDatum, and it's given generic parameters for each generic
         // parameter that its trait had. We want to map the new binders for
@@ -333,7 +334,7 @@ impl<I: Interner> RenderAsRust<I> for AssociatedTyDatum<I> {
         // they have inside the AssociatedTyDatum (assoc_ty_names_for_trait_params),
         // and then add that mapping to the WriterState when writing bounds and
         // where clauses.
-        let trait_datum = s.db.trait_datum(self.trait_id);
+        let trait_datum = s.db().trait_datum(self.trait_id);
         // inverted Debrujin indices for the trait's parameters in the trait
         // environment
         let trait_param_names_in_trait_env = s.binder_var_indices(&trait_datum.binders.binders);
@@ -345,8 +346,9 @@ impl<I: Interner> RenderAsRust<I> for AssociatedTyDatum<I> {
             .collect::<Vec<_>>();
         // inverted Debrujin indices to render the trait's parameters in the
         // associated type environment
-        let (trait_param_names_in_assoc_ty_env, _) =
-            s.db.split_associated_ty_parameters(&param_names_in_assoc_ty_env, self);
+        let (trait_param_names_in_assoc_ty_env, _) = s
+            .db()
+            .split_associated_ty_parameters(&param_names_in_assoc_ty_env, self);
 
         let s = &s.add_parameter_mapping(
             trait_param_names_in_assoc_ty_env.iter().copied(),
@@ -359,8 +361,9 @@ impl<I: Interner> RenderAsRust<I> for AssociatedTyDatum<I> {
             .binder_var_display(&self.binders.binders)
             .collect::<Vec<_>>();
 
-        let (_, assoc_ty_params) =
-            s.db.split_associated_ty_parameters(&binder_display_in_assoc_ty, self);
+        let (_, assoc_ty_params) = s
+            .db()
+            .split_associated_ty_parameters(&binder_display_in_assoc_ty, self);
         write!(f, "type {}", self.id.display(s))?;
         write_joined_non_empty_list!(f, "<{}>", assoc_ty_params, ", ")?;
 
@@ -395,11 +398,11 @@ impl<I: Interner> RenderAsRust<I> for AssociatedTyDatum<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for AssociatedTyValue<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         // see comments for a similar empty env operation in AssociatedTyDatum's
         // impl of RenderAsRust.
-        let assoc_ty_data = s.db.associated_ty_data(self.associated_ty_id);
-        let impl_datum = s.db.impl_datum(self.impl_id);
+        let assoc_ty_data = s.db().associated_ty_data(self.associated_ty_id);
+        let impl_datum = s.db().impl_datum(self.impl_id);
 
         let impl_param_names_in_impl_env = s.binder_var_indices(&impl_datum.binders.binders);
 
@@ -410,8 +413,9 @@ impl<I: Interner> RenderAsRust<I> for AssociatedTyValue<I> {
             .binder_var_indices(&self.value.binders)
             .collect::<Vec<_>>();
 
-        let (impl_params_in_assoc_ty_value_env, _assoc_ty_value_params) =
-            s.db.split_associated_ty_value_parameters(&param_names_in_assoc_ty_value_env, self);
+        let (impl_params_in_assoc_ty_value_env, _assoc_ty_value_params) = s
+            .db()
+            .split_associated_ty_value_parameters(&param_names_in_assoc_ty_value_env, self);
 
         let s = &s.add_parameter_mapping(
             impl_params_in_assoc_ty_value_env.iter().cloned(),
@@ -422,8 +426,9 @@ impl<I: Interner> RenderAsRust<I> for AssociatedTyValue<I> {
             .binder_var_display(&self.value.binders)
             .collect::<Vec<_>>();
 
-        let (_impl_display, assoc_ty_value_display) =
-            s.db.split_associated_ty_value_parameters(&display_params, self);
+        let (_impl_display, assoc_ty_value_display) = s
+            .db()
+            .split_associated_ty_value_parameters(&display_params, self);
 
         write!(f, "{}type {}", s.indent(), assoc_ty_data.id.display(s))?;
         write_joined_non_empty_list!(f, "<{}>", &assoc_ty_value_display, ", ")?;
@@ -433,14 +438,14 @@ impl<I: Interner> RenderAsRust<I> for AssociatedTyValue<I> {
 }
 
 impl<I: Interner> RenderAsRust<I> for FnDefDatum<I> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &mut Formatter<'_>) -> Result {
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &mut Formatter<'_>) -> Result {
         let s = &s.add_debrujin_index(None);
         let bound_datum = self.binders.skip_binders();
 
         // declaration
         // fn foo<T>(arg: u32, arg2: T) -> Result<T> where T: Bar
         // ^^^^^^
-        write!(f, "fn {}", s.db.fn_def_name(self.id))?;
+        write!(f, "fn {}", s.db().fn_def_name(self.id))?;
 
         // binders
         // fn foo<T>(arg: u32, arg2: T) -> Result<T> where T: Bar

--- a/chalk-solve/src/display/render_trait.rs
+++ b/chalk-solve/src/display/render_trait.rs
@@ -8,7 +8,7 @@ use super::state::InternalWriterState;
 /// Displays `RenderAsRust` data.
 ///
 /// This is a utility struct for making `RenderAsRust` nice to use with rust format macros.
-pub struct DisplayRenderAsRust<'a, I: Interner, T> {
+pub(in crate::display) struct DisplayRenderAsRust<'a, I: Interner, T> {
     s: &'a InternalWriterState<'a, I>,
     rar: &'a T,
 }
@@ -19,7 +19,7 @@ impl<I: Interner, T: RenderAsRust<I>> Display for DisplayRenderAsRust<'_, I, T> 
     }
 }
 
-pub trait RenderAsRust<I: Interner> {
+pub(in crate::display) trait RenderAsRust<I: Interner> {
     fn fmt(&self, s: &InternalWriterState<'_, I>, f: &mut Formatter<'_>) -> Result;
     fn display<'a>(&'a self, s: &'a InternalWriterState<'a, I>) -> DisplayRenderAsRust<'a, I, Self>
     where

--- a/chalk-solve/src/display/render_trait.rs
+++ b/chalk-solve/src/display/render_trait.rs
@@ -3,13 +3,13 @@ use std::fmt::{Display, Formatter, Result};
 
 use chalk_ir::interner::Interner;
 
-use super::state::WriterState;
+use super::state::InternalWriterState;
 
 /// Displays `RenderAsRust` data.
 ///
 /// This is a utility struct for making `RenderAsRust` nice to use with rust format macros.
 pub struct DisplayRenderAsRust<'a, I: Interner, T> {
-    s: &'a WriterState<'a, I>,
+    s: &'a InternalWriterState<'a, I>,
     rar: &'a T,
 }
 
@@ -20,8 +20,8 @@ impl<I: Interner, T: RenderAsRust<I>> Display for DisplayRenderAsRust<'_, I, T> 
 }
 
 pub trait RenderAsRust<I: Interner> {
-    fn fmt(&self, s: &WriterState<'_, I>, f: &mut Formatter<'_>) -> Result;
-    fn display<'a>(&'a self, s: &'a WriterState<'a, I>) -> DisplayRenderAsRust<'a, I, Self>
+    fn fmt(&self, s: &InternalWriterState<'_, I>, f: &mut Formatter<'_>) -> Result;
+    fn display<'a>(&'a self, s: &'a InternalWriterState<'a, I>) -> DisplayRenderAsRust<'a, I, Self>
     where
         Self: Sized,
     {

--- a/chalk-solve/src/display/state.rs
+++ b/chalk-solve/src/display/state.rs
@@ -148,12 +148,14 @@ where
     ///
     /// `f` will be run on the internal database, and the returned result will
     /// wrap the result from `f`. For consistency, `f` should always contain the
-    /// given database, and must keep the same ID<->item relationships.  
+    /// given database, and must keep the same ID<->item relationships.
     pub(super) fn wrap_db_ref<'a, DB2: ?Sized, P2, F>(&'a self, f: F) -> WriterState<I, DB2, P2>
     where
-        P: 'a,
         DB2: RustIrDatabase<I>,
         P2: Borrow<DB2>,
+        // We need to pass in `&'a P` specifically to guarantee that the `&P`
+        // can outlive the function body, and thus that it's safe to store `&P`
+        // in `P2`.
         F: FnOnce(&'a P) -> P2,
     {
         WriterState {

--- a/chalk-solve/src/display/state.rs
+++ b/chalk-solve/src/display/state.rs
@@ -1,11 +1,13 @@
 //! Persistent state passed down between writers.
 //!
-//! This is essentially `WriterState` and other things supporting that.
+//! This is essentially `InternalWriterState` and other things supporting that.
 use std::{
-    cell::RefCell,
+    borrow::Borrow,
     collections::BTreeMap,
-    fmt::{Display, Formatter, Result},
+    fmt::{Debug, Display, Formatter, Result},
+    marker::PhantomData,
     rc::Rc,
+    sync::{Arc, Mutex},
 };
 
 use crate::RustIrDatabase;
@@ -34,8 +36,14 @@ impl Display for InvertedBoundVar {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum UnifiedId<I: Interner> {
+    AdtId(I::InternedAdtId),
+    DefId(I::DefId),
+}
+
 #[derive(Debug)]
-pub struct DefIdAliases<T: Ord> {
+pub struct IdAliasStore<T: Ord> {
     /// Map from the DefIds we've encountered to a u32 alias id unique to all ids
     /// the same name.
     aliases: BTreeMap<T, u32>,
@@ -43,16 +51,16 @@ pub struct DefIdAliases<T: Ord> {
     next_unused_for_name: BTreeMap<String, u32>,
 }
 
-impl<T: Ord> Default for DefIdAliases<T> {
+impl<T: Ord> Default for IdAliasStore<T> {
     fn default() -> Self {
-        DefIdAliases {
+        IdAliasStore {
             aliases: BTreeMap::default(),
             next_unused_for_name: BTreeMap::default(),
         }
     }
 }
 
-impl<T: Copy + Ord> DefIdAliases<T> {
+impl<T: Copy + Ord> IdAliasStore<T> {
     fn alias_for_id_name(&mut self, id: T, name: String) -> String {
         let next_unused_for_name = &mut self.next_unused_for_name;
         let alias = *self.aliases.entry(id).or_insert_with(|| {
@@ -71,35 +79,130 @@ impl<T: Copy + Ord> DefIdAliases<T> {
     }
 }
 
+#[derive(Debug)]
+struct IdAliases<I: Interner> {
+    id_aliases: IdAliasStore<UnifiedId<I>>,
+}
+
+impl<I: Interner> Default for IdAliases<I> {
+    fn default() -> Self {
+        IdAliases {
+            id_aliases: IdAliasStore::default(),
+        }
+    }
+}
+
+/// Writer state which persists across multiple writes.
+///
+/// Currently, this means keeping track of what IDs have been given what names,
+/// including deduplication information.
+///
+/// This data is stored using interior mutability - clones will point to the same underlying
+/// data.
+///
+/// Uses a separate type, `P`, for the database stored inside to account for
+/// `Arc` or wrapping other storage mediums.
+#[derive(Debug)]
+pub struct WriterState<I, DB: ?Sized, P = DB>
+where
+    DB: RustIrDatabase<I>,
+    P: Borrow<DB>,
+    I: Interner,
+{
+    pub(super) db: P,
+    id_aliases: Arc<Mutex<IdAliases<I>>>,
+    _phantom: PhantomData<DB>,
+}
+
+impl<I, DB: ?Sized, P> Clone for WriterState<I, DB, P>
+where
+    DB: RustIrDatabase<I>,
+    P: Borrow<DB> + Clone,
+    I: Interner,
+{
+    fn clone(&self) -> Self {
+        WriterState {
+            db: self.db.clone(),
+            id_aliases: self.id_aliases.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, DB: ?Sized, P> WriterState<I, DB, P>
+where
+    DB: RustIrDatabase<I>,
+    P: Borrow<DB>,
+    I: Interner,
+{
+    pub fn new(db: P) -> Self {
+        WriterState {
+            db,
+            id_aliases: Arc::new(Mutex::new(IdAliases::default())),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Returns a new version of self containing a wrapped database which
+    /// references the outer data.
+    ///
+    /// `f` will be run on the internal database, and the returned result will
+    /// wrap the result from `f`. For consistency, `f` should always contain the
+    /// given database, and must keep the same ID<->item relationships.  
+    pub(super) fn wrap_db_ref<'a, DB2: ?Sized, P2, F>(&'a self, f: F) -> WriterState<I, DB2, P2>
+    where
+        P: 'a,
+        DB2: RustIrDatabase<I>,
+        P2: Borrow<DB2>,
+        F: FnOnce(&'a P) -> P2,
+    {
+        WriterState {
+            db: f(&self.db),
+            id_aliases: self.id_aliases.clone(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub(crate) fn db(&self) -> &DB {
+        self.db.borrow()
+    }
+}
+
+/// Writer state for a single write call, persistent only as long as necessary
+/// to write a single item.
+///
+/// Stores things necessary for .
 #[derive(Clone, Debug)]
-pub struct InternalWriterState<'a, I: Interner> {
-    db: &'a dyn RustIrDatabase<I>,
+pub(super) struct InternalWriterState<'a, I: Interner> {
+    persistent_state: WriterState<I, dyn RustIrDatabase<I> + 'a, &'a dyn RustIrDatabase<I>>,
     indent_level: usize,
     debrujin_indices_deep: u32,
     // lowered_(inverted_debrujin_idx, index) -> src_correct_(inverted_debrujin_idx, index)
     remapping: Rc<BTreeMap<InvertedBoundVar, InvertedBoundVar>>,
     // the inverted_bound_var which maps to "Self"
     self_mapping: Option<InvertedBoundVar>,
-    def_id_aliases: Rc<RefCell<DefIdAliases<I::DefId>>>,
-    adt_id_aliases: Rc<RefCell<DefIdAliases<I::InternedAdtId>>>,
 }
 
 type IndexWithinBinding = usize;
+
 impl<'a, I: Interner> InternalWriterState<'a, I> {
-    pub fn new(db: &'a dyn RustIrDatabase<I>) -> Self {
+    pub fn new<DB, P>(persistent_state: &'a WriterState<I, DB, P>) -> Self
+    where
+        DB: RustIrDatabase<I>,
+        P: Borrow<DB>,
+    {
         InternalWriterState {
-            db,
+            persistent_state: persistent_state
+                .wrap_db_ref(|db| db.borrow() as &dyn RustIrDatabase<I>),
             indent_level: 0,
             debrujin_indices_deep: 0,
             remapping: Rc::new(BTreeMap::new()),
             self_mapping: None,
-            def_id_aliases: Default::default(),
-            adt_id_aliases: Default::default(),
         }
     }
 
-    pub(super) fn db(&self) -> &'a dyn RustIrDatabase<I> {
-        self.db
+    pub(super) fn db(&self) -> &dyn RustIrDatabase<I> {
+        self.persistent_state.db
     }
 
     pub(super) fn add_indent(&self) -> Self {
@@ -113,12 +216,22 @@ impl<'a, I: Interner> InternalWriterState<'a, I> {
         std::iter::repeat("  ").take(self.indent_level).format("")
     }
 
-    pub(super) fn alias_for_id_name(&self, id: I::DefId, name: String) -> impl Display {
-        self.def_id_aliases.borrow_mut().alias_for_id_name(id, name)
+    pub(super) fn alias_for_adt_id_name(&self, id: I::InternedAdtId, name: String) -> impl Display {
+        self.persistent_state
+            .id_aliases
+            .lock()
+            .unwrap()
+            .id_aliases
+            .alias_for_id_name(UnifiedId::AdtId(id), name)
     }
 
-    pub(super) fn alias_for_adt_id_name(&self, id: I::InternedAdtId, name: String) -> impl Display {
-        self.adt_id_aliases.borrow_mut().alias_for_id_name(id, name)
+    pub(super) fn alias_for_id_name(&self, id: I::DefId, name: String) -> impl Display {
+        self.persistent_state
+            .id_aliases
+            .lock()
+            .unwrap()
+            .id_aliases
+            .alias_for_id_name(UnifiedId::DefId(id), name)
     }
 
     /// Adds a level of debrujin index, and possibly a "Self" parameter.

--- a/chalk-solve/src/logging_db.rs
+++ b/chalk-solve/src/logging_db.rs
@@ -372,9 +372,7 @@ where
         parameters: &[chalk_ir::GenericArg<I>],
         binders: &CanonicalVarKinds<I>,
     ) -> Vec<ImplId<I>> {
-        self.db
-            .borrow()
-            .impls_for_trait(trait_id, parameters, binders)
+        self.db.impls_for_trait(trait_id, parameters, binders)
     }
 
     fn local_impls_to_coherence_check(&self, trait_id: TraitId<I>) -> Vec<ImplId<I>> {
@@ -441,9 +439,7 @@ where
         closure_id: ClosureId<I>,
         substs: &Substitution<I>,
     ) -> Binders<FnDefInputsAndOutputDatum<I>> {
-        self.db
-            .borrow()
-            .closure_inputs_and_output(closure_id, substs)
+        self.db.closure_inputs_and_output(closure_id, substs)
     }
 
     fn closure_upvars(&self, closure_id: ClosureId<I>, substs: &Substitution<I>) -> Binders<Ty<I>> {

--- a/tests/display/mod.rs
+++ b/tests/display/mod.rs
@@ -14,6 +14,7 @@ mod opaque_ty;
 mod self_;
 mod struct_;
 mod trait_;
+mod unique_names;
 mod where_clauses;
 
 use self::util::*;

--- a/tests/display/unique_names.rs
+++ b/tests/display/unique_names.rs
@@ -1,0 +1,291 @@
+use chalk_integration::{program::Program, query::LoweringDatabase, tls};
+use chalk_ir::interner::Interner;
+use chalk_solve::{
+    display::{write_items, WriterState},
+    RustIrDatabase,
+};
+use std::marker::PhantomData;
+
+use super::util::{program_item_ids, ReparseTestResult};
+
+/// `DuplicateNamesDb` implements `RustIrDatabase`, and returns `Foo` for all
+/// requested item names. This allows us to test that names are correctly
+/// de-duplicated by the display code.
+#[derive(Debug)]
+struct DuplicateNamesDb<'a, I, DB>
+where
+    I: Interner,
+    DB: RustIrDatabase<I>,
+{
+    db: &'a DB,
+    _phantom: PhantomData<I>,
+}
+
+impl<'a, I, DB> DuplicateNamesDb<'a, I, DB>
+where
+    I: Interner,
+    DB: RustIrDatabase<I>,
+{
+    fn new(db: &'a DB) -> Self {
+        DuplicateNamesDb {
+            db,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, I, DB> RustIrDatabase<I> for DuplicateNamesDb<'a, I, DB>
+where
+    I: Interner,
+    DB: RustIrDatabase<I>,
+{
+    fn trait_name(&self, _trait_id: chalk_ir::TraitId<I>) -> String {
+        "Foo".to_owned()
+    }
+    fn adt_name(&self, _adt_id: chalk_ir::AdtId<I>) -> String {
+        "Foo".to_owned()
+    }
+    fn assoc_type_name(&self, _assoc_ty_id: chalk_ir::AssocTypeId<I>) -> String {
+        "Foo".to_owned()
+    }
+    fn opaque_type_name(&self, _opaque_ty_id: chalk_ir::OpaqueTyId<I>) -> String {
+        "Foo".to_owned()
+    }
+    fn fn_def_name(&self, _fn_def_id: chalk_ir::FnDefId<I>) -> String {
+        "Foo".to_owned()
+    }
+    fn custom_clauses(&self) -> Vec<chalk_ir::ProgramClause<I>> {
+        self.db.custom_clauses()
+    }
+    fn associated_ty_data(
+        &self,
+        ty: chalk_ir::AssocTypeId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::AssociatedTyDatum<I>> {
+        self.db.associated_ty_data(ty)
+    }
+    fn trait_datum(
+        &self,
+        trait_id: chalk_ir::TraitId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::TraitDatum<I>> {
+        self.db.trait_datum(trait_id)
+    }
+    fn adt_datum(
+        &self,
+        adt_id: chalk_ir::AdtId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::AdtDatum<I>> {
+        self.db.adt_datum(adt_id)
+    }
+    fn adt_repr(&self, id: chalk_ir::AdtId<I>) -> chalk_solve::rust_ir::AdtRepr {
+        self.db.adt_repr(id)
+    }
+    fn fn_def_datum(
+        &self,
+        fn_def_id: chalk_ir::FnDefId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::FnDefDatum<I>> {
+        self.db.fn_def_datum(fn_def_id)
+    }
+    fn impl_datum(
+        &self,
+        impl_id: chalk_ir::ImplId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::ImplDatum<I>> {
+        self.db.impl_datum(impl_id)
+    }
+    fn associated_ty_value(
+        &self,
+        id: chalk_solve::rust_ir::AssociatedTyValueId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::AssociatedTyValue<I>> {
+        self.db.associated_ty_value(id)
+    }
+    fn opaque_ty_data(
+        &self,
+        id: chalk_ir::OpaqueTyId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::OpaqueTyDatum<I>> {
+        self.db.opaque_ty_data(id)
+    }
+    fn hidden_opaque_type(&self, id: chalk_ir::OpaqueTyId<I>) -> chalk_ir::Ty<I> {
+        self.db.hidden_opaque_type(id)
+    }
+    fn impls_for_trait(
+        &self,
+        trait_id: chalk_ir::TraitId<I>,
+        parameters: &[chalk_ir::GenericArg<I>],
+        binders: &chalk_ir::CanonicalVarKinds<I>,
+    ) -> Vec<chalk_ir::ImplId<I>> {
+        self.db.impls_for_trait(trait_id, parameters, binders)
+    }
+    fn local_impls_to_coherence_check(
+        &self,
+        trait_id: chalk_ir::TraitId<I>,
+    ) -> Vec<chalk_ir::ImplId<I>> {
+        self.db.local_impls_to_coherence_check(trait_id)
+    }
+    fn impl_provided_for(
+        &self,
+        auto_trait_id: chalk_ir::TraitId<I>,
+        adt_id: chalk_ir::AdtId<I>,
+    ) -> bool {
+        self.db.impl_provided_for(auto_trait_id, adt_id)
+    }
+    fn well_known_trait_id(
+        &self,
+        well_known_trait: chalk_solve::rust_ir::WellKnownTrait,
+    ) -> Option<chalk_ir::TraitId<I>> {
+        self.db.well_known_trait_id(well_known_trait)
+    }
+    fn program_clauses_for_env(
+        &self,
+        environment: &chalk_ir::Environment<I>,
+    ) -> chalk_ir::ProgramClauses<I> {
+        self.db.program_clauses_for_env(environment)
+    }
+    fn interner(&self) -> &I {
+        self.db.interner()
+    }
+    fn is_object_safe(&self, trait_id: chalk_ir::TraitId<I>) -> bool {
+        self.db.is_object_safe(trait_id)
+    }
+    fn closure_kind(
+        &self,
+        closure_id: chalk_ir::ClosureId<I>,
+        substs: &chalk_ir::Substitution<I>,
+    ) -> chalk_solve::rust_ir::ClosureKind {
+        self.db.closure_kind(closure_id, substs)
+    }
+    fn closure_inputs_and_output(
+        &self,
+        closure_id: chalk_ir::ClosureId<I>,
+        substs: &chalk_ir::Substitution<I>,
+    ) -> chalk_ir::Binders<chalk_solve::rust_ir::FnDefInputsAndOutputDatum<I>> {
+        self.db.closure_inputs_and_output(closure_id, substs)
+    }
+    fn closure_upvars(
+        &self,
+        closure_id: chalk_ir::ClosureId<I>,
+        substs: &chalk_ir::Substitution<I>,
+    ) -> chalk_ir::Binders<chalk_ir::Ty<I>> {
+        self.db.closure_upvars(closure_id, substs)
+    }
+    fn closure_fn_substitution(
+        &self,
+        closure_id: chalk_ir::ClosureId<I>,
+        substs: &chalk_ir::Substitution<I>,
+    ) -> chalk_ir::Substitution<I> {
+        self.db.closure_fn_substitution(closure_id, substs)
+    }
+}
+
+/// Writes the given program with all names duplicated and then deduplicated by
+/// display code.
+///
+/// This additionally tests to ensure that duplicated names are deduplicated
+/// across `write_items` calls, by making one write_items call per item.
+pub fn write_program_duplicated_names(db: &Program) -> String {
+    let mut out = String::new();
+    let ids = program_item_ids(db);
+    let db = DuplicateNamesDb::new(db);
+    let ws = WriterState::new(db);
+    // Test that names are preserved between write_items calls
+    for id in ids {
+        write_items(&mut out, &ws, std::iter::once(id)).unwrap();
+    }
+    out
+}
+
+/// Tests that a given source file can function given a database which always
+/// returns the same name for all variables.
+///
+/// Only checks that the resulting program parses, not that it matches any
+/// particular format. Use returned data to perform further checks.
+pub fn run_reparse_with_duplicate_names<'a>(program_text: &'a str) -> ReparseTestResult<'a> {
+    let original_db = chalk_integration::db::ChalkDatabase::with(program_text, <_>::default());
+    let original_program = original_db.program_ir().unwrap_or_else(|e| {
+        panic!(
+            "unable to lower test program:\n{}\nSource:\n{}\n",
+            e, program_text
+        )
+    });
+    let output_text = tls::set_current_program(&original_program, || {
+        write_program_duplicated_names(&*original_program)
+    });
+    let output_db = chalk_integration::db::ChalkDatabase::with(&output_text, <_>::default());
+    let output_program = output_db.program_ir().unwrap_or_else(|e| {
+        panic!(
+            "error lowering writer output:\n{}\nNew source:\n{}\n",
+            e, output_text
+        )
+    });
+    eprintln!("\nTest Succeeded:\n\n{}\n---", output_text);
+    ReparseTestResult {
+        original_text: program_text,
+        output_text,
+        target_text: "",
+        original_program: original_program.clone(),
+        output_program,
+        target_program: original_program,
+    }
+}
+
+/// Performs a test on chalk's `display` code to render programs as `.chalk` files.
+macro_rules! reparse_with_duplicated_names {
+    (program $program:tt) => {
+        run_reparse_with_duplicate_names(crate::display::util::strip_leading_trailing_braces(
+            stringify!($program),
+        ))
+    };
+}
+
+#[test]
+fn lots_of_structs() {
+    reparse_with_duplicated_names! {
+        program {
+            struct A {}
+            struct B {}
+            struct C {}
+            struct D {}
+        }
+    };
+}
+#[test]
+fn lots_of_traits() {
+    reparse_with_duplicated_names! {
+        program {
+            trait A {}
+            trait B {}
+            trait C {}
+            trait D {}
+        }
+    };
+}
+#[test]
+fn traits_and_structs() {
+    reparse_with_duplicated_names! {
+        program {
+            trait A {}
+            struct B {}
+            trait C {}
+            struct D {}
+        }
+    };
+}
+#[test]
+fn assoc_types() {
+    reparse_with_duplicated_names! {
+        program {
+            trait A {
+                type A;
+                type A;
+                type C;
+                type D;
+            }
+            trait B {
+                type A;
+                type B;
+                type C;
+                type D;
+            }
+            struct Test<T> where T: B {
+                field: <T as B>::C,
+            }
+        }
+    };
+}

--- a/tests/display/where_clauses.rs
+++ b/tests/display/where_clauses.rs
@@ -118,10 +118,10 @@ fn test_generic_vars_inside_assoc_bounds() {
         program {
             struct Foo { }
             trait Bar<T, U> {
-                type Assoc;
+                type Quz;
             }
             trait Baz<U> {
-                type Assoc<T>: Bar<T, U, Assoc=Foo>;
+                type Zuq<T>: Bar<T, U, Quz=Foo>;
             }
         }
     );


### PR DESCRIPTION
While working on https://github.com/rust-lang/chalk/pull/575, we found a bug in the name de-duplication logic. To ensure we have unique names, we store a mapping between ids and names for ids that don't have unique names. This state was managed inside of `write_items`, but we call `write_items` twice when we output the data from the `LoggingRustIrDatabase`. It is called once to output the logged items, and once to output the necessary stub items. The id to name mappings are lost between these calls, which breaks the unique name guarantee.

We fixed this by creating the mapping information store outside of the display code, and passing it into calls to `write_items`. We also significantly improved the name de-duplication tests. 