### PR TITLE
Fix links in chalk book

### DIFF
--- a/book/src/clauses/goals_and_clauses.md
+++ b/book/src/clauses/goals_and_clauses.md
@@ -38,11 +38,11 @@ paper
 gives the details.
 
 In terms of code, these types are defined in
-[`librustc_middle/traits/mod.rs`][traits_mod] in rustc, and in
+[`compiler/rustc_middle/src/traits/mod.rs`][traits_mod] in rustc, and in
 [`chalk-ir/src/lib.rs`][chalk_ir] in chalk.
 
 [pphhf]: ../bibliography.html#pphhf
-[traits_mod]: https://github.com/rust-lang/rust/blob/master/src/librustc_middle/traits/mod.rs
+[traits_mod]: https://github.com/rust-lang/rust/blob/master/compiler/rustc_middle/src/traits/mod.rs
 [chalk_ir]: https://github.com/rust-lang/chalk/blob/master/chalk-ir/src/lib.rs
 
 <a name="domain-goals"></a>

--- a/book/src/clauses/lowering_rules.md
+++ b/book/src/clauses/lowering_rules.md
@@ -29,10 +29,10 @@ comment like so:
 
 The reference implementation of these rules is to be found in
 [`chalk/chalk-solve/src/clauses.rs`][chalk_rules]. They are also ported in
-rustc in the [`librustc_traits`][librustc_traits] crate.
+rustc in the [`rustc_traits`][rustc_traits] crate.
 
 [chalk_rules]: https://github.com/rust-lang/chalk/blob/master/chalk-solve/src/clauses.rs
-[librustc_traits]: https://github.com/rust-lang/rust/tree/master/src/librustc_traits
+[rustc_traits]: https://github.com/rust-lang/rust/tree/master/compiler/rustc_traits
 
 ## Lowering where clauses
 

--- a/book/src/clauses/type_equality.md
+++ b/book/src/clauses/type_equality.md
@@ -94,12 +94,12 @@ They are used internally by the trait system only, as we will see
 shortly.
 
 In rustc, they correspond to the `TyKind::UnnormalizedProjectionTy` enum
-variant, declared in [`librustc_middle/ty/sty.rs`][sty]. In chalk, we use an
+variant, declared in [`compiler/rustc_middle/src/ty/sty.rs`][sty]. In chalk, we use an
 `ApplicationTy` with a name living in a special namespace dedicated to
 placeholder associated types (see the `TypeName` enum declared in
 [`chalk-ir/src/lib.rs`][chalk_type_name]).
 
-[sty]: https://github.com/rust-lang/rust/blob/master/src/librustc_middle/ty/sty.rs
+[sty]: https://github.com/rust-lang/rust/blob/master/compiler/rustc_middle/src/ty/sty.rs
 [chalk_type_name]: https://github.com/rust-lang-nursery/chalk/blob/master/chalk-ir/src/lib.rs
 
 ## Projection equality


### PR DESCRIPTION
A few links in the book were broken due to the directory changes in rustc, causing the link check to fail.