### PR TITLE
Program printer: Use Debug to print concrete consts

### DIFF
--- a/chalk-solve/src/display/ty.rs
+++ b/chalk-solve/src/display/ty.rs
@@ -259,7 +259,7 @@ impl<I: Interner> RenderAsRust<I> for ConstValue<I> {
             ConstValue::BoundVar(v) => write!(f, "{}", s.display_bound_var(v)),
             ConstValue::InferenceVar(_) => write!(f, "_"),
             ConstValue::Placeholder(_) => write!(f, "<const placeholder>"),
-            ConstValue::Concrete(_value) => unimplemented!("const values"),
+            ConstValue::Concrete(value) => write!(f, "{:?}", value.interned),
         }
     }
 }


### PR DESCRIPTION
Most importantly, we shouldn't panic for them. I was considering requiring `Interner::InternedConcreteConst` to implement `Display`, but it already requires `Debug` and I think that may be a better choice anyway. Of course this may result in an invalid program being printed, but that's still better than panicking.