### PR TITLE
Clauses cleanup

### DIFF
--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1346,12 +1346,7 @@ impl<I: Interner> AliasTy<I> {
     /// Gets the type parameters of the `Self` type in this alias type.
     pub fn self_type_parameter(&self, interner: &I) -> Ty<I> {
         match self {
-            AliasTy::Projection(projection_ty) => projection_ty
-                .substitution
-                .iter(interner)
-                .find_map(move |p| p.ty(interner))
-                .unwrap()
-                .clone(),
+            AliasTy::Projection(projection_ty) => projection_ty.self_type_parameter(interner),
             _ => todo!(),
         }
     }
@@ -1367,6 +1362,17 @@ pub struct ProjectionTy<I: Interner> {
 }
 
 impl<I: Interner> Copy for ProjectionTy<I> where I::InternedSubstitution: Copy {}
+
+impl<I: Interner> ProjectionTy<I> {
+    /// Gets the type parameters of the `Self` type in this alias type.
+    pub fn self_type_parameter(&self, interner: &I) -> Ty<I> {
+        self.substitution
+            .iter(interner)
+            .find_map(move |p| p.ty(interner))
+            .unwrap()
+            .clone()
+    }
+}
 
 /// An opaque type `opaque type T<..>: Trait = HiddenTy`.
 #[derive(Clone, PartialEq, Eq, Hash, Fold, Visit, HasInterner, Zip)]

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -75,8 +75,10 @@ fn constituent_types<I: Interner>(db: &dyn RustIrDatabase<I>, ty: &TyKind<I>) ->
         TyKind::Alias(_) => panic!("this function should not be called for alias"),
         TyKind::Foreign(_) => panic!("constituent_types of foreign types are unknown!"),
         TyKind::Error => Vec::new(),
-        TyKind::OpaqueType(_, _) => unimplemented!(),
-        TyKind::AssociatedType(_, _) => unimplemented!(),
+        TyKind::OpaqueType(_, _) => panic!("constituent_types of opaque types are unknown!"),
+        TyKind::AssociatedType(_, _) => {
+            panic!("constituent_types of associated types are unknown!")
+        }
     }
 }
 
@@ -176,12 +178,16 @@ pub fn push_auto_trait_impls<I: Interner>(
             Ok(())
         }
 
-        // Unimplemented
-        TyKind::OpaqueType(_, _) => Ok(()),
-        TyKind::AssociatedType(_, _) => Ok(()),
+        TyKind::OpaqueType(opaque_ty_id, _) => {
+            push_auto_trait_impls_opaque(builder, auto_trait_id, *opaque_ty_id);
+            Ok(())
+        }
 
         // No auto traits
-        TyKind::Placeholder(_) | TyKind::Dyn(_) | TyKind::Alias(_) => Ok(()),
+        TyKind::AssociatedType(_, _)
+        | TyKind::Placeholder(_)
+        | TyKind::Dyn(_)
+        | TyKind::Alias(_) => Ok(()),
 
         // app_ty implements AutoTrait if all constituents of app_ty implement AutoTrait
         _ => {

--- a/tests/test/opaque_types.rs
+++ b/tests/test/opaque_types.rs
@@ -205,3 +205,40 @@ fn opaque_auto_traits() {
         }
     }
 }
+
+#[test]
+fn opaque_auto_traits_indirect() {
+    test! {
+        program {
+            struct Bar { }
+            struct Baz { }
+            trait Trait { }
+
+            impl Trait for Bar { }
+            impl Trait for Baz { }
+
+            #[auto]
+            trait Send { }
+            trait SendDerived where Self: Send { }
+
+            impl<T> SendDerived for T where T: Send { }
+
+            impl !Send for Baz { }
+
+            opaque type Opaque1: Trait = Bar;
+            opaque type Opaque2: Trait = Baz;
+        }
+
+        goal {
+            Opaque1: SendDerived
+        } yields {
+            "Unique"
+        }
+
+        goal {
+            Opaque2: SendDerived
+        } yields {
+            "No possible solution"
+        }
+    }
+}

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -1043,3 +1043,67 @@ fn guidance_for_projection_on_flounder() {
         }
     }
 }
+
+#[test]
+fn projection_to_dyn() {
+    test! {
+        program {
+            trait AsDyn {
+                type Dyn;
+            }
+
+            #[object_safe]
+            trait Debug {}
+
+            impl AsDyn for () {
+                type Dyn = dyn Debug + 'static;
+            }
+        }
+
+        goal {
+            <() as AsDyn>::Dyn: Debug
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+    }
+}
+
+#[test]
+fn projection_to_opaque() {
+    test! {
+        program {
+            #[non_enumerable]
+            trait Debug {
+                type Output;
+            }
+
+            impl Debug for () {
+                type Output = ();
+            }
+
+            opaque type OpaqueDebug: Debug<Output = ()> = ();
+
+            struct A {}
+
+            trait AsProj {
+                type Proj;
+            }
+
+            impl AsProj for A {
+                type Proj = OpaqueDebug;
+            }
+        }
+
+        goal {
+            <A as AsProj>::Proj: Debug
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            <<A as AsProj>::Proj as Debug>::Output = ()
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+    }
+}


### PR DESCRIPTION
- Add basic clauses for trait objects being wf
- Push clauses for auto traits on `TyKind::OpaqueType`
- Use a single match on the `TyKind` for Implemented goals
- Normalize `TyKind::Alias` self types