### PR TITLE
Format parse errors better

### DIFF
--- a/chalk-parse/src/lib.rs
+++ b/chalk-parse/src/lib.rs
@@ -16,14 +16,14 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 pub fn parse_program(text: &str) -> Result<ast::Program> {
     match parser::ProgramParser::new().parse(text) {
         Ok(v) => Ok(v),
-        Err(e) => Err(format!("parse error: {:?}", e))?,
+        Err(e) => Err(format!("parse error: {}", e))?,
     }
 }
 
 pub fn parse_ty(text: &str) -> Result<ast::Ty> {
     match parser::TyParser::new().parse(text) {
         Ok(v) => Ok(v),
-        Err(e) => Err(format!("error parsing `{}`: {:?}", text, e))?,
+        Err(e) => Err(format!("error parsing `{}`: {}", text, e))?,
     }
 }
 
@@ -42,7 +42,7 @@ pub fn parse_goal(text: &str) -> Result<Box<ast::Goal>> {
             };
             match e {
                 ParseError::InvalidToken { location } => Err(format!(
-                    "parse error: {:?}\n{}",
+                    "parse error: {}\n{}",
                     e,
                     position_string(location, location + 1)
                 ))?,
@@ -50,7 +50,7 @@ pub fn parse_goal(text: &str) -> Result<Box<ast::Goal>> {
                     token: (start, _, end),
                     ..
                 } => Err(format!(
-                    "parse error: {:?}\n{}",
+                    "parse error: {}\n{}",
                     e,
                     position_string(start, end)
                 ))?,
@@ -58,11 +58,11 @@ pub fn parse_goal(text: &str) -> Result<Box<ast::Goal>> {
                     token: (start, _, end),
                     ..
                 } => Err(format!(
-                    "parse error: {:?}\n{}",
+                    "parse error: {}\n{}",
                     e,
                     position_string(start, end)
                 ))?,
-                _ => Err(format!("parse error: {:?}", e))?,
+                _ => Err(format!("parse error: {}", e))?,
             }
         }
     }

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -503,7 +503,7 @@ fn scalars() {
         }
 
         error_msg {
-            "parse error: UnrecognizedToken"
+            "parse error: Unrecognizedtoken"
         }
     }
 }
@@ -527,7 +527,7 @@ fn raw_pointers() {
             struct *const i32 { }
         }
         error_msg {
-            "parse error: UnrecognizedToken"
+            "parse error: Unrecognizedtoken"
         }
     }
 
@@ -537,7 +537,7 @@ fn raw_pointers() {
             impl Foo for *i32 { }
         }
         error_msg {
-            "parse error: UnrecognizedToken"
+            "parse error: Unrecognizedtoken"
         }
     }
 }
@@ -561,7 +561,7 @@ fn refs() {
         }
 
         error_msg {
-            "parse error: UnrecognizedToken"
+            "parse error: Unrecognizedtoken"
         }
     }
 }
@@ -587,7 +587,7 @@ fn slices() {
         }
 
         error_msg {
-            "parse error: UnrecognizedToken"
+            "parse error: Unrecognizedtoken"
         }
     }
 }
@@ -635,7 +635,7 @@ fn arrays() {
         }
 
         error_msg {
-            "parse error: UnrecognizedToken"
+            "parse error: Unrecognizedtoken"
         }
     }
 
@@ -659,7 +659,7 @@ fn arrays() {
         }
 
         error_msg {
-            "parse error: UnrecognizedToken"
+            "parse error: Unrecognizedtoken"
         }
     }
 }


### PR DESCRIPTION
Previously the parser printed parse errors with Debug formatting, even
though Display formatting is implemented and looks much better.

Before:

    ?- load libstd.chalk
    ?- forall<T: Clone> { Vec<T>: Clone }
    error: parse error: UnrecognizedToken { token: (8, Token(17, ":"), 9), expected: ["\",\"", "\">\""] }
    position: `forall<T: Clone> { Vec<T>: Clone }`
                       ^

After:

    ?- load libstd.chalk
    ?- forall<T: Clone> { Vec<T>: Clone }
    error: parse error: Unrecognized token `:` found at 8:9
    Expected one of "," or ">"
    position: `forall<T: Clone> { Vec<T>: Clone }`
                       ^
