### PR TITLE
Simplify lowering

### DIFF
--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::ChalkError,
     interner::ChalkIr,
-    lowering::LowerGoal,
+    lowering::lower_goal,
     program::Program,
     query::{Lowering, LoweringDatabase},
     tls, SolverChoice,
@@ -43,7 +43,7 @@ impl ChalkDatabase {
 
     pub fn parse_and_lower_goal(&self, text: &str) -> Result<Goal<ChalkIr>, ChalkError> {
         let program = self.checked_program()?;
-        Ok(chalk_parse::parse_goal(text)?.lower(&*program)?)
+        Ok(lower_goal(&*chalk_parse::parse_goal(text)?, &*program)?)
     }
 
     pub fn solve(

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -85,7 +85,7 @@ struct AssociatedTyLookup {
 }
 
 enum ApplyTypeLookup<'k> {
-    Param(&'k chalk_ir::WithKind<ChalkIr, BoundVar>),
+    Parameter(&'k chalk_ir::WithKind<ChalkIr, BoundVar>),
     Adt(AdtId<ChalkIr>),
     FnDef(FnDefId<ChalkIr>),
     Closure(ClosureId<ChalkIr>),
@@ -117,7 +117,7 @@ impl Env<'_> {
         };
 
         match self.lookup_apply_type(name) {
-            Ok(ApplyTypeLookup::Param(p)) => {
+            Ok(ApplyTypeLookup::Parameter(p)) => {
                 let b = p.skip_kind();
                 match &p.kind {
                     chalk_ir::VariableKind::Ty(_) => Ok(chalk_ir::TyData::BoundVar(*b)
@@ -165,7 +165,7 @@ impl Env<'_> {
 
     fn lookup_apply_type(&self, name: &Identifier) -> LowerResult<ApplyTypeLookup> {
         if let Some(id) = self.parameter_map.get(&name.str) {
-            return Ok(ApplyTypeLookup::Param(id));
+            return Ok(ApplyTypeLookup::Parameter(id));
         }
 
         if let Some(id) = self.adt_ids.get(&name.str) {
@@ -1357,7 +1357,7 @@ impl LowerWithEnv for Ty {
 
             Ty::Apply { name, ref args } => {
                 let (apply_name, k) = match env.lookup_apply_type(&name)? {
-                    ApplyTypeLookup::Param(_) => {
+                    ApplyTypeLookup::Parameter(_) => {
                         return Err(RustIrError::CannotApplyTypeParameter(name.clone()))
                     }
 

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -692,7 +692,9 @@ trait LowerTypeKind {
 }
 
 trait LowerParameterMap {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>>;
+    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
+        None
+    }
     fn declared_parameters(&self) -> &[VariableKind];
     fn all_parameters(&self) -> Vec<chalk_ir::WithKind<ChalkIr, Ident>> {
         self.synthetic_parameters()
@@ -722,60 +724,36 @@ trait LowerParameterMap {
 }
 
 impl LowerParameterMap for AdtDefn {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
-        None
-    }
-
     fn declared_parameters(&self) -> &[VariableKind] {
         &self.variable_kinds
     }
 }
 
 impl LowerParameterMap for FnDefn {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
-        None
-    }
-
     fn declared_parameters(&self) -> &[VariableKind] {
         &self.variable_kinds
     }
 }
 
 impl LowerParameterMap for ClosureDefn {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
-        None
-    }
-
     fn declared_parameters(&self) -> &[VariableKind] {
         &self.variable_kinds
     }
 }
 
 impl LowerParameterMap for Impl {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
-        None
-    }
-
     fn declared_parameters(&self) -> &[VariableKind] {
         &self.variable_kinds
     }
 }
 
 impl LowerParameterMap for AssocTyDefn {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
-        None
-    }
-
     fn declared_parameters(&self) -> &[VariableKind] {
         &self.variable_kinds
     }
 }
 
 impl LowerParameterMap for AssocTyValue {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
-        None
-    }
-
     fn declared_parameters(&self) -> &[VariableKind] {
         &self.variable_kinds
     }
@@ -795,10 +773,6 @@ impl LowerParameterMap for TraitDefn {
 }
 
 impl LowerParameterMap for Clause {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
-        None
-    }
-
     fn declared_parameters(&self) -> &[VariableKind] {
         &self.variable_kinds
     }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -365,14 +365,14 @@ pub fn lower_program(program: &Program) -> LowerResult<LoweredProgram> {
                 adt_kinds.insert(id, type_kind);
             }
             Item::FnDefn(defn) => {
-                let type_kind = lower_type_kind!(defn, Adt, defn.all_parameters())?;
+                let type_kind = lower_type_kind!(defn, FnDef, defn.all_parameters())?;
                 let id = FnDefId(raw_id);
                 fn_def_ids.insert(type_kind.name.clone(), id);
                 fn_def_kinds.insert(id, type_kind);
                 fn_def_abis.insert(id, lower_fn_abi(&defn.sig.abi)?);
             }
             Item::ClosureDefn(defn) => {
-                let type_kind = lower_type_kind!(defn, Adt, defn.all_parameters())?;
+                let type_kind = lower_type_kind!(defn, Closure, defn.all_parameters())?;
                 let id = ClosureId(raw_id);
                 closure_ids.insert(defn.name.str.clone(), id);
                 closure_kinds.insert(id, type_kind);

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -679,9 +679,7 @@ pub fn lower_program(program: &Program) -> LowerResult<LoweredProgram> {
 }
 
 trait LowerParameterMap {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
-        None
-    }
+    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>>;
     fn declared_parameters(&self) -> &[VariableKind];
     fn all_parameters(&self) -> Vec<chalk_ir::WithKind<ChalkIr, Ident>> {
         self.synthetic_parameters()
@@ -710,60 +708,32 @@ trait LowerParameterMap {
     }
 }
 
-impl LowerParameterMap for AdtDefn {
-    fn declared_parameters(&self) -> &[VariableKind] {
-        &self.variable_kinds
-    }
+macro_rules! lower_param_map {
+    ($type: ident, $synthetic: expr) => {
+        impl LowerParameterMap for $type {
+            fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
+                $synthetic
+            }
+            fn declared_parameters(&self) -> &[VariableKind] {
+                &self.variable_kinds
+            }
+        }
+    };
 }
-
-impl LowerParameterMap for FnDefn {
-    fn declared_parameters(&self) -> &[VariableKind] {
-        &self.variable_kinds
-    }
-}
-
-impl LowerParameterMap for ClosureDefn {
-    fn declared_parameters(&self) -> &[VariableKind] {
-        &self.variable_kinds
-    }
-}
-
-impl LowerParameterMap for Impl {
-    fn declared_parameters(&self) -> &[VariableKind] {
-        &self.variable_kinds
-    }
-}
-
-impl LowerParameterMap for AssocTyDefn {
-    fn declared_parameters(&self) -> &[VariableKind] {
-        &self.variable_kinds
-    }
-}
-
-impl LowerParameterMap for AssocTyValue {
-    fn declared_parameters(&self) -> &[VariableKind] {
-        &self.variable_kinds
-    }
-}
-
-impl LowerParameterMap for TraitDefn {
-    fn synthetic_parameters(&self) -> Option<chalk_ir::WithKind<ChalkIr, Ident>> {
-        Some(chalk_ir::WithKind::new(
-            chalk_ir::VariableKind::Ty(TyKind::General),
-            Atom::from(SELF),
-        ))
-    }
-
-    fn declared_parameters(&self) -> &[VariableKind] {
-        &self.variable_kinds
-    }
-}
-
-impl LowerParameterMap for Clause {
-    fn declared_parameters(&self) -> &[VariableKind] {
-        &self.variable_kinds
-    }
-}
+lower_param_map!(AdtDefn, None);
+lower_param_map!(FnDefn, None);
+lower_param_map!(ClosureDefn, None);
+lower_param_map!(Impl, None);
+lower_param_map!(AssocTyDefn, None);
+lower_param_map!(AssocTyValue, None);
+lower_param_map!(Clause, None);
+lower_param_map!(
+    TraitDefn,
+    Some(chalk_ir::WithKind::new(
+        chalk_ir::VariableKind::Ty(TyKind::General),
+        Atom::from(SELF),
+    ))
+);
 
 fn get_type_of_u32() -> chalk_ir::Ty<ChalkIr> {
     chalk_ir::ApplicationTy {

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -852,27 +852,17 @@ impl Lower for VariableKind {
     type Lowered = chalk_ir::WithKind<ChalkIr, Ident>;
 
     fn lower(&self) -> Self::Lowered {
-        match self {
-            VariableKind::Ty(n) => chalk_ir::WithKind::new(
-                chalk_ir::VariableKind::Ty(chalk_ir::TyKind::General),
-                n.str.clone(),
-            ),
-            VariableKind::IntegerTy(n) => chalk_ir::WithKind::new(
-                chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Integer),
-                n.str.clone(),
-            ),
-            VariableKind::FloatTy(n) => chalk_ir::WithKind::new(
-                chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Float),
-                n.str.clone(),
-            ),
-            VariableKind::Lifetime(n) => {
-                chalk_ir::WithKind::new(chalk_ir::VariableKind::Lifetime, n.str.clone())
+        let (kind, n) = match self {
+            VariableKind::Ty(n) => (chalk_ir::VariableKind::Ty(chalk_ir::TyKind::General), n),
+            VariableKind::IntegerTy(n) => {
+                (chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Integer), n)
             }
-            VariableKind::Const(ref n) => chalk_ir::WithKind::new(
-                chalk_ir::VariableKind::Const(get_type_of_u32()),
-                n.str.clone(),
-            ),
-        }
+            VariableKind::FloatTy(n) => (chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Float), n),
+            VariableKind::Lifetime(n) => (chalk_ir::VariableKind::Lifetime, n),
+            VariableKind::Const(ref n) => (chalk_ir::VariableKind::Const(get_type_of_u32()), n),
+        };
+
+        chalk_ir::WithKind::new(kind, n.str.clone())
     }
 }
 

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -282,311 +282,317 @@ impl Env<'_> {
     }
 }
 
-pub fn lower_program(program: &Program) -> LowerResult<LoweredProgram> {
-    let mut index = 0;
-    let mut next_item_id = || -> RawId {
-        let i = index;
-        index += 1;
-        RawId { index: i }
-    };
+impl Lower for Program {
+    type Lowered = LowerResult<LoweredProgram>;
 
-    // Make a vector mapping each thing in `items` to an id,
-    // based just on its position:
-    let raw_ids: Vec<_> = program.items.iter().map(|_| next_item_id()).collect();
+    fn lower(&self) -> Self::Lowered {
+        let mut index = 0;
+        let mut next_item_id = || -> RawId {
+            let i = index;
+            index += 1;
+            RawId { index: i }
+        };
 
-    // Create ids for associated type declarations and values
-    let mut associated_ty_lookups = BTreeMap::new();
-    let mut associated_ty_value_ids = BTreeMap::new();
-    for (item, &raw_id) in program.items.iter().zip(&raw_ids) {
-        match item {
-            Item::TraitDefn(d) => {
-                if d.flags.auto && !d.assoc_ty_defns.is_empty() {
-                    Err(RustIrError::AutoTraitAssociatedTypes(d.name.clone()))?;
+        // Make a vector mapping each thing in `items` to an id,
+        // based just on its position:
+        let raw_ids: Vec<_> = self.items.iter().map(|_| next_item_id()).collect();
+
+        // Create ids for associated type declarations and values
+        let mut associated_ty_lookups = BTreeMap::new();
+        let mut associated_ty_value_ids = BTreeMap::new();
+        for (item, &raw_id) in self.items.iter().zip(&raw_ids) {
+            match item {
+                Item::TraitDefn(d) => {
+                    if d.flags.auto && !d.assoc_ty_defns.is_empty() {
+                        Err(RustIrError::AutoTraitAssociatedTypes(d.name.clone()))?;
+                    }
+                    for defn in &d.assoc_ty_defns {
+                        let addl_variable_kinds = defn.all_parameters();
+                        let lookup = AssociatedTyLookup {
+                            id: AssocTypeId(next_item_id()),
+                            addl_variable_kinds: addl_variable_kinds.anonymize(),
+                        };
+                        associated_ty_lookups
+                            .insert((TraitId(raw_id), defn.name.str.clone()), lookup);
+                    }
                 }
-                for defn in &d.assoc_ty_defns {
-                    let addl_variable_kinds = defn.all_parameters();
-                    let lookup = AssociatedTyLookup {
-                        id: AssocTypeId(next_item_id()),
-                        addl_variable_kinds: addl_variable_kinds.anonymize(),
-                    };
-                    associated_ty_lookups.insert((TraitId(raw_id), defn.name.str.clone()), lookup);
+
+                Item::Impl(d) => {
+                    for atv in &d.assoc_ty_values {
+                        let atv_id = AssociatedTyValueId(next_item_id());
+                        associated_ty_value_ids
+                            .insert((ImplId(raw_id), atv.name.str.clone()), atv_id);
+                    }
                 }
+
+                _ => {}
             }
-
-            Item::Impl(d) => {
-                for atv in &d.assoc_ty_values {
-                    let atv_id = AssociatedTyValueId(next_item_id());
-                    associated_ty_value_ids.insert((ImplId(raw_id), atv.name.str.clone()), atv_id);
-                }
-            }
-
-            _ => {}
         }
-    }
 
-    let mut adt_ids = BTreeMap::new();
-    let mut fn_def_ids = BTreeMap::new();
-    let mut closure_ids = BTreeMap::new();
-    let mut trait_ids = BTreeMap::new();
-    let mut auto_traits = BTreeMap::new();
-    let mut opaque_ty_ids = BTreeMap::new();
-    let mut adt_kinds = BTreeMap::new();
-    let mut fn_def_kinds = BTreeMap::new();
-    let mut closure_kinds = BTreeMap::new();
-    let mut trait_kinds = BTreeMap::new();
-    let mut opaque_ty_kinds = BTreeMap::new();
-    let mut object_safe_traits = HashSet::new();
+        let mut adt_ids = BTreeMap::new();
+        let mut fn_def_ids = BTreeMap::new();
+        let mut closure_ids = BTreeMap::new();
+        let mut trait_ids = BTreeMap::new();
+        let mut auto_traits = BTreeMap::new();
+        let mut opaque_ty_ids = BTreeMap::new();
+        let mut adt_kinds = BTreeMap::new();
+        let mut fn_def_kinds = BTreeMap::new();
+        let mut closure_kinds = BTreeMap::new();
+        let mut trait_kinds = BTreeMap::new();
+        let mut opaque_ty_kinds = BTreeMap::new();
+        let mut object_safe_traits = HashSet::new();
 
-    for (item, &raw_id) in program.items.iter().zip(&raw_ids) {
-        match item {
-            Item::AdtDefn(defn) => {
-                let type_kind = defn.lower_type_kind()?;
-                let id = AdtId(raw_id);
-                adt_ids.insert(type_kind.name.clone(), id);
-                adt_kinds.insert(id, type_kind);
-            }
-            Item::FnDefn(defn) => {
-                let type_kind = defn.lower_type_kind()?;
-                let id = FnDefId(raw_id);
-                fn_def_ids.insert(type_kind.name.clone(), id);
-                fn_def_kinds.insert(id, type_kind);
-            }
-            Item::ClosureDefn(defn) => {
-                let type_kind = defn.lower_type_kind()?;
-                let id = ClosureId(raw_id);
-                closure_ids.insert(defn.name.str.clone(), id);
-                closure_kinds.insert(id, type_kind);
-            }
-            Item::TraitDefn(defn) => {
-                let type_kind = defn.lower_type_kind()?;
-                let id = TraitId(raw_id);
-                trait_ids.insert(type_kind.name.clone(), id);
-                trait_kinds.insert(id, type_kind);
-                auto_traits.insert(id, defn.flags.auto);
-
-                if defn.flags.object_safe {
-                    object_safe_traits.insert(id);
+        for (item, &raw_id) in self.items.iter().zip(&raw_ids) {
+            match item {
+                Item::AdtDefn(defn) => {
+                    let type_kind = defn.lower_type_kind()?;
+                    let id = AdtId(raw_id);
+                    adt_ids.insert(type_kind.name.clone(), id);
+                    adt_kinds.insert(id, type_kind);
                 }
-            }
-            Item::OpaqueTyDefn(defn) => {
-                let type_kind = defn.lower_type_kind()?;
-                let id = OpaqueTyId(raw_id);
-                opaque_ty_ids.insert(defn.name.str.clone(), id);
-                opaque_ty_kinds.insert(id, type_kind);
-            }
-            Item::Impl(_) => continue,
-            Item::Clause(_) => continue,
-            Item::Foreign(_) => continue,
-        };
-    }
+                Item::FnDefn(defn) => {
+                    let type_kind = defn.lower_type_kind()?;
+                    let id = FnDefId(raw_id);
+                    fn_def_ids.insert(type_kind.name.clone(), id);
+                    fn_def_kinds.insert(id, type_kind);
+                }
+                Item::ClosureDefn(defn) => {
+                    let type_kind = defn.lower_type_kind()?;
+                    let id = ClosureId(raw_id);
+                    closure_ids.insert(defn.name.str.clone(), id);
+                    closure_kinds.insert(id, type_kind);
+                }
+                Item::TraitDefn(defn) => {
+                    let type_kind = defn.lower_type_kind()?;
+                    let id = TraitId(raw_id);
+                    trait_ids.insert(type_kind.name.clone(), id);
+                    trait_kinds.insert(id, type_kind);
+                    auto_traits.insert(id, defn.flags.auto);
 
-    let mut adt_data = BTreeMap::new();
-    let mut adt_reprs = BTreeMap::new();
-    let mut fn_def_data = BTreeMap::new();
-    let mut closure_inputs_and_output = BTreeMap::new();
-    let mut closure_closure_kind = BTreeMap::new();
-    let mut closure_upvars = BTreeMap::new();
-    let mut trait_data = BTreeMap::new();
-    let mut well_known_traits = BTreeMap::new();
-    let mut impl_data = BTreeMap::new();
-    let mut associated_ty_data = BTreeMap::new();
-    let mut associated_ty_values = BTreeMap::new();
-    let mut opaque_ty_data = BTreeMap::new();
-    let mut hidden_opaque_types = BTreeMap::new();
-    let mut custom_clauses = Vec::new();
-    let mut foreign_ty_ids = BTreeMap::new();
+                    if defn.flags.object_safe {
+                        object_safe_traits.insert(id);
+                    }
+                }
+                Item::OpaqueTyDefn(defn) => {
+                    let type_kind = defn.lower_type_kind()?;
+                    let id = OpaqueTyId(raw_id);
+                    opaque_ty_ids.insert(defn.name.str.clone(), id);
+                    opaque_ty_kinds.insert(id, type_kind);
+                }
+                Item::Impl(_) => continue,
+                Item::Clause(_) => continue,
+                Item::Foreign(_) => continue,
+            };
+        }
 
-    for (item, &raw_id) in program.items.iter().zip(&raw_ids) {
-        let empty_env = Env {
-            adt_ids: &adt_ids,
-            adt_kinds: &adt_kinds,
-            fn_def_ids: &fn_def_ids,
-            fn_def_kinds: &fn_def_kinds,
-            closure_ids: &closure_ids,
-            closure_kinds: &closure_kinds,
-            trait_ids: &trait_ids,
-            trait_kinds: &trait_kinds,
-            opaque_ty_ids: &opaque_ty_ids,
-            opaque_ty_kinds: &opaque_ty_kinds,
-            associated_ty_lookups: &associated_ty_lookups,
-            parameter_map: BTreeMap::new(),
-            auto_traits: &auto_traits,
-            foreign_ty_ids: &foreign_ty_ids,
-        };
+        let mut adt_data = BTreeMap::new();
+        let mut adt_reprs = BTreeMap::new();
+        let mut fn_def_data = BTreeMap::new();
+        let mut closure_inputs_and_output = BTreeMap::new();
+        let mut closure_closure_kind = BTreeMap::new();
+        let mut closure_upvars = BTreeMap::new();
+        let mut trait_data = BTreeMap::new();
+        let mut well_known_traits = BTreeMap::new();
+        let mut impl_data = BTreeMap::new();
+        let mut associated_ty_data = BTreeMap::new();
+        let mut associated_ty_values = BTreeMap::new();
+        let mut opaque_ty_data = BTreeMap::new();
+        let mut hidden_opaque_types = BTreeMap::new();
+        let mut custom_clauses = Vec::new();
+        let mut foreign_ty_ids = BTreeMap::new();
 
-        match *item {
-            Item::AdtDefn(ref d) => {
-                let adt_id = AdtId(raw_id);
-                adt_data.insert(adt_id, Arc::new(lower_adt(d, adt_id, &empty_env)?));
-                adt_reprs.insert(adt_id, lower_adt_repr(&d.repr));
-            }
-            Item::FnDefn(ref defn) => {
-                let fn_def_id = FnDefId(raw_id);
-                fn_def_data.insert(
-                    fn_def_id,
-                    Arc::new(lower_fn_def(defn, fn_def_id, &empty_env)?),
-                );
-            }
-            Item::ClosureDefn(ref defn) => {
-                let closure_def_id = ClosureId(raw_id);
-                let (kind, inputs_and_output) = defn.lower(&empty_env)?;
-                closure_closure_kind.insert(closure_def_id, kind);
-                closure_inputs_and_output.insert(closure_def_id, inputs_and_output);
-                let upvars = empty_env.in_binders(defn.all_parameters(), |env| {
-                    let upvar_tys: LowerResult<Vec<chalk_ir::Ty<ChalkIr>>> =
-                        defn.upvars.iter().map(|ty| ty.lower(&env)).collect();
-                    let substitution = chalk_ir::Substitution::from_iter(
-                        &ChalkIr,
-                        upvar_tys?.into_iter().map(|ty| ty.cast(&ChalkIr)),
+        for (item, &raw_id) in self.items.iter().zip(&raw_ids) {
+            let empty_env = Env {
+                adt_ids: &adt_ids,
+                adt_kinds: &adt_kinds,
+                fn_def_ids: &fn_def_ids,
+                fn_def_kinds: &fn_def_kinds,
+                closure_ids: &closure_ids,
+                closure_kinds: &closure_kinds,
+                trait_ids: &trait_ids,
+                trait_kinds: &trait_kinds,
+                opaque_ty_ids: &opaque_ty_ids,
+                opaque_ty_kinds: &opaque_ty_kinds,
+                associated_ty_lookups: &associated_ty_lookups,
+                parameter_map: BTreeMap::new(),
+                auto_traits: &auto_traits,
+                foreign_ty_ids: &foreign_ty_ids,
+            };
+
+            match *item {
+                Item::AdtDefn(ref d) => {
+                    let adt_id = AdtId(raw_id);
+                    adt_data.insert(adt_id, Arc::new(lower_adt(d, adt_id, &empty_env)?));
+                    adt_reprs.insert(adt_id, d.repr.lower());
+                }
+                Item::FnDefn(ref defn) => {
+                    let fn_def_id = FnDefId(raw_id);
+                    fn_def_data.insert(
+                        fn_def_id,
+                        Arc::new(lower_fn_def(defn, fn_def_id, &empty_env)?),
                     );
-                    Ok(chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
-                        name: chalk_ir::TypeName::Tuple(defn.upvars.len()),
-                        substitution,
-                    })
-                    .intern(&ChalkIr))
-                })?;
-                closure_upvars.insert(closure_def_id, upvars);
-            }
-            Item::TraitDefn(ref trait_defn) => {
-                let trait_id = TraitId(raw_id);
-                let trait_datum = lower_trait(trait_defn, trait_id, &empty_env)?;
-
-                if let Some(well_known) = trait_datum.well_known {
-                    well_known_traits.insert(well_known, trait_id);
                 }
-
-                trait_data.insert(trait_id, Arc::new(trait_datum));
-
-                for assoc_ty_defn in &trait_defn.assoc_ty_defns {
-                    let lookup =
-                        &associated_ty_lookups[&(trait_id, assoc_ty_defn.name.str.clone())];
-
-                    // The parameters in scope for the associated
-                    // type definitions are *both* those from the
-                    // trait *and* those from the associated type
-                    // itself.
-                    //
-                    // Insert the associated type parameters first
-                    // into the list so that they are given the
-                    // indices starting from 0. This corresponds
-                    // to the "de bruijn" convention where "more
-                    // inner" sets of parameters get the lower
-                    // indices:
-                    //
-                    // e.g., in this example, the indices would be
-                    // assigned `[A0, A1, T0, T1]`:
-                    //
-                    // ```
-                    // trait Foo<T0, T1> {
-                    //     type Bar<A0, A1>;
-                    // }
-                    // ```
-                    let mut variable_kinds = assoc_ty_defn.all_parameters();
-                    variable_kinds.extend(trait_defn.all_parameters());
-
-                    let binders = empty_env.in_binders(variable_kinds, |env| {
-                        Ok(rust_ir::AssociatedTyDatumBound {
-                            bounds: assoc_ty_defn.bounds.lower(&env)?,
-                            where_clauses: assoc_ty_defn.where_clauses.lower(&env)?,
+                Item::ClosureDefn(ref defn) => {
+                    let closure_def_id = ClosureId(raw_id);
+                    let (kind, inputs_and_output) = defn.lower(&empty_env)?;
+                    closure_closure_kind.insert(closure_def_id, kind);
+                    closure_inputs_and_output.insert(closure_def_id, inputs_and_output);
+                    let upvars = empty_env.in_binders(defn.all_parameters(), |env| {
+                        let upvar_tys: LowerResult<Vec<chalk_ir::Ty<ChalkIr>>> =
+                            defn.upvars.iter().map(|ty| ty.lower(&env)).collect();
+                        let substitution = chalk_ir::Substitution::from_iter(
+                            &ChalkIr,
+                            upvar_tys?.into_iter().map(|ty| ty.cast(&ChalkIr)),
+                        );
+                        Ok(chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
+                            name: chalk_ir::TypeName::Tuple(defn.upvars.len()),
+                            substitution,
                         })
+                        .intern(&ChalkIr))
                     })?;
-
-                    associated_ty_data.insert(
-                        lookup.id,
-                        Arc::new(rust_ir::AssociatedTyDatum {
-                            trait_id: TraitId(raw_id),
-                            id: lookup.id,
-                            name: assoc_ty_defn.name.str.clone(),
-                            binders,
-                        }),
-                    );
+                    closure_upvars.insert(closure_def_id, upvars);
                 }
-            }
-            Item::Impl(ref impl_defn) => {
-                let impl_id = ImplId(raw_id);
-                let impl_datum = Arc::new(lower_impl(
-                    impl_defn,
-                    &empty_env,
-                    impl_id,
-                    &associated_ty_value_ids,
-                )?);
-                impl_data.insert(impl_id, impl_datum.clone());
-                let trait_id = impl_datum.trait_id();
+                Item::TraitDefn(ref trait_defn) => {
+                    let trait_id = TraitId(raw_id);
+                    let trait_datum = lower_trait(trait_defn, trait_id, &empty_env)?;
 
-                for atv in &impl_defn.assoc_ty_values {
-                    let atv_id = associated_ty_value_ids[&(impl_id, atv.name.str.clone())];
-                    let lookup = &associated_ty_lookups[&(trait_id, atv.name.str.clone())];
+                    if let Some(well_known) = trait_datum.well_known {
+                        well_known_traits.insert(well_known, trait_id);
+                    }
 
-                    // The parameters in scope for the associated
-                    // type definitions are *both* those from the
-                    // impl *and* those from the associated type
-                    // itself. As in the "trait" case above, we begin
-                    // with the parameters from the impl.
-                    let mut variable_kinds = atv.all_parameters();
-                    variable_kinds.extend(impl_defn.all_parameters());
+                    trait_data.insert(trait_id, Arc::new(trait_datum));
 
-                    let value = empty_env.in_binders(variable_kinds, |env| {
-                        Ok(rust_ir::AssociatedTyValueBound {
-                            ty: atv.value.lower(env)?,
-                        })
-                    })?;
+                    for assoc_ty_defn in &trait_defn.assoc_ty_defns {
+                        let lookup =
+                            &associated_ty_lookups[&(trait_id, assoc_ty_defn.name.str.clone())];
 
-                    associated_ty_values.insert(
-                        atv_id,
-                        Arc::new(rust_ir::AssociatedTyValue {
-                            impl_id,
-                            associated_ty_id: lookup.id,
-                            value,
-                        }),
-                    );
+                        // The parameters in scope for the associated
+                        // type definitions are *both* those from the
+                        // trait *and* those from the associated type
+                        // itself.
+                        //
+                        // Insert the associated type parameters first
+                        // into the list so that they are given the
+                        // indices starting from 0. This corresponds
+                        // to the "de bruijn" convention where "more
+                        // inner" sets of parameters get the lower
+                        // indices:
+                        //
+                        // e.g., in this example, the indices would be
+                        // assigned `[A0, A1, T0, T1]`:
+                        //
+                        // ```
+                        // trait Foo<T0, T1> {
+                        //     type Bar<A0, A1>;
+                        // }
+                        // ```
+                        let mut variable_kinds = assoc_ty_defn.all_parameters();
+                        variable_kinds.extend(trait_defn.all_parameters());
+
+                        let binders = empty_env.in_binders(variable_kinds, |env| {
+                            Ok(rust_ir::AssociatedTyDatumBound {
+                                bounds: assoc_ty_defn.bounds.lower(&env)?,
+                                where_clauses: assoc_ty_defn.where_clauses.lower(&env)?,
+                            })
+                        })?;
+
+                        associated_ty_data.insert(
+                            lookup.id,
+                            Arc::new(rust_ir::AssociatedTyDatum {
+                                trait_id: TraitId(raw_id),
+                                id: lookup.id,
+                                name: assoc_ty_defn.name.str.clone(),
+                                binders,
+                            }),
+                        );
+                    }
                 }
-            }
-            Item::Clause(ref clause) => {
-                custom_clauses.extend(clause.lower(&empty_env)?);
-            }
-            Item::OpaqueTyDefn(ref opaque_ty) => {
-                if let Some(&opaque_ty_id) = opaque_ty_ids.get(&opaque_ty.name.str) {
-                    let variable_kinds = opaque_ty
-                        .variable_kinds
-                        .iter()
-                        .map(lower_variable_kind)
-                        .collect::<Vec<_>>();
+                Item::Impl(ref impl_defn) => {
+                    let impl_id = ImplId(raw_id);
+                    let impl_datum = Arc::new(lower_impl(
+                        impl_defn,
+                        &empty_env,
+                        impl_id,
+                        &associated_ty_value_ids,
+                    )?);
+                    impl_data.insert(impl_id, impl_datum.clone());
+                    let trait_id = impl_datum.trait_id();
 
-                    // Introduce the parameters declared on the opaque type definition.
-                    // So if we have `type Foo<P1..Pn> = impl Trait<T1..Tn>`, this would introduce `P1..Pn`
-                    let binders = empty_env.in_binders(variable_kinds, |env| {
-                        let hidden_ty = opaque_ty.ty.lower(&env)?;
-                        hidden_opaque_types.insert(opaque_ty_id, Arc::new(hidden_ty));
+                    for atv in &impl_defn.assoc_ty_values {
+                        let atv_id = associated_ty_value_ids[&(impl_id, atv.name.str.clone())];
+                        let lookup = &associated_ty_lookups[&(trait_id, atv.name.str.clone())];
 
-                        // Introduce a variable to represent the hidden "self type". This will be used in the bounds.
-                        // So the `impl Trait<T1..Tn>` will be lowered to `exists<Self> { Self: Trait<T1..Tn> }`.
-                        let bounds: chalk_ir::Binders<Vec<chalk_ir::Binders<_>>> = env.in_binders(
-                            Some(chalk_ir::WithKind::new(
-                                chalk_ir::VariableKind::Ty(TyKind::General),
-                                Atom::from(FIXME_SELF),
-                            )),
-                            |env| {
-                                let interner = env.interner();
-                                Ok(opaque_ty
-                                    .bounds
-                                    .lower(&env)?
-                                    .iter()
-                                    .flat_map(|qil| {
-                                        // Instantiate the bounds with the innermost bound variable, which represents Self, as the self type.
-                                        qil.into_where_clauses(
-                                            interner,
-                                            chalk_ir::TyData::BoundVar(BoundVar::new(
-                                                DebruijnIndex::INNERMOST,
-                                                0,
-                                            ))
-                                            .intern(interner),
-                                        )
-                                    })
-                                    .collect())
-                            },
-                        )?;
-                        let where_clauses: chalk_ir::Binders<Vec<chalk_ir::Binders<_>>> = env
-                            .in_binders(
+                        // The parameters in scope for the associated
+                        // type definitions are *both* those from the
+                        // impl *and* those from the associated type
+                        // itself. As in the "trait" case above, we begin
+                        // with the parameters from the impl.
+                        let mut variable_kinds = atv.all_parameters();
+                        variable_kinds.extend(impl_defn.all_parameters());
+
+                        let value = empty_env.in_binders(variable_kinds, |env| {
+                            Ok(rust_ir::AssociatedTyValueBound {
+                                ty: atv.value.lower(env)?,
+                            })
+                        })?;
+
+                        associated_ty_values.insert(
+                            atv_id,
+                            Arc::new(rust_ir::AssociatedTyValue {
+                                impl_id,
+                                associated_ty_id: lookup.id,
+                                value,
+                            }),
+                        );
+                    }
+                }
+                Item::Clause(ref clause) => {
+                    custom_clauses.extend(clause.lower(&empty_env)?);
+                }
+                Item::OpaqueTyDefn(ref opaque_ty) => {
+                    if let Some(&opaque_ty_id) = opaque_ty_ids.get(&opaque_ty.name.str) {
+                        let variable_kinds = opaque_ty
+                            .variable_kinds
+                            .iter()
+                            .map(|k| k.lower())
+                            .collect::<Vec<_>>();
+
+                        // Introduce the parameters declared on the opaque type definition.
+                        // So if we have `type Foo<P1..Pn> = impl Trait<T1..Tn>`, this would introduce `P1..Pn`
+                        let binders = empty_env.in_binders(variable_kinds, |env| {
+                            let hidden_ty = opaque_ty.ty.lower(&env)?;
+                            hidden_opaque_types.insert(opaque_ty_id, Arc::new(hidden_ty));
+
+                            // Introduce a variable to represent the hidden "self type". This will be used in the bounds.
+                            // So the `impl Trait<T1..Tn>` will be lowered to `exists<Self> { Self: Trait<T1..Tn> }`.
+                            let bounds: chalk_ir::Binders<Vec<chalk_ir::Binders<_>>> = env
+                                .in_binders(
+                                    Some(chalk_ir::WithKind::new(
+                                        chalk_ir::VariableKind::Ty(TyKind::General),
+                                        Atom::from(FIXME_SELF),
+                                    )),
+                                    |env| {
+                                        let interner = env.interner();
+                                        Ok(opaque_ty
+                                            .bounds
+                                            .lower(&env)?
+                                            .iter()
+                                            .flat_map(|qil| {
+                                                // Instantiate the bounds with the innermost bound variable, which represents Self, as the self type.
+                                                qil.into_where_clauses(
+                                                    interner,
+                                                    chalk_ir::TyData::BoundVar(BoundVar::new(
+                                                        DebruijnIndex::INNERMOST,
+                                                        0,
+                                                    ))
+                                                    .intern(interner),
+                                                )
+                                            })
+                                            .collect())
+                                    },
+                                )?;
+                            let where_clauses: chalk_ir::Binders<Vec<chalk_ir::Binders<_>>> = env
+                                .in_binders(
                                 Some(chalk_ir::WithKind::new(
                                     chalk_ir::VariableKind::Ty(TyKind::General),
                                     Atom::from(FIXME_SELF),
@@ -594,57 +600,58 @@ pub fn lower_program(program: &Program) -> LowerResult<LoweredProgram> {
                                 |env| opaque_ty.where_clauses.lower(env),
                             )?;
 
-                        Ok(OpaqueTyDatumBound {
-                            bounds,
-                            where_clauses,
-                        })
-                    })?;
+                            Ok(OpaqueTyDatumBound {
+                                bounds,
+                                where_clauses,
+                            })
+                        })?;
 
-                    opaque_ty_data.insert(
-                        opaque_ty_id,
-                        Arc::new(OpaqueTyDatum {
+                        opaque_ty_data.insert(
                             opaque_ty_id,
-                            bound: binders,
-                        }),
-                    );
+                            Arc::new(OpaqueTyDatum {
+                                opaque_ty_id,
+                                bound: binders,
+                            }),
+                        );
+                    }
+                }
+                Item::Foreign(ForeignDefn(ref ident)) => {
+                    foreign_ty_ids.insert(ident.str.clone(), ForeignDefId(raw_id));
                 }
             }
-            Item::Foreign(ForeignDefn(ref ident)) => {
-                foreign_ty_ids.insert(ident.str.clone(), ForeignDefId(raw_id));
-            }
         }
+
+        let program = LoweredProgram {
+            adt_ids,
+            fn_def_ids,
+            closure_ids,
+            closure_upvars,
+            closure_kinds,
+            trait_ids,
+            adt_kinds,
+            fn_def_kinds,
+            trait_kinds,
+            adt_data,
+            adt_reprs,
+            fn_def_data,
+            closure_inputs_and_output,
+            closure_closure_kind,
+            trait_data,
+            well_known_traits,
+            impl_data,
+            associated_ty_values,
+            associated_ty_data,
+            opaque_ty_ids,
+            opaque_ty_kinds,
+            opaque_ty_data,
+            hidden_opaque_types,
+            custom_clauses,
+            object_safe_traits,
+            foreign_ty_ids,
+        };
+
+        Ok(program)
     }
-
-    let program = LoweredProgram {
-        adt_ids,
-        fn_def_ids,
-        closure_ids,
-        closure_upvars,
-        closure_kinds,
-        trait_ids,
-        adt_kinds,
-        fn_def_kinds,
-        trait_kinds,
-        adt_data,
-        adt_reprs,
-        fn_def_data,
-        closure_inputs_and_output,
-        closure_closure_kind,
-        trait_data,
-        well_known_traits,
-        impl_data,
-        associated_ty_values,
-        associated_ty_data,
-        opaque_ty_ids,
-        opaque_ty_kinds,
-        opaque_ty_data,
-        hidden_opaque_types,
-        custom_clauses,
-        object_safe_traits,
-        foreign_ty_ids,
-    };
-
-    Ok(program)
 }
 
 trait LowerParameterMap {
@@ -653,7 +660,7 @@ trait LowerParameterMap {
     fn all_parameters(&self) -> Vec<chalk_ir::WithKind<ChalkIr, Ident>> {
         self.synthetic_parameters()
             .into_iter()
-            .chain(self.declared_parameters().iter().map(lower_variable_kind))
+            .chain(self.declared_parameters().iter().map(|id| id.lower()))
             .collect()
 
         /* TODO: switch to this ordering, but adjust *all* the code to match
@@ -732,12 +739,12 @@ lower_type_kind!(ClosureDefn, Closure, |defn: &ClosureDefn| defn
 lower_type_kind!(TraitDefn, Trait, |defn: &TraitDefn| defn
     .variable_kinds
     .iter()
-    .map(lower_variable_kind)
+    .map(|k| k.lower())
     .collect::<Vec<_>>());
 lower_type_kind!(OpaqueTyDefn, Opaque, |defn: &OpaqueTyDefn| defn
     .variable_kinds
     .iter()
-    .map(lower_variable_kind)
+    .map(|k| k.lower())
     .collect::<Vec<_>>());
 
 fn get_type_of_u32() -> chalk_ir::Ty<ChalkIr> {
@@ -749,25 +756,36 @@ fn get_type_of_u32() -> chalk_ir::Ty<ChalkIr> {
     .intern(&ChalkIr)
 }
 
-fn lower_variable_kind(variable_kind: &VariableKind) -> chalk_ir::WithKind<ChalkIr, Ident> {
-    let (kind, n) = match variable_kind {
-        VariableKind::Ty(n) => (chalk_ir::VariableKind::Ty(chalk_ir::TyKind::General), n),
-        VariableKind::IntegerTy(n) => (chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Integer), n),
-        VariableKind::FloatTy(n) => (chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Float), n),
-        VariableKind::Lifetime(n) => (chalk_ir::VariableKind::Lifetime, n),
-        VariableKind::Const(ref n) => (chalk_ir::VariableKind::Const(get_type_of_u32()), n),
-    };
+impl Lower for VariableKind {
+    type Lowered = chalk_ir::WithKind<ChalkIr, Ident>;
+    fn lower(&self) -> Self::Lowered {
+        let (kind, n) = match self {
+            VariableKind::Ty(n) => (chalk_ir::VariableKind::Ty(chalk_ir::TyKind::General), n),
+            VariableKind::IntegerTy(n) => {
+                (chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Integer), n)
+            }
+            VariableKind::FloatTy(n) => (chalk_ir::VariableKind::Ty(chalk_ir::TyKind::Float), n),
+            VariableKind::Lifetime(n) => (chalk_ir::VariableKind::Lifetime, n),
+            VariableKind::Const(ref n) => (chalk_ir::VariableKind::Const(get_type_of_u32()), n),
+        };
 
-    chalk_ir::WithKind::new(kind, n.str.clone())
+        chalk_ir::WithKind::new(kind, n.str.clone())
+    }
 }
 
-trait Lower {
+pub trait Lower {
+    type Lowered;
+
+    fn lower(&self) -> Self::Lowered;
+}
+
+trait LowerWithEnv {
     type Lowered;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered>;
 }
 
-impl Lower for [QuantifiedWhereClause] {
+impl LowerWithEnv for [QuantifiedWhereClause] {
     type Lowered = Vec<chalk_ir::QuantifiedWhereClause<ChalkIr>>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -780,7 +798,7 @@ impl Lower for [QuantifiedWhereClause] {
     }
 }
 
-impl Lower for WhereClause {
+impl LowerWithEnv for WhereClause {
     type Lowered = Vec<chalk_ir::WhereClause<ChalkIr>>;
 
     /// Lower from an AST `where` clause to an internal IR.
@@ -820,7 +838,7 @@ impl Lower for WhereClause {
     }
 }
 
-impl Lower for QuantifiedWhereClause {
+impl LowerWithEnv for QuantifiedWhereClause {
     type Lowered = Vec<chalk_ir::QuantifiedWhereClause<ChalkIr>>;
 
     /// Lower from an AST `where` clause to an internal IR.
@@ -828,13 +846,13 @@ impl Lower for QuantifiedWhereClause {
     /// As for now, this is the only the case for `where T: Foo<Item = U>` which lowers to
     /// `Implemented(T: Foo)` and `ProjectionEq(<T as Foo>::Item = U)`.
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
-        let variable_kinds = self.variable_kinds.iter().map(lower_variable_kind);
+        let variable_kinds = self.variable_kinds.iter().map(|k| k.lower());
         let binders = env.in_binders(variable_kinds, |env| Ok(self.where_clause.lower(env)?))?;
         Ok(binders.into_iter().collect())
     }
 }
 
-impl Lower for DomainGoal {
+impl LowerWithEnv for DomainGoal {
     type Lowered = Vec<chalk_ir::DomainGoal<ChalkIr>>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -886,7 +904,7 @@ impl Lower for DomainGoal {
     }
 }
 
-impl Lower for LeafGoal {
+impl LowerWithEnv for LeafGoal {
     type Lowered = chalk_ir::Goal<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -947,10 +965,14 @@ fn lower_adt(
     })
 }
 
-fn lower_adt_repr(adt_repr: &AdtRepr) -> rust_ir::AdtRepr {
-    rust_ir::AdtRepr {
-        repr_c: adt_repr.repr_c,
-        repr_packed: adt_repr.repr_packed,
+impl Lower for AdtRepr {
+    type Lowered = rust_ir::AdtRepr;
+
+    fn lower(&self) -> Self::Lowered {
+        rust_ir::AdtRepr {
+            repr_c: self.repr_c,
+            repr_packed: self.repr_packed,
+        }
     }
 }
 
@@ -982,28 +1004,35 @@ fn lower_fn_def(
 
     Ok(rust_ir::FnDefDatum {
         id: fn_def_id,
-        sig: lower_fn_sig(&fn_defn.sig)?,
+        sig: fn_defn.sig.lower()?,
         binders,
     })
 }
 
-fn lower_fn_sig(fn_sig: &FnSig) -> LowerResult<chalk_ir::FnSig<ChalkIr>> {
-    Ok(chalk_ir::FnSig {
-        abi: lower_fn_abi(&fn_sig.abi)?,
-        safety: lower_safety(&fn_sig.safety),
-        variadic: fn_sig.variadic,
-    })
-}
+impl Lower for FnSig {
+    type Lowered = LowerResult<chalk_ir::FnSig<ChalkIr>>;
 
-fn lower_fn_abi(fn_abi: &FnAbi) -> LowerResult<ChalkFnAbi> {
-    match fn_abi.0.as_ref() {
-        "Rust" => Ok(ChalkFnAbi::Rust),
-        "C" => Ok(ChalkFnAbi::C),
-        _ => Err(RustIrError::InvalidExternAbi(fn_abi.0.clone())),
+    fn lower(&self) -> Self::Lowered {
+        Ok(chalk_ir::FnSig {
+            abi: self.abi.lower()?,
+            safety: self.safety.lower(),
+            variadic: self.variadic,
+        })
     }
 }
 
-impl Lower for ClosureDefn {
+impl Lower for FnAbi {
+    type Lowered = LowerResult<ChalkFnAbi>;
+    fn lower(&self) -> Self::Lowered {
+        match self.0.as_ref() {
+            "Rust" => Ok(ChalkFnAbi::Rust),
+            "C" => Ok(ChalkFnAbi::C),
+            _ => Err(RustIrError::InvalidExternAbi(self.0.clone())),
+        }
+    }
+}
+
+impl LowerWithEnv for ClosureDefn {
     type Lowered = (
         rust_ir::ClosureKind,
         chalk_ir::Binders<rust_ir::FnDefInputsAndOutputDatum<ChalkIr>>,
@@ -1019,19 +1048,23 @@ impl Lower for ClosureDefn {
             })
         })?;
 
-        Ok((lower_closure_kind(&self.kind), inputs_and_output))
+        Ok((self.kind.lower(), inputs_and_output))
     }
 }
 
-fn lower_closure_kind(closure_kind: &ClosureKind) -> rust_ir::ClosureKind {
-    match closure_kind {
-        ClosureKind::Fn => rust_ir::ClosureKind::Fn,
-        ClosureKind::FnMut => rust_ir::ClosureKind::FnMut,
-        ClosureKind::FnOnce => rust_ir::ClosureKind::FnOnce,
+impl Lower for ClosureKind {
+    type Lowered = rust_ir::ClosureKind;
+
+    fn lower(&self) -> Self::Lowered {
+        match self {
+            ClosureKind::Fn => rust_ir::ClosureKind::Fn,
+            ClosureKind::FnMut => rust_ir::ClosureKind::FnMut,
+            ClosureKind::FnOnce => rust_ir::ClosureKind::FnOnce,
+        }
     }
 }
 
-impl Lower for TraitRef {
+impl LowerWithEnv for TraitRef {
     type Lowered = chalk_ir::TraitRef<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1047,7 +1080,7 @@ impl Lower for TraitRef {
     }
 }
 
-impl Lower for TraitBound {
+impl LowerWithEnv for TraitBound {
     type Lowered = rust_ir::TraitBound<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1090,7 +1123,7 @@ impl Lower for TraitBound {
     }
 }
 
-impl Lower for AliasEqBound {
+impl LowerWithEnv for AliasEqBound {
     type Lowered = rust_ir::AliasEqBound<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1135,7 +1168,7 @@ impl Lower for AliasEqBound {
     }
 }
 
-impl Lower for InlineBound {
+impl LowerWithEnv for InlineBound {
     type Lowered = rust_ir::InlineBound<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1147,17 +1180,17 @@ impl Lower for InlineBound {
     }
 }
 
-impl Lower for QuantifiedInlineBound {
+impl LowerWithEnv for QuantifiedInlineBound {
     type Lowered = rust_ir::QuantifiedInlineBound<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
-        let variable_kinds = self.variable_kinds.iter().map(lower_variable_kind);
+        let variable_kinds = self.variable_kinds.iter().map(|k| k.lower());
         let binders = env.in_binders(variable_kinds, |env| Ok(self.bound.lower(env)?))?;
         Ok(binders)
     }
 }
 
-impl Lower for [QuantifiedInlineBound] {
+impl LowerWithEnv for [QuantifiedInlineBound] {
     type Lowered = Vec<rust_ir::QuantifiedInlineBound<ChalkIr>>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1190,32 +1223,43 @@ impl Lower for [QuantifiedInlineBound] {
     }
 }
 
-fn lower_polarity(polarity: &Polarity) -> rust_ir::Polarity {
-    match polarity {
-        Polarity::Positive => rust_ir::Polarity::Positive,
-        Polarity::Negative => rust_ir::Polarity::Negative,
+impl Lower for Polarity {
+    type Lowered = rust_ir::Polarity;
+
+    fn lower(&self) -> Self::Lowered {
+        match self {
+            Polarity::Positive => rust_ir::Polarity::Positive,
+            Polarity::Negative => rust_ir::Polarity::Negative,
+        }
     }
 }
 
-fn lower_impl_type(impl_type: &ImplType) -> rust_ir::ImplType {
-    match impl_type {
-        ImplType::Local => rust_ir::ImplType::Local,
-        ImplType::External => rust_ir::ImplType::External,
+impl Lower for ImplType {
+    type Lowered = rust_ir::ImplType;
+    fn lower(&self) -> Self::Lowered {
+        match self {
+            ImplType::Local => rust_ir::ImplType::Local,
+            ImplType::External => rust_ir::ImplType::External,
+        }
     }
 }
 
-fn lower_trait_flags(trait_flags: &TraitFlags) -> rust_ir::TraitFlags {
-    rust_ir::TraitFlags {
-        auto: trait_flags.auto,
-        marker: trait_flags.marker,
-        upstream: trait_flags.upstream,
-        fundamental: trait_flags.fundamental,
-        non_enumerable: trait_flags.non_enumerable,
-        coinductive: trait_flags.coinductive,
+impl Lower for TraitFlags {
+    type Lowered = rust_ir::TraitFlags;
+
+    fn lower(&self) -> Self::Lowered {
+        rust_ir::TraitFlags {
+            auto: self.auto,
+            marker: self.marker,
+            upstream: self.upstream,
+            fundamental: self.fundamental,
+            non_enumerable: self.non_enumerable,
+            coinductive: self.coinductive,
+        }
     }
 }
 
-impl Lower for ProjectionTy {
+impl LowerWithEnv for ProjectionTy {
     type Lowered = chalk_ir::ProjectionTy<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1265,7 +1309,7 @@ impl Lower for ProjectionTy {
     }
 }
 
-impl Lower for Ty {
+impl LowerWithEnv for Ty {
     type Lowered = chalk_ir::Ty<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1385,7 +1429,7 @@ impl Lower for Ty {
                 let function = chalk_ir::FnPointer {
                     num_binders: lifetime_names.len(),
                     substitution: Substitution::from_iter(interner, lowered_tys),
-                    sig: lower_fn_sig(sig)?,
+                    sig: sig.lower()?,
                 };
                 Ok(chalk_ir::TyData::Function(function).intern(interner))
             }
@@ -1399,7 +1443,7 @@ impl Lower for Ty {
             .intern(interner)),
 
             Ty::Scalar { ty } => Ok(chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
-                name: chalk_ir::TypeName::Scalar(lower_scalar_type(ty)),
+                name: chalk_ir::TypeName::Scalar(ty.lower()),
                 substitution: chalk_ir::Substitution::empty(interner),
             })
             .intern(interner)),
@@ -1426,7 +1470,7 @@ impl Lower for Ty {
             .intern(interner)),
 
             Ty::Raw { mutability, ty } => Ok(chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
-                name: chalk_ir::TypeName::Raw(lower_mutability(mutability)),
+                name: chalk_ir::TypeName::Raw(mutability.lower()),
                 substitution: chalk_ir::Substitution::from_fallible(
                     interner,
                     std::iter::once(Ok(ty.lower(env)?)),
@@ -1439,7 +1483,7 @@ impl Lower for Ty {
                 lifetime,
                 ty,
             } => Ok(chalk_ir::TyData::Apply(chalk_ir::ApplicationTy {
-                name: chalk_ir::TypeName::Ref(lower_mutability(mutability)),
+                name: chalk_ir::TypeName::Ref(mutability.lower()),
                 substitution: chalk_ir::Substitution::from_iter(
                     interner,
                     &[
@@ -1465,7 +1509,7 @@ impl Lower for Ty {
     }
 }
 
-impl Lower for Const {
+impl LowerWithEnv for Const {
     type Lowered = chalk_ir::Const<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1491,7 +1535,7 @@ impl Lower for Const {
     }
 }
 
-impl Lower for GenericArg {
+impl LowerWithEnv for GenericArg {
     type Lowered = chalk_ir::GenericArg<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1505,7 +1549,7 @@ impl Lower for GenericArg {
     }
 }
 
-impl Lower for Lifetime {
+impl LowerWithEnv for Lifetime {
     type Lowered = chalk_ir::Lifetime<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1532,7 +1576,7 @@ fn lower_impl(
     impl_id: ImplId<ChalkIr>,
     associated_ty_value_ids: &AssociatedTyValueIds,
 ) -> LowerResult<rust_ir::ImplDatum<ChalkIr>> {
-    let polarity = lower_polarity(&impl_.polarity);
+    let polarity = impl_.polarity.lower();
     let binders = empty_env.in_binders(impl_.all_parameters(), |env| {
         let trait_ref = impl_.trait_ref.lower(env)?;
         debug!(?trait_ref);
@@ -1565,12 +1609,12 @@ fn lower_impl(
     Ok(rust_ir::ImplDatum {
         polarity,
         binders,
-        impl_type: lower_impl_type(&impl_.impl_type),
+        impl_type: impl_.impl_type.lower(),
         associated_ty_value_ids,
     })
 }
 
-impl Lower for Clause {
+impl LowerWithEnv for Clause {
     type Lowered = Vec<chalk_ir::ProgramClause<ChalkIr>>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1641,9 +1685,9 @@ fn lower_trait(
     let trait_datum = rust_ir::TraitDatum {
         id: trait_id,
         binders,
-        flags: lower_trait_flags(&trait_defn.flags),
+        flags: trait_defn.flags.lower(),
         associated_ty_ids,
-        well_known: trait_defn.well_known.map(lower_well_known_trait),
+        well_known: trait_defn.well_known.map(|def| def.lower()),
     };
 
     debug!(?trait_datum);
@@ -1696,7 +1740,7 @@ pub fn lower_goal(goal: &Goal, program: &LoweredProgram) -> LowerResult<chalk_ir
     goal.lower(&env)
 }
 
-impl Lower for Goal {
+impl LowerWithEnv for Goal {
     type Lowered = chalk_ir::Goal<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1748,21 +1792,25 @@ fn lower_quantified(
         return goal.lower(env);
     }
 
-    let variable_kinds = variable_kinds.iter().map(lower_variable_kind);
+    let variable_kinds = variable_kinds.iter().map(|k| k.lower());
     let subgoal = env.in_binders(variable_kinds, |env| goal.lower(env))?;
     Ok(chalk_ir::GoalData::Quantified(quantifier_kind, subgoal).intern(interner))
 }
 
-fn lower_well_known_trait(well_known_trait: WellKnownTrait) -> rust_ir::WellKnownTrait {
-    match well_known_trait {
-        WellKnownTrait::Sized => rust_ir::WellKnownTrait::Sized,
-        WellKnownTrait::Copy => rust_ir::WellKnownTrait::Copy,
-        WellKnownTrait::Clone => rust_ir::WellKnownTrait::Clone,
-        WellKnownTrait::Drop => rust_ir::WellKnownTrait::Drop,
-        WellKnownTrait::FnOnce => rust_ir::WellKnownTrait::FnOnce,
-        WellKnownTrait::FnMut => rust_ir::WellKnownTrait::FnMut,
-        WellKnownTrait::Fn => rust_ir::WellKnownTrait::Fn,
-        WellKnownTrait::Unsize => rust_ir::WellKnownTrait::Unsize,
+impl Lower for WellKnownTrait {
+    type Lowered = rust_ir::WellKnownTrait;
+
+    fn lower(&self) -> Self::Lowered {
+        match self {
+            WellKnownTrait::Sized => rust_ir::WellKnownTrait::Sized,
+            WellKnownTrait::Copy => rust_ir::WellKnownTrait::Copy,
+            WellKnownTrait::Clone => rust_ir::WellKnownTrait::Clone,
+            WellKnownTrait::Drop => rust_ir::WellKnownTrait::Drop,
+            WellKnownTrait::FnOnce => rust_ir::WellKnownTrait::FnOnce,
+            WellKnownTrait::FnMut => rust_ir::WellKnownTrait::FnMut,
+            WellKnownTrait::Fn => rust_ir::WellKnownTrait::Fn,
+            WellKnownTrait::Unsize => rust_ir::WellKnownTrait::Unsize,
+        }
     }
 }
 
@@ -1791,43 +1839,53 @@ impl Kinded for chalk_ir::GenericArg<ChalkIr> {
     }
 }
 
-fn lower_scalar_type(scalar_type: &ScalarType) -> chalk_ir::Scalar {
-    match scalar_type {
-        ScalarType::Int(int) => chalk_ir::Scalar::Int(match int {
-            IntTy::I8 => chalk_ir::IntTy::I8,
-            IntTy::I16 => chalk_ir::IntTy::I16,
-            IntTy::I32 => chalk_ir::IntTy::I32,
-            IntTy::I64 => chalk_ir::IntTy::I64,
-            IntTy::I128 => chalk_ir::IntTy::I128,
-            IntTy::Isize => chalk_ir::IntTy::Isize,
-        }),
-        ScalarType::Uint(uint) => chalk_ir::Scalar::Uint(match uint {
-            UintTy::U8 => chalk_ir::UintTy::U8,
-            UintTy::U16 => chalk_ir::UintTy::U16,
-            UintTy::U32 => chalk_ir::UintTy::U32,
-            UintTy::U64 => chalk_ir::UintTy::U64,
-            UintTy::U128 => chalk_ir::UintTy::U128,
-            UintTy::Usize => chalk_ir::UintTy::Usize,
-        }),
-        ScalarType::Float(float) => chalk_ir::Scalar::Float(match float {
-            FloatTy::F32 => chalk_ir::FloatTy::F32,
-            FloatTy::F64 => chalk_ir::FloatTy::F64,
-        }),
-        ScalarType::Bool => chalk_ir::Scalar::Bool,
-        ScalarType::Char => chalk_ir::Scalar::Char,
+impl Lower for ScalarType {
+    type Lowered = chalk_ir::Scalar;
+
+    fn lower(&self) -> Self::Lowered {
+        match self {
+            ScalarType::Int(int) => chalk_ir::Scalar::Int(match int {
+                IntTy::I8 => chalk_ir::IntTy::I8,
+                IntTy::I16 => chalk_ir::IntTy::I16,
+                IntTy::I32 => chalk_ir::IntTy::I32,
+                IntTy::I64 => chalk_ir::IntTy::I64,
+                IntTy::I128 => chalk_ir::IntTy::I128,
+                IntTy::Isize => chalk_ir::IntTy::Isize,
+            }),
+            ScalarType::Uint(uint) => chalk_ir::Scalar::Uint(match uint {
+                UintTy::U8 => chalk_ir::UintTy::U8,
+                UintTy::U16 => chalk_ir::UintTy::U16,
+                UintTy::U32 => chalk_ir::UintTy::U32,
+                UintTy::U64 => chalk_ir::UintTy::U64,
+                UintTy::U128 => chalk_ir::UintTy::U128,
+                UintTy::Usize => chalk_ir::UintTy::Usize,
+            }),
+            ScalarType::Float(float) => chalk_ir::Scalar::Float(match float {
+                FloatTy::F32 => chalk_ir::FloatTy::F32,
+                FloatTy::F64 => chalk_ir::FloatTy::F64,
+            }),
+            ScalarType::Bool => chalk_ir::Scalar::Bool,
+            ScalarType::Char => chalk_ir::Scalar::Char,
+        }
     }
 }
 
-fn lower_mutability(mutability: &Mutability) -> chalk_ir::Mutability {
-    match mutability {
-        Mutability::Mut => chalk_ir::Mutability::Mut,
-        Mutability::Not => chalk_ir::Mutability::Not,
+impl Lower for Mutability {
+    type Lowered = chalk_ir::Mutability;
+    fn lower(&self) -> Self::Lowered {
+        match self {
+            Mutability::Mut => chalk_ir::Mutability::Mut,
+            Mutability::Not => chalk_ir::Mutability::Not,
+        }
     }
 }
 
-fn lower_safety(safety: &Safety) -> chalk_ir::Safety {
-    match safety {
-        Safety::Safe => chalk_ir::Safety::Safe,
-        Safety::Unsafe => chalk_ir::Safety::Unsafe,
+impl Lower for Safety {
+    type Lowered = chalk_ir::Safety;
+    fn lower(&self) -> Self::Lowered {
+        match self {
+            Safety::Safe => chalk_ir::Safety::Safe,
+            Safety::Unsafe => chalk_ir::Safety::Unsafe,
+        }
     }
 }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -815,13 +815,13 @@ fn lower_variable_kind(variable_kind: &VariableKind) -> chalk_ir::WithKind<Chalk
     chalk_ir::WithKind::new(kind, n.str.clone())
 }
 
-trait LowerInEnv {
+trait Lower {
     type Lowered;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered>;
 }
 
-impl LowerInEnv for [QuantifiedWhereClause] {
+impl Lower for [QuantifiedWhereClause] {
     type Lowered = Vec<chalk_ir::QuantifiedWhereClause<ChalkIr>>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -834,7 +834,7 @@ impl LowerInEnv for [QuantifiedWhereClause] {
     }
 }
 
-impl LowerInEnv for WhereClause {
+impl Lower for WhereClause {
     type Lowered = Vec<chalk_ir::WhereClause<ChalkIr>>;
 
     /// Lower from an AST `where` clause to an internal IR.
@@ -874,7 +874,7 @@ impl LowerInEnv for WhereClause {
     }
 }
 
-impl LowerInEnv for QuantifiedWhereClause {
+impl Lower for QuantifiedWhereClause {
     type Lowered = Vec<chalk_ir::QuantifiedWhereClause<ChalkIr>>;
 
     /// Lower from an AST `where` clause to an internal IR.
@@ -888,7 +888,7 @@ impl LowerInEnv for QuantifiedWhereClause {
     }
 }
 
-impl LowerInEnv for DomainGoal {
+impl Lower for DomainGoal {
     type Lowered = Vec<chalk_ir::DomainGoal<ChalkIr>>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -940,7 +940,7 @@ impl LowerInEnv for DomainGoal {
     }
 }
 
-impl LowerInEnv for LeafGoal {
+impl Lower for LeafGoal {
     type Lowered = chalk_ir::Goal<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1057,7 +1057,7 @@ fn lower_fn_abi(fn_abi: &FnAbi) -> LowerResult<ChalkFnAbi> {
     }
 }
 
-impl LowerInEnv for ClosureDefn {
+impl Lower for ClosureDefn {
     type Lowered = (
         rust_ir::ClosureKind,
         chalk_ir::Binders<rust_ir::FnDefInputsAndOutputDatum<ChalkIr>>,
@@ -1085,7 +1085,7 @@ fn lower_closure_kind(closure_kind: &ClosureKind) -> rust_ir::ClosureKind {
     }
 }
 
-impl LowerInEnv for TraitRef {
+impl Lower for TraitRef {
     type Lowered = chalk_ir::TraitRef<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1101,7 +1101,7 @@ impl LowerInEnv for TraitRef {
     }
 }
 
-impl LowerInEnv for TraitBound {
+impl Lower for TraitBound {
     type Lowered = rust_ir::TraitBound<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1144,7 +1144,7 @@ impl LowerInEnv for TraitBound {
     }
 }
 
-impl LowerInEnv for AliasEqBound {
+impl Lower for AliasEqBound {
     type Lowered = rust_ir::AliasEqBound<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1189,7 +1189,7 @@ impl LowerInEnv for AliasEqBound {
     }
 }
 
-impl LowerInEnv for InlineBound {
+impl Lower for InlineBound {
     type Lowered = rust_ir::InlineBound<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1201,7 +1201,7 @@ impl LowerInEnv for InlineBound {
     }
 }
 
-impl LowerInEnv for QuantifiedInlineBound {
+impl Lower for QuantifiedInlineBound {
     type Lowered = rust_ir::QuantifiedInlineBound<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1211,7 +1211,7 @@ impl LowerInEnv for QuantifiedInlineBound {
     }
 }
 
-impl LowerInEnv for [QuantifiedInlineBound] {
+impl Lower for [QuantifiedInlineBound] {
     type Lowered = Vec<rust_ir::QuantifiedInlineBound<ChalkIr>>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1269,7 +1269,7 @@ fn lower_trait_flags(trait_flags: &TraitFlags) -> rust_ir::TraitFlags {
     }
 }
 
-impl LowerInEnv for ProjectionTy {
+impl Lower for ProjectionTy {
     type Lowered = chalk_ir::ProjectionTy<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1319,7 +1319,7 @@ impl LowerInEnv for ProjectionTy {
     }
 }
 
-impl LowerInEnv for Ty {
+impl Lower for Ty {
     type Lowered = chalk_ir::Ty<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1515,7 +1515,7 @@ impl LowerInEnv for Ty {
     }
 }
 
-impl LowerInEnv for Const {
+impl Lower for Const {
     type Lowered = chalk_ir::Const<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1541,7 +1541,7 @@ impl LowerInEnv for Const {
     }
 }
 
-impl LowerInEnv for GenericArg {
+impl Lower for GenericArg {
     type Lowered = chalk_ir::GenericArg<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1555,7 +1555,7 @@ impl LowerInEnv for GenericArg {
     }
 }
 
-impl LowerInEnv for Lifetime {
+impl Lower for Lifetime {
     type Lowered = chalk_ir::Lifetime<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1620,7 +1620,7 @@ fn lower_impl(
     })
 }
 
-impl LowerInEnv for Clause {
+impl Lower for Clause {
     type Lowered = Vec<chalk_ir::ProgramClause<ChalkIr>>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
@@ -1753,7 +1753,7 @@ pub fn lower_goal(goal: &Goal, program: &LoweredProgram) -> LowerResult<chalk_ir
     goal.lower(&env)
 }
 
-impl LowerInEnv for Goal {
+impl Lower for Goal {
     type Lowered = chalk_ir::Goal<ChalkIr>;
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {

--- a/chalk-integration/src/query.rs
+++ b/chalk-integration/src/query.rs
@@ -3,7 +3,7 @@
 
 use crate::error::ChalkError;
 use crate::interner::ChalkIr;
-use crate::lowering::LowerProgram;
+use crate::lowering::Lower;
 use crate::program::Program;
 use crate::program_environment::ProgramEnvironment;
 use crate::tls;

--- a/chalk-integration/src/query.rs
+++ b/chalk-integration/src/query.rs
@@ -3,7 +3,7 @@
 
 use crate::error::ChalkError;
 use crate::interner::ChalkIr;
-use crate::lowering::lower_program;
+use crate::lowering::Lower;
 use crate::program::Program;
 use crate::program_environment::ProgramEnvironment;
 use crate::tls;
@@ -124,9 +124,7 @@ impl<T> Clone for ArcEq<T> {
 
 fn program_ir(db: &dyn LoweringDatabase) -> Result<Arc<Program>, ChalkError> {
     let text = db.program_text();
-    Ok(Arc::new(lower_program(&chalk_parse::parse_program(
-        &text,
-    )?)?))
+    Ok(Arc::new(chalk_parse::parse_program(&text)?.lower()?))
 }
 
 fn orphan_check(db: &dyn LoweringDatabase) -> Result<(), ChalkError> {

--- a/chalk-integration/src/query.rs
+++ b/chalk-integration/src/query.rs
@@ -3,7 +3,7 @@
 
 use crate::error::ChalkError;
 use crate::interner::ChalkIr;
-use crate::lowering::Lower;
+use crate::lowering::lower_program;
 use crate::program::Program;
 use crate::program_environment::ProgramEnvironment;
 use crate::tls;
@@ -124,7 +124,9 @@ impl<T> Clone for ArcEq<T> {
 
 fn program_ir(db: &dyn LoweringDatabase) -> Result<Arc<Program>, ChalkError> {
     let text = db.program_text();
-    Ok(Arc::new(chalk_parse::parse_program(&text)?.lower()?))
+    Ok(Arc::new(lower_program(&chalk_parse::parse_program(
+        &text,
+    )?)?))
 }
 
 fn orphan_check(db: &dyn LoweringDatabase) -> Result<(), ChalkError> {

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -151,7 +151,7 @@ pub struct AssocTyDefn {
 pub struct OpaqueTyDefn {
     pub ty: Ty,
     pub variable_kinds: Vec<VariableKind>,
-    pub identifier: Identifier,
+    pub name: Identifier,
     pub bounds: Vec<QuantifiedInlineBound>,
     pub where_clauses: Vec<QuantifiedWhereClause>,
 }

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -231,12 +231,12 @@ AssocTyDefn: AssocTyDefn = {
 };
 
 OpaqueTyDefn: OpaqueTyDefn = {
-    "opaque" "type" <identifier:Id> <p:Angle<VariableKind>> ":" <b:Plus<QuantifiedInlineBound>>
+    "opaque" "type" <name:Id> <p:Angle<VariableKind>> ":" <b:Plus<QuantifiedInlineBound>>
         <w:QuantifiedWhereClauses> "=" <ty:Ty> ";" => {
         OpaqueTyDefn {
             ty,
             variable_kinds: p,
-            identifier,
+            name,
             bounds: b,
             where_clauses: w,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ impl LoadedProgram {
         multiple_answers: bool,
     ) -> Result<()> {
         let program = self.db.checked_program()?;
-        let goal = chalk_parse::parse_goal(text)?.lower(&*program)?;
+        let goal = lower_goal(&*chalk_parse::parse_goal(text)?, &*program)?;
         let peeled_goal = goal.into_peeled_goal(self.db.interner());
         if multiple_answers {
             if self.db.solve_multiple(&peeled_goal, &mut |v, has_next| {

--- a/tests/logging_db/util.rs
+++ b/tests/logging_db/util.rs
@@ -5,7 +5,8 @@
 //! to `test/`. We can't compile without access to `test/`, so we can't be under
 //! of `test_util.rs`.
 use chalk_integration::{
-    db::ChalkDatabase, lowering::LowerGoal, program::Program, query::LoweringDatabase, SolverChoice,
+    db::ChalkDatabase, lowering::lower_goal, program::Program, query::LoweringDatabase,
+    SolverChoice,
 };
 use chalk_solve::ext::*;
 use chalk_solve::logging_db::LoggingRustIrDatabase;
@@ -47,10 +48,11 @@ pub fn logging_db_output_sufficient(
                 println!("goal {}", goal_text);
                 assert!(goal_text.starts_with("{"));
                 assert!(goal_text.ends_with("}"));
-                let goal = chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1])
-                    .unwrap()
-                    .lower(&*program)
-                    .unwrap();
+                let goal = lower_goal(
+                    &*chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1]).unwrap(),
+                    &*program,
+                )
+                .unwrap();
 
                 println!("using solver: {:?}", solver_choice);
                 let peeled_goal = goal.into_peeled_goal(db.interner());
@@ -88,10 +90,11 @@ pub fn logging_db_output_sufficient(
             println!("goal {}", goal_text);
             assert!(goal_text.starts_with("{"));
             assert!(goal_text.ends_with("}"));
-            let goal = chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1])
-                .unwrap()
-                .lower(&*new_program)
-                .unwrap();
+            let goal = lower_goal(
+                &*chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1]).unwrap(),
+                &*new_program,
+            )
+            .unwrap();
 
             println!("using solver: {:?}", solver_choice);
             let peeled_goal = goal.into_peeled_goal(db.interner());

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -3,7 +3,7 @@
 use crate::test_util::assert_same;
 use chalk_integration::db::ChalkDatabase;
 use chalk_integration::interner::ChalkIr;
-use chalk_integration::lowering::LowerGoal;
+use chalk_integration::lowering::lower_goal;
 use chalk_integration::query::LoweringDatabase;
 use chalk_integration::SolverChoice;
 use chalk_ir::Constraints;
@@ -254,10 +254,11 @@ fn solve_goal(program_text: &str, goals: Vec<(&str, SolverChoice, TestGoal)>, co
                 println!("goal {}", goal_text);
                 assert!(goal_text.starts_with("{"));
                 assert!(goal_text.ends_with("}"));
-                let goal = chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1])
-                    .unwrap()
-                    .lower(&*program)
-                    .unwrap();
+                let goal = lower_goal(
+                    &*chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1]).unwrap(),
+                    &*program,
+                )
+                .unwrap();
 
                 println!("using solver: {:?}", solver_choice);
                 let peeled_goal = goal.into_peeled_goal(db.interner());


### PR DESCRIPTION
- Moved lowering functions that just take `Env` to a single `Lower` trait with associated `type Lowered`, to get rid of all the single-use traits. This retains `.lower(env)` chaining for the most important types.
- Changed lowering functions with extra params to freestanding functions. These could in principle be handled by the same trait, by making the argument generic, but that would make it less clear, and having lowering functions that take extra parameters named differenlty is a good thing, so they stand out.
- Same for lowering functions that don't take an environment. These often aren't chained anyways, and having names like  `lower_adt_repr` makes the code clearer IMO.
- Use macros to reduce boilerplate around `LowerParameterMap` (also removing some unused functions there) and `lower_type_kind` (renamed `OpaqueTyDefn.identifier` to `OpaqueTyDefn.name` to line things up better)
- Re-use `lookup_apply_type` in `ApplyTypeLookup` by changing it slightly, to avoid duplicating map lookup code