### PR TITLE
Don't add wf clauses for function args

### DIFF
--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -755,12 +755,6 @@ fn match_ty<I: Interner>(
             .to_program_clauses(builder, environment),
         TyData::Function(quantified_ty) => {
             builder.push_fact(WellFormed::Ty(ty.clone()));
-            quantified_ty
-                .substitution
-                .iter(interner)
-                .map(|p| p.assert_ty_ref(interner))
-                .map(|ty| match_ty(builder, environment, &ty))
-                .collect::<Result<_, Floundered>>()?;
         }
         TyData::BoundVar(_) | TyData::InferenceVar(_, _) => return Err(Floundered),
         TyData::Dyn(_) => {}


### PR DESCRIPTION
Closes #556

We might want to add this back in *correctly* at some point, but it does need some design work anyways (in terms of what WF functions mean). For now, this is broken and not needed for any tests. So remove it.