### PR TITLE
Implement generators

### DIFF
--- a/book/src/types/rust_types.md
+++ b/book/src/types/rust_types.md
@@ -132,24 +132,6 @@ because of the above subtyping rules there are actually a range of
 values that `V` could have and still be equal with `F`. This may
 or may not be something to consider revisiting.
 
-### Generator witness types
-
-The `GeneratorWitness` variant wraps a `GeneratorWitness` type.  These
-witnesses represent the types that may be part of a generator
-state. Unlike other types, witnesses include bound, existential
-lifetimes, which refer to lifetimes within the suspended stack frame.
-You can think of it as a type like `exists<'a> { (T...) }`.
-
-Witnesses are very similar to an `Apply` type, but it has a binder for
-the erased lifetime(s), which must be handled specifically in equating
-and so forth. In many ways, witnesses are also quite similar to `Fn`
-types, and it is not out of the question that these two could be
-unified; however, they are quite distinct semantically and so that
-would be an annoying mismatch in other parts of the system.
-Witnesses are also similar to a `Dyn` type, in that they represent an
-existential type, but in contrast to `Dyn`, what we know here is
-not a *predicate* but rather some upper bound on the set of types
-contained within.
 
 ### Alias types
 

--- a/book/src/types/rust_types/application_ty.md
+++ b/book/src/types/rust_types/application_ty.md
@@ -48,7 +48,10 @@ the generator with id `GeneratorId`.
 
 The generator witness contains multiple witness types,
 which represent the types that may be part of a generator
-state. Unlike other types, witnesses include bound, existential
+state - that is, the types of all variables that may be live across
+a `yield` point.
+
+Unlike other types, witnesses include bound, existential
 lifetimes, which refer to lifetimes within the suspended stack frame.
 You can think of it as a type like `exists<'a> { (T...) }`.
 

--- a/book/src/types/rust_types/application_ty.md
+++ b/book/src/types/rust_types/application_ty.md
@@ -22,5 +22,47 @@ _)`) or "fixed-length array" `[_; _]`. Note that the precise set of
 these built-in types is defined by the `Interner` and is unknown to
 chalk-ir.
 
+## [`TypeName`] variants
+
+### Generator
+
+A `Generator` represents a Rust generator. There are three major components
+to a generator:
+
+* Upvars - similar to closure upvars, they reference values outside of the generator,
+  and are stored across al yield points.
+* Resume/yield/return types - the types produced/consumed by various generator methods.
+  These are not stored in the generator across yield points - they are only
+  used when the generator is running.
+* Generator witness - see the `Generator Witness` section below.
+
+Of these types, only upvars and resume/yield/return are stored directly in
+`TypeName::Generator`. The generator witness is implicitly associated with the generator
+by virtue of sharing the same `GeneratorId`. It is only used when determining auto trait
+impls, where it is considered a 'constituent type'.
+
+### Generator witness types
+
+The `GeneratorWitness` variant represents the generator witness of
+the generator with id `GeneratorId`. 
+
+The generator witness contains multiple witness types,
+which represent the types that may be part of a generator
+state. Unlike other types, witnesses include bound, existential
+lifetimes, which refer to lifetimes within the suspended stack frame.
+You can think of it as a type like `exists<'a> { (T...) }`.
+
+Witnesses are very similar to an `Apply` type, but it has a binder for
+the erased lifetime(s), which must be handled specifically in equating
+and so forth. In many ways, witnesses are also quite similar to `Fn`
+types, and it is not out of the question that these two could be
+unified; however, they are quite distinct semantically and so that
+would be an annoying mismatch in other parts of the system.
+Witnesses are also similar to a `Dyn` type, in that they represent an
+existential type, but in contrast to `Dyn`, what we know here is
+not a *predicate* but rather some upper bound on the set of types
+contained within.
+
+
 [`TypeName`]: http://rust-lang.github.io/chalk/chalk_ir/enum.TypeName.html
 [`Substitution`]: http://rust-lang.github.io/chalk/chalk_ir/struct.Substitution.html

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -8,12 +8,13 @@ use crate::{
 };
 use chalk_ir::{
     AdtId, ApplicationTy, AssocTypeId, Binders, Canonical, CanonicalVarKinds, ClosureId,
-    ConstrainedSubst, Environment, FnDefId, GenericArg, Goal, ImplId, InEnvironment, OpaqueTyId,
-    ProgramClause, ProgramClauses, Substitution, TraitId, Ty, UCanonical,
+    ConstrainedSubst, Environment, FnDefId, GeneratorId, GenericArg, Goal, ImplId, InEnvironment,
+    OpaqueTyId, ProgramClause, ProgramClauses, Substitution, TraitId, Ty, UCanonical,
 };
 use chalk_solve::rust_ir::{
     AdtDatum, AdtRepr, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ClosureKind,
-    FnDefDatum, FnDefInputsAndOutputDatum, ImplDatum, OpaqueTyDatum, TraitDatum, WellKnownTrait,
+    FnDefDatum, FnDefInputsAndOutputDatum, GeneratorDatum, GeneratorWitnessDatum, ImplDatum,
+    OpaqueTyDatum, TraitDatum, WellKnownTrait,
 };
 use chalk_solve::{RustIrDatabase, Solution, SubstitutionResult};
 use salsa::Database;
@@ -104,6 +105,17 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
 
     fn adt_datum(&self, id: AdtId<ChalkIr>) -> Arc<AdtDatum<ChalkIr>> {
         self.program_ir().unwrap().adt_datum(id)
+    }
+
+    fn generator_datum(&self, id: GeneratorId<ChalkIr>) -> Arc<GeneratorDatum<ChalkIr>> {
+        self.program_ir().unwrap().generator_datum(id)
+    }
+
+    fn generator_witness_datum(
+        &self,
+        id: GeneratorId<ChalkIr>,
+    ) -> Arc<GeneratorWitnessDatum<ChalkIr>> {
+        self.program_ir().unwrap().generator_witness_datum(id)
     }
 
     fn adt_repr(&self, id: AdtId<ChalkIr>) -> AdtRepr {

--- a/chalk-integration/src/lib.rs
+++ b/chalk-integration/src/lib.rs
@@ -27,6 +27,7 @@ pub enum TypeSort {
     Closure,
     Trait,
     Opaque,
+    Generator,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -709,6 +709,9 @@ impl LowerWithEnv for Ty {
                     TypeLookup::Opaque(id) => {
                         (chalk_ir::TypeName::OpaqueType(id), env.opaque_kind(id))
                     }
+                    TypeLookup::Generator(id) => {
+                        (chalk_ir::TypeName::Generator(id), env.generator_kind(id))
+                    }
 
                     TypeLookup::Foreign(_) | TypeLookup::Trait(_) => {
                         panic!("Unexpected apply type")
@@ -1070,6 +1073,8 @@ pub fn lower_goal(goal: &Goal, program: &LoweredProgram) -> LowerResult<chalk_ir
         closure_ids: &program.closure_ids,
         trait_ids: &program.trait_ids,
         opaque_ty_ids: &program.opaque_ty_ids,
+        generator_ids: &program.generator_ids,
+        generator_kinds: &program.generator_kinds,
         adt_kinds: &program.adt_kinds,
         fn_def_kinds: &program.fn_def_kinds,
         closure_kinds: &program.closure_kinds,

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -4,14 +4,14 @@ use chalk_ir::could_match::CouldMatch;
 use chalk_ir::debug::Angle;
 use chalk_ir::{
     debug::SeparatorTraitRef, AdtId, AliasTy, ApplicationTy, AssocTypeId, Binders,
-    CanonicalVarKinds, ClosureId, FnDefId, ForeignDefId, GenericArg, Goal, Goals, ImplId, Lifetime,
-    OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication, ProgramClauses, ProjectionTy,
-    Substitution, TraitId, Ty, TyData,
+    CanonicalVarKinds, ClosureId, FnDefId, ForeignDefId, GeneratorId, GenericArg, Goal, Goals,
+    ImplId, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause, ProgramClauseImplication,
+    ProgramClauses, ProjectionTy, Substitution, TraitId, Ty, TyData,
 };
 use chalk_solve::rust_ir::{
     AdtDatum, AdtRepr, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ClosureKind,
-    FnDefDatum, FnDefInputsAndOutputDatum, ImplDatum, ImplType, OpaqueTyDatum, TraitDatum,
-    WellKnownTrait,
+    FnDefDatum, FnDefInputsAndOutputDatum, GeneratorDatum, GeneratorWitnessDatum, ImplDatum,
+    ImplType, OpaqueTyDatum, TraitDatum, WellKnownTrait,
 };
 use chalk_solve::split::Split;
 use chalk_solve::RustIrDatabase;
@@ -36,6 +36,15 @@ pub struct Program {
     pub closure_upvars: BTreeMap<ClosureId<ChalkIr>, Binders<Ty<ChalkIr>>>,
 
     pub closure_kinds: BTreeMap<ClosureId<ChalkIr>, TypeKind>,
+
+    /// For each generator
+    pub generator_ids: BTreeMap<Identifier, GeneratorId<ChalkIr>>,
+
+    pub generator_kinds: BTreeMap<GeneratorId<ChalkIr>, TypeKind>,
+
+    pub generator_data: BTreeMap<GeneratorId<ChalkIr>, Arc<GeneratorDatum<ChalkIr>>>,
+
+    pub generator_witness_data: BTreeMap<GeneratorId<ChalkIr>, Arc<GeneratorWitnessDatum<ChalkIr>>>,
 
     /// From trait name to item-id. Used during lowering only.
     pub trait_ids: BTreeMap<Identifier, TraitId<ChalkIr>>,
@@ -378,6 +387,17 @@ impl RustIrDatabase<ChalkIr> for Program {
 
     fn adt_datum(&self, id: AdtId<ChalkIr>) -> Arc<AdtDatum<ChalkIr>> {
         self.adt_data[&id].clone()
+    }
+
+    fn generator_datum(&self, id: GeneratorId<ChalkIr>) -> Arc<GeneratorDatum<ChalkIr>> {
+        self.generator_data[&id].clone()
+    }
+
+    fn generator_witness_datum(
+        &self,
+        id: GeneratorId<ChalkIr>,
+    ) -> Arc<GeneratorWitnessDatum<ChalkIr>> {
+        self.generator_witness_data[&id].clone()
     }
 
     fn adt_repr(&self, id: AdtId<ChalkIr>) -> AdtRepr {

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -315,6 +315,15 @@ where
     }
 }
 
+impl<I> CastTo<TypeName<I>> for GeneratorId<I>
+where
+    I: Interner,
+{
+    fn cast_to(self, _interner: &I) -> TypeName<I> {
+        TypeName::Generator(self)
+    }
+}
+
 impl<I> CastTo<TypeName<I>> for FnDefId<I>
 where
     I: Interner,

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -35,6 +35,13 @@ impl<I: Interner> Debug for ClosureId<I> {
     }
 }
 
+impl<I: Interner> Debug for GeneratorId<I> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        I::debug_generator_id(*self, fmt)
+            .unwrap_or_else(|| write!(fmt, "GeneratorId({:?})", self.0))
+    }
+}
+
 impl<I: Interner> Debug for ForeignDefId<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
         I::debug_foreign_def_id(*self, fmt)
@@ -205,6 +212,8 @@ impl<I: Interner> Debug for TypeName<I> {
             TypeName::Never => write!(fmt, "Never"),
             TypeName::Array => write!(fmt, "{{array}}"),
             TypeName::Closure(id) => write!(fmt, "{{closure:{:?}}}", id),
+            TypeName::Generator(generator) => write!(fmt, "{:?}", generator),
+            TypeName::GeneratorWitness(witness) => write!(fmt, "{:?}", witness),
             TypeName::Foreign(foreign_ty) => write!(fmt, "{:?}", foreign_ty),
             TypeName::Error => write!(fmt, "{{error}}"),
         }

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -303,6 +303,7 @@ id_fold!(AssocTypeId);
 id_fold!(OpaqueTyId);
 id_fold!(FnDefId);
 id_fold!(ClosureId);
+id_fold!(GeneratorId);
 id_fold!(ForeignDefId);
 
 impl<I: Interner, TI: TargetInterner<I>> SuperFold<I, TI> for ProgramClauseData<I> {

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -10,6 +10,7 @@ use crate::Constraint;
 use crate::Constraints;
 use crate::FnDefId;
 use crate::ForeignDefId;
+use crate::GeneratorId;
 use crate::GenericArg;
 use crate::GenericArgData;
 use crate::Goal;
@@ -258,6 +259,21 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Prints the debug representation of an alias.
     /// Returns `None` to fallback to the default debug output.
+    #[allow(unused_variables)]
+    fn debug_generator_id(
+        generator_id: GeneratorId<Self>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> Option<fmt::Result> {
+        None
+    }
+
+    /// Prints the debug representation of an alias. To get good
+    /// results, this requires inspecting TLS, and is difficult to
+    /// code without reference to a specific interner (and hence
+    /// fully known types).
+    ///
+    /// Returns `None` to fallback to the default debug output (e.g.,
+    /// if no info about current program is available from TLS).
     #[allow(unused_variables)]
     fn debug_alias(alias: &AliasTy<Self>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
         None

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -254,6 +254,12 @@ pub enum TypeName<I: Interner> {
     /// A closure.
     Closure(ClosureId<I>),
 
+    /// A generator.
+    Generator(GeneratorId<I>),
+
+    /// A generator witness.
+    GeneratorWitness(GeneratorId<I>),
+
     /// foreign types
     Foreign(ForeignDefId<I>),
 
@@ -365,6 +371,10 @@ pub struct FnDefId<I: Interner>(pub I::DefId);
 /// Id for Rust closures.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClosureId<I: Interner>(pub I::DefId);
+
+/// Id for Rust generators.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GeneratorId<I: Interner>(pub I::DefId);
 
 /// Id for foreign types.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     AdtId, AssocTypeId, ClausePriority, ClosureId, Constraints, DebruijnIndex, FloatTy, FnDefId,
-    ForeignDefId, GenericArg, Goals, ImplId, IntTy, Interner, Mutability, OpaqueTyId,
+    ForeignDefId, GeneratorId, GenericArg, Goals, ImplId, IntTy, Interner, Mutability, OpaqueTyId,
     PlaceholderIndex, ProgramClause, ProgramClauses, QuantifiedWhereClauses, QuantifierKind,
     Safety, Scalar, Substitution, SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult,
     Visitor,
@@ -240,6 +240,7 @@ id_visit!(OpaqueTyId);
 id_visit!(AssocTypeId);
 id_visit!(FnDefId);
 id_visit!(ClosureId);
+id_visit!(GeneratorId);
 id_visit!(ForeignDefId);
 
 impl<I: Interner> SuperVisit<I> for ProgramClause<I> {

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -25,6 +25,7 @@ pub enum Item {
     ClosureDefn(ClosureDefn),
     TraitDefn(TraitDefn),
     OpaqueTyDefn(OpaqueTyDefn),
+    GeneratorDefn(GeneratorDefn),
     Impl(Impl),
     Clause(Clause),
     Foreign(ForeignDefn),
@@ -47,6 +48,18 @@ pub struct AdtDefn {
 pub struct Variant {
     pub name: Identifier,
     pub fields: Vec<Field>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct GeneratorDefn {
+    pub name: Identifier,
+    pub variable_kinds: Vec<VariableKind>,
+    pub upvars: Vec<Ty>,
+    pub resume_ty: Ty,
+    pub yield_ty: Ty,
+    pub return_ty: Ty,
+    pub witness_types: Vec<Ty>,
+    pub witness_lifetimes: Vec<Identifier>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -18,6 +18,7 @@ Item: Option<Item> = {
     ClosureDefn => Some(Item::ClosureDefn(<>)),
     TraitDefn => Some(Item::TraitDefn(<>)),
     OpaqueTyDefn => Some(Item::OpaqueTyDefn(<>)),
+    GeneratorDefn => Some(Item::GeneratorDefn(<>)),
     Impl => Some(Item::Impl(<>)),
     Clause => Some(Item::Clause(<>)),
     ForeignType => Some(Item::Foreign(<>)),
@@ -162,6 +163,23 @@ FnDefn: FnDefn = {
         return_type: ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() }),
     }
 };
+
+GeneratorDefn: GeneratorDefn = {
+    "generator" <n:Id> <p:Angle<VariableKind>> "[" "resume" "=" <resume:Ty> "," "yield" "=" <yield_ty:Ty> "]" <ret_ty:FnReturn?>
+    "{"
+       "upvars" "[" <upvars:SemiColon<Ty>> "]"
+       "witnesses" <l:ForLifetimes?> "[" <witnesses:SemiColon<Ty>> "]"
+    "}" => GeneratorDefn {
+       name: n,
+       variable_kinds: p,
+       upvars: upvars,
+       witness_lifetimes: l.unwrap_or_default(),
+       resume_ty: resume,
+       yield_ty: yield_ty,
+       return_ty: ret_ty.unwrap_or_else(|| Ty::Tuple { types: Vec::new() }),
+       witness_types: witnesses
+   }
+}
 
 FnAbi: FnAbi = "extern" "\"" <id:Id> "\"" => FnAbi(id.str);
 

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -168,7 +168,7 @@ GeneratorDefn: GeneratorDefn = {
     "generator" <n:Id> <p:Angle<VariableKind>> "[" "resume" "=" <resume:Ty> "," "yield" "=" <yield_ty:Ty> "]" <ret_ty:FnReturn?>
     "{"
        "upvars" "[" <upvars:SemiColon<Ty>> "]"
-       "witnesses" <l:ForLifetimes?> "[" <witnesses:SemiColon<Ty>> "]"
+       "witnesses" <l:ExistsLifetimes?> "[" <witnesses:SemiColon<Ty>> "]"
     "}" => GeneratorDefn {
        name: n,
        variable_kinds: p,
@@ -391,6 +391,7 @@ TyWithoutId: Ty = {
     "[" <t:Ty> ";" <len:Const> "]" => Ty::Array { ty: Box::new(t), len },
 };
 
+ExistsLifetimes: Vec<Identifier> = "exists" "<" <Comma<LifetimeId>> ">" => <>;
 ForLifetimes: Vec<Identifier> = "for" "<" <Comma<LifetimeId>> ">" => <>;
 
 ScalarType: ScalarType = {

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -1,6 +1,7 @@
 use self::builder::ClauseBuilder;
 use self::env_elaborator::elaborate_env_clauses;
 use self::program_clauses::ToProgramClauses;
+use crate::goal_builder::GoalBuilder;
 use crate::split::Split;
 use crate::RustIrDatabase;
 use chalk_ir::cast::{Cast, Caster};
@@ -53,7 +54,27 @@ fn constituent_types<I: Interner>(
             .cloned()
             .collect(),
 
+        TypeName::Generator(generator_id) => {
+            let generator_datum = &db.generator_datum(generator_id);
+            let generator_datum_bound = generator_datum
+                .input_output
+                .substitute(interner, &app_ty.substitution);
+
+            let mut tys = generator_datum_bound.upvars;
+            tys.push(
+                ApplicationTy {
+                    name: TypeName::GeneratorWitness(generator_id),
+                    substitution: app_ty.substitution.clone(),
+                }
+                .intern(interner),
+            );
+            tys
+        }
+
         TypeName::Closure(_) => panic!("this function should not be called for closures"),
+        TypeName::GeneratorWitness(_) => {
+            panic!("this function should not be called for generator witnesses")
+        }
         TypeName::Foreign(_) => panic!("constituent_types of foreign types are unknown!"),
         TypeName::Error => Vec::new(),
         TypeName::OpaqueType(_) => unimplemented!(),
@@ -142,6 +163,10 @@ pub fn push_auto_trait_impls<I: Interner>(
             });
         }
 
+        TypeName::GeneratorWitness(generator_id) => {
+            push_auto_trait_impls_generator_witness(builder, auto_trait_id, generator_id);
+        }
+
         // app_ty implements AutoTrait if all constituents of app_ty implement AutoTrait
         _ => {
             let conditions = constituent_types(builder.db, app_ty)
@@ -210,6 +235,89 @@ pub fn push_auto_trait_impls_opaque<I: Interner>(
             }),
         );
     });
+}
+
+#[instrument(level = "debug", skip(builder))]
+pub fn push_auto_trait_impls_generator_witness<I: Interner>(
+    builder: &mut ClauseBuilder<'_, I>,
+    auto_trait_id: TraitId<I>,
+    generator_id: GeneratorId<I>,
+) {
+    let witness_datum = builder.db.generator_witness_datum(generator_id);
+    let interner = builder.interner();
+
+    // Must be an auto trait.
+    assert!(builder.db.trait_datum(auto_trait_id).is_auto_trait());
+
+    // Auto traits never have generic parameters of their own (apart from `Self`).
+    assert_eq!(
+        builder.db.trait_datum(auto_trait_id).binders.len(interner),
+        1
+    );
+
+    // Push binders for the generator generic parameters. These can be used by
+    // both upvars and witness types
+    builder.push_binders(&witness_datum.inner_types, |builder, inner_types| {
+        let witness_ty = ApplicationTy {
+            name: TypeName::GeneratorWitness(generator_id),
+            substitution: builder.substitution_in_scope(),
+        }
+        .intern(interner);
+
+        // trait_ref = `GeneratorWitness<...>: MyAutoTrait`
+        let auto_trait_ref = TraitRef {
+            trait_id: auto_trait_id,
+            substitution: Substitution::from1(interner, witness_ty),
+        };
+
+        // Create a goal of the form:
+        // forall<L0, L1, ..., LN> {
+        //     WitnessType1<L0, L1, ... LN, P0, P1, ..., PN>: MyAutoTrait,
+        //     ...
+        //     WitnessTypeN<L0, L1, ... LN, P0, P1, ..., PN>: MyAutoTrait,
+        //
+        // }
+        //
+        // where `L0, L1, ...LN` are our existentially bound witness lifetimes,
+        // and `P0, P1, ..., PN` are the normal generator generics.
+        //
+        // We create a 'forall' goal due to the fact that our witness lifetimes
+        // are *existentially* quantified - the precise reigon is erased during
+        // type checking, so we just know that the type takes *some* region
+        // as a parameter. Therefore, we require that the auto trait bound
+        // hold for *all* regions, which guarantees that the bound will
+        // hold for the original lifetime (before it was erased).
+        //
+        // This does not take into account well-formed information from
+        // the witness types. For example, if we have the type
+        // `struct Foo<'a, 'b> { val: &'a &'b u8 }`
+        // then `'b: 'a` must hold for `Foo<'a, 'b>` to be well-formed.
+        // If we have `Foo<'a, 'b>` stored as a witness type, we will
+        // not currently use this information to determine a more precise
+        // relationship between 'a and 'b. In the future, we will likely
+        // do this to avoid incorrectly rejecting correct code.
+        let gb = &mut GoalBuilder::new(builder.db);
+        let witness_goal = gb.forall(
+            &inner_types.types,
+            auto_trait_id,
+            |gb, _subst, types, auto_trait_id| {
+                Goal::new(
+                    gb.interner(),
+                    GoalData::All(Goals::from_iter(
+                        gb.interner(),
+                        types.iter().map(|witness_ty| TraitRef {
+                            trait_id: auto_trait_id,
+                            substitution: Substitution::from1(gb.interner(), witness_ty.clone()),
+                        }),
+                    )),
+                )
+            },
+        );
+
+        // GeneratorWitnessType: AutoTrait :- forall<...> ...
+        // where 'forall<...> ...' is the goal described above.
+        builder.push_clause(auto_trait_ref, std::iter::once(witness_goal));
+    })
 }
 
 /// Given some goal `goal` that must be proven, along with
@@ -689,7 +797,9 @@ fn match_type_name<I: Interner>(
         | TypeName::Array
         | TypeName::Never
         | TypeName::Closure(_)
-        | TypeName::Foreign(_) => {
+        | TypeName::Foreign(_)
+        | TypeName::Generator(_)
+        | TypeName::GeneratorWitness(_) => {
             builder.push_fact(WellFormed::Ty(application.clone().intern(interner)))
         }
     }

--- a/chalk-solve/src/clauses/builtin_traits/copy.rs
+++ b/chalk-solve/src/clauses/builtin_traits/copy.rs
@@ -76,6 +76,8 @@ pub fn add_copy_program_clauses<I: Interner>(
             | TypeName::Slice
             | TypeName::OpaqueType(_)
             | TypeName::Foreign(_)
+            | TypeName::Generator(_)
+            | TypeName::GeneratorWitness(_)
             | TypeName::Error => {}
         },
 

--- a/chalk-solve/src/clauses/builtin_traits/sized.rs
+++ b/chalk-solve/src/clauses/builtin_traits/sized.rs
@@ -87,6 +87,8 @@ pub fn add_sized_program_clauses<I: Interner>(
             | TypeName::FnDef(_)
             | TypeName::Scalar(_)
             | TypeName::Raw(_)
+            | TypeName::Generator(_)
+            | TypeName::GeneratorWitness(_)
             | TypeName::Ref(_) => builder.push_fact(trait_ref.clone()),
 
             TypeName::AssociatedType(_)

--- a/chalk-solve/src/display.rs
+++ b/chalk-solve/src/display.rs
@@ -92,6 +92,11 @@ where
                 let v = ws.db().fn_def_datum(id);
                 write_item(f, &InternalWriterState::new(ws), &*v)?;
             }
+            RecordedItemId::Generator(id) => {
+                let generator = ws.db().generator_datum(id);
+                let witness = ws.db().generator_witness_datum(id);
+                write_item(f, &InternalWriterState::new(ws), &(&*generator, &*witness))?;
+            }
         }
     }
     Ok(())

--- a/chalk-solve/src/display/items.rs
+++ b/chalk-solve/src/display/items.rs
@@ -63,6 +63,12 @@ macro_rules! write_flags {
     };
 }
 
+impl<'a, I: Interner> RenderAsRust<I> for (&'a GeneratorDatum<I>, &'a GeneratorWitnessDatum<I>) {
+    fn fmt(&self, _s: &InternalWriterState<'_, I>, _f: &'_ mut Formatter<'_>) -> Result {
+        unimplemented!()
+    }
+}
+
 impl<I: Interner> RenderAsRust<I> for AdtDatum<I> {
     fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         // When support for Self in structs is added, self_binding should be

--- a/chalk-solve/src/display/stub.rs
+++ b/chalk-solve/src/display/stub.rs
@@ -2,6 +2,7 @@
 //! queried.
 use std::sync::Arc;
 
+use crate::rust_ir::{GeneratorDatum, GeneratorWitnessDatum};
 use crate::{
     rust_ir::{
         AdtDatumBound, AdtKind, AdtVariantDatum, AssociatedTyDatumBound, FnDefDatumBound,
@@ -10,7 +11,8 @@ use crate::{
     RustIrDatabase,
 };
 use chalk_ir::{
-    interner::Interner, ApplicationTy, Binders, CanonicalVarKinds, TypeName, VariableKinds,
+    interner::Interner, ApplicationTy, Binders, CanonicalVarKinds, GeneratorId, TypeName,
+    VariableKinds,
 };
 
 #[derive(Debug)]
@@ -207,6 +209,17 @@ impl<I: Interner, DB: RustIrDatabase<I>> RustIrDatabase<I> for StubWrapper<'_, D
         _substs: &chalk_ir::Substitution<I>,
     ) -> chalk_ir::Binders<chalk_ir::Ty<I>> {
         unimplemented!("cannot stub closures")
+    }
+
+    fn generator_datum(&self, _generator_id: GeneratorId<I>) -> Arc<GeneratorDatum<I>> {
+        unimplemented!("cannot stub generator")
+    }
+
+    fn generator_witness_datum(
+        &self,
+        _generator_id: GeneratorId<I>,
+    ) -> Arc<GeneratorWitnessDatum<I>> {
+        unimplemented!("cannot stub generator witness")
     }
 
     fn closure_fn_substitution(

--- a/chalk-solve/src/display/ty.rs
+++ b/chalk-solve/src/display/ty.rs
@@ -218,6 +218,8 @@ impl<I: Interner> RenderAsRust<I> for ApplicationTy<I> {
             TypeName::FnDef(_) => write!(f, "<fn_def>")?,
             TypeName::Closure(..) => write!(f, "<closure>")?,
             TypeName::Foreign(_) => write!(f, "<foreign>")?,
+            TypeName::Generator(..) => write!(f, "<generator>")?,
+            TypeName::GeneratorWitness(..) => write!(f, "<generator_witness>")?,
 
             TypeName::Array => write!(
                 f,

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -55,6 +55,15 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// Returns the datum for the ADT with the given id.
     fn adt_datum(&self, adt_id: AdtId<I>) -> Arc<AdtDatum<I>>;
 
+    /// Returns the generator datum for the generator with the given id.
+    fn generator_datum(&self, generator_id: GeneratorId<I>) -> Arc<GeneratorDatum<I>>;
+
+    /// Returns the generator witness datum for the generator with the given id.
+    fn generator_witness_datum(
+        &self,
+        generator_id: GeneratorId<I>,
+    ) -> Arc<GeneratorWitnessDatum<I>>;
+
     /// Returns the representation for the ADT definition with the given id.
     fn adt_repr(&self, id: AdtId<I>) -> AdtRepr;
 

--- a/chalk-solve/src/logging_db.rs
+++ b/chalk-solve/src/logging_db.rs
@@ -120,6 +120,19 @@ where
         self.ws.db().adt_datum(adt_id)
     }
 
+    fn generator_datum(&self, generator_id: GeneratorId<I>) -> Arc<GeneratorDatum<I>> {
+        self.record(generator_id);
+        self.ws.db().borrow().generator_datum(generator_id)
+    }
+
+    fn generator_witness_datum(
+        &self,
+        generator_id: GeneratorId<I>,
+    ) -> Arc<GeneratorWitnessDatum<I>> {
+        self.record(generator_id);
+        self.ws.db().borrow().generator_witness_datum(generator_id)
+    }
+
     fn adt_repr(&self, id: AdtId<I>) -> AdtRepr {
         self.record(id);
         self.ws.db().adt_repr(id)
@@ -345,6 +358,18 @@ where
         self.db.adt_datum(adt_id)
     }
 
+    fn generator_datum(&self, generator_id: GeneratorId<I>) -> Arc<GeneratorDatum<I>> {
+        self.db.borrow().generator_datum(generator_id)
+    }
+
+    /// Returns the generator witness datum for the generator with the given id.
+    fn generator_witness_datum(
+        &self,
+        generator_id: GeneratorId<I>,
+    ) -> Arc<GeneratorWitnessDatum<I>> {
+        self.db.borrow().generator_witness_datum(generator_id)
+    }
+
     fn adt_repr(&self, id: AdtId<I>) -> AdtRepr {
         self.db.adt_repr(id)
     }
@@ -464,6 +489,7 @@ pub enum RecordedItemId<I: Interner> {
     Impl(ImplId<I>),
     OpaqueTy(OpaqueTyId<I>),
     FnDef(FnDefId<I>),
+    Generator(GeneratorId<I>),
 }
 
 impl<I: Interner> From<AdtId<I>> for RecordedItemId<I> {
@@ -496,6 +522,12 @@ impl<I: Interner> From<FnDefId<I>> for RecordedItemId<I> {
     }
 }
 
+impl<I: Interner> From<GeneratorId<I>> for RecordedItemId<I> {
+    fn from(v: GeneratorId<I>) -> Self {
+        RecordedItemId::Generator(v)
+    }
+}
+
 /// Utility for implementing Ord for RecordedItemId.
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 enum OrderedItemId<'a, DefId, AdtId> {
@@ -512,6 +544,7 @@ impl<I: Interner> RecordedItemId<I> {
             RecordedItemId::Trait(TraitId(x))
             | RecordedItemId::Impl(ImplId(x))
             | RecordedItemId::OpaqueTy(OpaqueTyId(x))
+            | RecordedItemId::Generator(GeneratorId(x))
             | RecordedItemId::FnDef(FnDefId(x)) => OrderedItemId::DefId(x),
             RecordedItemId::Adt(AdtId(x)) => OrderedItemId::AdtId(x),
         }

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -53,6 +53,7 @@ pub fn collect_unrecorded_ids<'i, I: Interner, DB: RustIrDatabase<I>>(
                     .fn_def_datum(fn_def)
                     .visit_with(&mut collector, DebruijnIndex::INNERMOST);
             }
+            RecordedItemId::Generator(_generator_id) => unimplemented!(),
             RecordedItemId::Trait(trait_id) => {
                 let trait_datum = collector.db.trait_datum(trait_id);
 

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -653,6 +653,68 @@ pub struct OpaqueTyDatumBound<I: Interner> {
     pub where_clauses: Binders<Vec<QuantifiedWhereClause<I>>>,
 }
 
+/// Represents a generator type.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+pub struct GeneratorDatum<I: Interner> {
+    /// All of the nested types for this generator. The `Binder`
+    /// represents the types and lifetimes that this generator is generic over -
+    /// this behaves in the same way as `AdtDatun.binders`
+    pub input_output: Binders<GeneratorInputOutputDatum<I>>,
+}
+
+/// The nested types for a generator. This always appears inside a `GeneratorDatum`
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+pub struct GeneratorInputOutputDatum<I: Interner> {
+    /// The generator resume type - a value of this type
+    /// is supplied by the caller when resuming the generator.
+    /// Currently, this plays no rule in goal resolution.
+    pub resume_type: Ty<I>,
+    /// The generator yield type - a value of this type
+    /// is supplied by the generator during a yield.
+    /// Currently, this plays no role in goal resolution.
+    pub yield_type: Ty<I>,
+    /// The generator return type - a value of this type
+    /// is supplied by the generator when it returns.
+    /// Currently, this plays no role in goal resolution
+    pub return_type: Ty<I>,
+    /// The upvars stored by the generator. These represent
+    /// types captured from the generator's environment,
+    /// and are stored across all yields. These types (along with the witness types)
+    /// are considered 'constituent types' for the purposes of determining auto trait
+    /// implementations - that its, a generator impls an auto trait A
+    /// iff all of its constituent types implement A.
+    pub upvars: Vec<Ty<I>>,
+}
+
+/// The generator witness data. Each `GeneratorId` has both a `GeneratorDatum`
+/// and a `GeneratorWitnessDatum` - these represent two distinct types in Rust.
+/// `GeneratorWitnessDatum` is logically 'inside' a generator - this only
+/// matters when we treat the witness type as a 'constituent type for the
+/// purposes of determining auto trait implementations.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+pub struct GeneratorWitnessDatum<I: Interner> {
+    /// This binder is identical to the `input_output` binder in `GeneratorWitness` -
+    /// it binds the types and lifetimes that the generator is generic over.
+    /// There is an additional binder inside `GeneratorWitnessExistential`, which
+    /// is treated specially.
+    pub inner_types: Binders<GeneratorWitnessExistential<I>>,
+}
+
+/// The generator witness types, together with existentially bound lifetimes.
+/// Each 'witness type' represents a type stored inside the generator across
+/// a yield. When a generator type is constructed, the precise region relationships
+/// found in the generator body are erased. As a result, we are left with existential
+/// lifetimes - each type is parameterized over *some* lifetimes, but we do not
+/// know their precise values.
+///
+/// Unlike the binder in `GeneratorWitnessDatum`, this `Binder` never gets substituted
+/// via an `ApplicationTy`. Instead, we handle this `Binders` specially when determining
+/// auto trait impls. See `push_auto_trait_impls_generator_witness` for more details.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+pub struct GeneratorWitnessExistential<I: Interner> {
+    pub types: Binders<Vec<Ty<I>>>,
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 pub enum Polarity {
     Positive,

--- a/tests/display/unique_names.rs
+++ b/tests/display/unique_names.rs
@@ -96,6 +96,18 @@ where
     ) -> std::sync::Arc<chalk_solve::rust_ir::AssociatedTyValue<I>> {
         self.db.associated_ty_value(id)
     }
+    fn generator_datum(
+        &self,
+        generator_id: chalk_ir::GeneratorId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::GeneratorDatum<I>> {
+        self.db.generator_datum(generator_id)
+    }
+    fn generator_witness_datum(
+        &self,
+        generator_id: chalk_ir::GeneratorId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::GeneratorWitnessDatum<I>> {
+        self.db.generator_witness_datum(generator_id)
+    }
     fn opaque_ty_data(
         &self,
         id: chalk_ir::OpaqueTyId<I>,

--- a/tests/integration/panic.rs
+++ b/tests/integration/panic.rs
@@ -154,6 +154,17 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
         unimplemented!()
     }
 
+    fn generator_datum(&self, generator_id: GeneratorId<ChalkIr>) -> Arc<GeneratorDatum<ChalkIr>> {
+        unimplemented!()
+    }
+
+    fn generator_witness_datum(
+        &self,
+        generator_id: GeneratorId<ChalkIr>,
+    ) -> Arc<GeneratorWitnessDatum<ChalkIr>> {
+        unimplemented!()
+    }
+
     // All `Bar` impls
     fn impls_for_trait(
         &self,

--- a/tests/test/generators.rs
+++ b/tests/test/generators.rs
@@ -24,12 +24,12 @@ fn generator_test() {
 
             generator upvar_lifetime_restrict<T>[resume = (), yield = ()] {
                 upvars [T; StructOne]
-                witnesses for<'a, 'b> [SendSameLifetime<'a, 'b, T>]
+                witnesses exists<'a, 'b> [SendSameLifetime<'a, 'b, T>]
             }
 
             generator send_any_lifetime<T>[resume = (), yield = ()] {
                 upvars []
-                witnesses for<'a, 'b> [SendAnyLifetime<'a, 'b, T>; u8]
+                witnesses exists<'a, 'b> [SendAnyLifetime<'a, 'b, T>; u8]
             }
 
 

--- a/tests/test/generators.rs
+++ b/tests/test/generators.rs
@@ -1,0 +1,89 @@
+use super::*;
+
+#[test]
+fn generator_test() {
+    test! {
+        program {
+            #[auto] trait Send { }
+
+
+            struct StructOne {}
+            struct NotSend {}
+            struct SendSameLifetime<'a, 'b, T> { val: &'a T, other: &'b T }
+            impl<'a, T> Send for SendSameLifetime<'a, 'a, T> {}
+
+            struct SendAnyLifetime<'a, 'b, T> { val: &'a u8, other: &'b u8, field: T }
+
+            impl !Send for NotSend {}
+            struct StructThree<'a> { val: &'a () }
+
+            generator empty_gen<>[resume = (), yield = ()] {
+                upvars []
+                witnesses []
+            }
+
+            generator upvar_lifetime_restrict<T>[resume = (), yield = ()] {
+                upvars [T; StructOne]
+                witnesses for<'a, 'b> [SendSameLifetime<'a, 'b, T>]
+            }
+
+            generator send_any_lifetime<T>[resume = (), yield = ()] {
+                upvars []
+                witnesses for<'a, 'b> [SendAnyLifetime<'a, 'b, T>; u8]
+            }
+
+
+            generator not_send_resume_yield<>[resume = NotSend, yield = NotSend] {
+                upvars []
+                witnesses []
+            }
+
+        }
+
+        goal {
+            WellFormed(empty_gen)
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            empty_gen: Send
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            forall<T> {
+                upvar_lifetime_restrict<T>: Send
+            }
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            forall<T> {
+                if (T: Send) {
+                    upvar_lifetime_restrict<T>: Send
+                }
+            }
+        } yields {
+            "Unique; substitution [], lifetime constraints [InEnvironment { environment: Env([for<> FromEnv(!1_0: Send)]), goal: '!2_0: '!2_1 }, InEnvironment { environment: Env([for<> FromEnv(!1_0: Send)]), goal: '!2_1: '!2_0 }]"
+        }
+
+        goal {
+            not_send_resume_yield: Send
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            forall<T> {
+                if (T: Send) {
+                    send_any_lifetime<T>: Send
+                }
+            }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+    }
+}

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -331,6 +331,7 @@ mod cycle;
 mod existential_types;
 mod fn_def;
 mod foreign_types;
+mod generators;
 mod implied_bounds;
 mod impls;
 mod misc;


### PR DESCRIPTION
`GeneratorDatum` and `GeneratorWitnessDatum` are introduced, which
mirror `TyKind::Generator` and `TyKind::GeneratorWitness` in rustc.

We handle auto traits for `GeneratorDatum` using the existing
`constituent_types` method. For `GeneratorWitnessDatum`, we generate a
`forall<'a, 'b, ... 'z>` goal to reflect the fact that our lifetimes are
existentially bound.

Unresolved questions:
* The implementation of `GeneratorWitnessDatum` needs careful review -
  I'm not certain that I fully understand how `Binders` works.
* The syntax implemented in `parser.lalrpop` can be bikesheeded. We
  might want to use something other than `for<>` for the witness types,
  to reflect that fact that we have existential rather than universal
  quantification.
* The generator grammar only allows quantifying over liftimes for the
  witness types - however, this gets lowered to a `Binders`, which
  supports types and constants as well. Should we do anything else
  to ensure we never end up with types/consts where they're not
  expected?
* I added a test to ensure that we treat the witness lifetimes as
  existentially quantified - for example, if we have
  `for<'a, 'b> Foo<'a, 'b>`, we should only be able to use an auto
  trait impl that is fully generic over lifetimes - e.g.
  `impl<'a> Send for Foo<'a, 'b>` will not be used. I *believe*
  that the test is showing this behavior - it ends up returning
  region constraints that require `'a` and `'b` to outlive each other.
  Since these are 'existential' lifetimes (which cannot be substituted),
  this is an unsatisfiable constraint. However, I'm not sure where we
  should be detecting that this is unsatisfiable.
* In rustc, all of the existential witness lifetimes are distinct. This is not enforced by this PR e.g. you can repeat a lifetime in the witness type. I'm not sure if/where we should enforce this.