### PR TITLE
Use `ControlFlow` in `Visitor`

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -162,10 +162,7 @@ fn derive_any_visit(
 
     let body = s.each(|bi| {
         quote! {
-            result = result.combine(::chalk_ir::visit::Visit::visit_with(#bi, visitor, outer_binder));
-            if result.return_early() {
-                return result;
-            }
+            ::chalk_ir::try_break!(::chalk_ir::visit::Visit::visit_with(#bi, visitor, outer_binder));
         }
     });
 
@@ -178,19 +175,18 @@ fn derive_any_visit(
     s.bound_impl(
         quote!(::chalk_ir::visit:: #trait_name <#interner>),
         quote! {
-            fn #method_name <'i, R: ::chalk_ir::visit::VisitResult>(
+            fn #method_name <'i>(
                 &self,
-                visitor: &mut dyn ::chalk_ir::visit::Visitor < 'i, #interner, Result = R >,
+                visitor: &mut dyn ::chalk_ir::visit::Visitor < 'i, #interner >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
-            ) -> R
+            ) -> ::chalk_ir::visit::ControlFlow<()>
             where
                 #interner: 'i
             {
-                let mut result = R::new();
                 match *self {
                     #body
                 }
-                return result;
+                ::chalk_ir::visit::ControlFlow::CONTINUE
             }
         },
     )

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -58,7 +58,7 @@ use std::usize;
 
 use chalk_derive::{Fold, HasInterner, Visit};
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::VisitResult;
+use chalk_ir::visit::ControlFlow;
 use chalk_ir::{
     AnswerSubst, Canonical, ConstrainedSubst, Constraint, DebruijnIndex, Goal, InEnvironment,
     Substitution,

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -9,7 +9,7 @@ extern crate self as chalk_ir;
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
 use crate::fold::{Fold, Folder, Subst, SuperFold};
-use crate::visit::{SuperVisit, Visit, VisitExt, VisitResult, Visitor};
+use crate::visit::{ControlFlow, SuperVisit, Visit, VisitExt, Visitor};
 use chalk_derive::{Fold, HasInterner, SuperVisit, Visit, Zip};
 use std::marker::PhantomData;
 

--- a/chalk-ir/src/visit.rs
+++ b/chalk-ir/src/visit.rs
@@ -14,21 +14,27 @@ pub use visitors::VisitExt;
 
 /// An copy of the unstable `std::ops::ControlFlow` for use in Chalk visitors.
 pub enum ControlFlow<B, C = ()> {
+    /// Continue in the loop, using the given value for the next iteration
     Continue(C),
+    /// Exit the loop, yielding the given value
     Break(B),
 }
 
 impl<B, C> ControlFlow<B, C> {
+    /// Returns `true` if this is a `Break` variant.
     #[inline]
     pub fn is_break(&self) -> bool {
         matches!(*self, ControlFlow::Break(_))
     }
 
+    /// Returns `true` if this is a `Continue` variant.
     #[inline]
     pub fn is_continue(&self) -> bool {
         matches!(*self, ControlFlow::Continue(_))
     }
 
+    /// Converts the `ControlFlow` into an `Option` which is `Some`
+    /// if the `ControlFlow` was `Break` and `None` otherwise.
     #[inline]
     pub fn break_value(self) -> Option<B> {
         match self {
@@ -39,13 +45,20 @@ impl<B, C> ControlFlow<B, C> {
 }
 
 impl<B> ControlFlow<B, ()> {
+    /// It's frequently the case that there's no value needed with `Continue`,
+    /// so this provides a way to avoid typing `(())`, if you prefer it.
     pub const CONTINUE: Self = ControlFlow::Continue(());
 }
 
 impl<C> ControlFlow<(), C> {
+    /// APIs like `try_for_each` don't need values with `Break`,
+    /// so this provides a way to avoid typing `(())`, if you prefer it.
     pub const BREAK: Self = ControlFlow::Break(());
 }
 
+/// Unwraps a `ControlFlow` or propagates its `Break` value.
+/// This replaces the `Try` implementation that would be used
+/// with `std::ops::ControlFlow`.
 #[macro_export]
 macro_rules! try_break {
     ($expr:expr) => {

--- a/chalk-ir/src/visit.rs
+++ b/chalk-ir/src/visit.rs
@@ -12,53 +12,48 @@ pub mod visitors;
 
 pub use visitors::VisitExt;
 
-/// A "result type" that can be returned from a visitor. Visitors pick
-/// an appropriate result type depending on what sort of operation they
-/// are doing. A common choice is `FindAny`, which indicates that the visitor
-/// is searching for something and that the visitor should stop once it is found.
-pub trait VisitResult: Sized {
-    /// Creates a new visitor result.
-    fn new() -> Self;
+/// An copy of the unstable `std::ops::ControlFlow` for use in Chalk visitors.
+pub enum ControlFlow<B, C = ()> {
+    Continue(C),
+    Break(B),
+}
 
-    /// Returns true if this result is "complete" and we can stop visiting any
-    /// further parts of the term. This is used by `FindAny`, for example, to
-    /// stop the search after a match has been found.
-    fn return_early(&self) -> bool;
+impl<B, C> ControlFlow<B, C> {
+    #[inline]
+    pub fn is_break(&self) -> bool {
+        matches!(*self, ControlFlow::Break(_))
+    }
 
-    /// Combines two visitor results.
-    fn combine(self, other: Self) -> Self;
+    #[inline]
+    pub fn is_continue(&self) -> bool {
+        matches!(*self, ControlFlow::Continue(_))
+    }
 
-    /// Convenience helper for use in writing `Visitor` impls. Returns `self`
-    /// if `return_early()` is true, but otherwise combines `self` with the
-    /// result of invoking `op`.
-    ///
-    /// If you have a struct with two fields, `foo` and `bar`, you can
-    /// thus write code like
-    ///
-    /// ```rust,ignore
-    /// self.foo.visit_with(visitor, outer_binder)
-    ///     .and_then(|| self.bar.visit_with(visitor, outer_binder))
-    /// ```
-    ///
-    /// and `bar` will only be visited if necessary.
-    fn and_then(self, op: impl FnOnce() -> Self) -> Self {
-        if self.return_early() {
-            self
-        } else {
-            self.combine(op())
+    #[inline]
+    pub fn break_value(self) -> Option<B> {
+        match self {
+            ControlFlow::Continue(..) => None,
+            ControlFlow::Break(x) => Some(x),
         }
     }
 }
 
-/// Unit type for a visitor indicates a "side-effecting" visitor that
-/// should visit an entire term.
-impl VisitResult for () {
-    fn new() -> Self {}
+impl<B> ControlFlow<B, ()> {
+    pub const CONTINUE: Self = ControlFlow::Continue(());
+}
 
-    fn return_early(&self) -> bool {
-        false
-    }
-    fn combine(self, _other: Self) {}
+impl<C> ControlFlow<(), C> {
+    pub const BREAK: Self = ControlFlow::Break(());
+}
+
+#[macro_export]
+macro_rules! try_break {
+    ($expr:expr) => {
+        match $expr {
+            $crate::visit::ControlFlow::Continue(c) => c,
+            $crate::visit::ControlFlow::Break(b) => return $crate::visit::ControlFlow::Break(b),
+        }
+    };
 }
 
 /// A "visitor" recursively folds some term -- that is, some bit of IR,
@@ -74,9 +69,6 @@ pub trait Visitor<'i, I: Interner>
 where
     I: 'i,
 {
-    /// The type of result that this visitor produces.
-    type Result: VisitResult;
-
     /// Creates a `dyn` value from this visitor. Unfortunately, this
     /// must be added manually to each impl of visitor; it permits the
     /// default implements below to create a `&mut dyn Visitor` from
@@ -84,13 +76,13 @@ where
     /// method). Effectively, this limits impls of `visitor` to types
     /// for which we are able to create a dyn value (i.e., not `[T]`
     /// types).
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, Result = Self::Result>;
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I>;
 
     /// Top-level callback: invoked for each `Ty<I>` that is
     /// encountered when visiting. By default, invokes
     /// `super_visit_with`, which will in turn invoke the more
     /// specialized visiting methods below, like `visit_free_var`.
-    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> Self::Result {
+    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         ty.super_visit_with(self.as_dyn(), outer_binder)
     }
 
@@ -102,7 +94,7 @@ where
         &mut self,
         lifetime: &Lifetime<I>,
         outer_binder: DebruijnIndex,
-    ) -> Self::Result {
+    ) -> ControlFlow<()> {
         lifetime.super_visit_with(self.as_dyn(), outer_binder)
     }
 
@@ -110,7 +102,7 @@ where
     /// encountered when visiting. By default, invokes
     /// `super_visit_with`, which will in turn invoke the more
     /// specialized visiting methods below, like `visit_free_var`.
-    fn visit_const(&mut self, constant: &Const<I>, outer_binder: DebruijnIndex) -> Self::Result {
+    fn visit_const(&mut self, constant: &Const<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         constant.super_visit_with(self.as_dyn(), outer_binder)
     }
 
@@ -119,12 +111,12 @@ where
         &mut self,
         clause: &ProgramClause<I>,
         outer_binder: DebruijnIndex,
-    ) -> Self::Result {
+    ) -> ControlFlow<()> {
         clause.super_visit_with(self.as_dyn(), outer_binder)
     }
 
     /// Invoked for every goal. By default, recursively visits the goals contents.
-    fn visit_goal(&mut self, goal: &Goal<I>, outer_binder: DebruijnIndex) -> Self::Result {
+    fn visit_goal(&mut self, goal: &Goal<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         goal.super_visit_with(self.as_dyn(), outer_binder)
     }
 
@@ -133,7 +125,7 @@ where
         &mut self,
         domain_goal: &DomainGoal<I>,
         outer_binder: DebruijnIndex,
-    ) -> Self::Result {
+    ) -> ControlFlow<()> {
         domain_goal.super_visit_with(self.as_dyn(), outer_binder)
     }
 
@@ -146,14 +138,18 @@ where
 
     /// Invoked for `BoundVar` instances that are not bound
     /// within the type being visited over:
-    fn visit_free_var(&mut self, bound_var: BoundVar, outer_binder: DebruijnIndex) -> Self::Result {
+    fn visit_free_var(
+        &mut self,
+        bound_var: BoundVar,
+        outer_binder: DebruijnIndex,
+    ) -> ControlFlow<()> {
         if self.forbid_free_vars() {
             panic!(
                 "unexpected free variable `{:?}` with outer binder {:?}",
                 bound_var, outer_binder
             )
         } else {
-            Self::Result::new()
+            ControlFlow::CONTINUE
         }
     }
 
@@ -169,11 +165,11 @@ where
         &mut self,
         universe: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
-    ) -> Self::Result {
+    ) -> ControlFlow<()> {
         if self.forbid_free_placeholders() {
             panic!("unexpected placeholder type `{:?}`", universe)
         } else {
-            Self::Result::new()
+            ControlFlow::CONTINUE
         }
     }
 
@@ -182,7 +178,7 @@ where
         &mut self,
         where_clause: &WhereClause<I>,
         outer_binder: DebruijnIndex,
-    ) -> Self::Result {
+    ) -> ControlFlow<()> {
         where_clause.super_visit_with(self.as_dyn(), outer_binder)
     }
 
@@ -199,11 +195,11 @@ where
         &mut self,
         var: InferenceVar,
         _outer_binder: DebruijnIndex,
-    ) -> Self::Result {
+    ) -> ControlFlow<()> {
         if self.forbid_inference_vars() {
             panic!("unexpected inference type `{:?}`", var)
         } else {
-            Self::Result::new()
+            ControlFlow::CONTINUE
         }
     }
 
@@ -219,11 +215,11 @@ pub trait Visit<I: Interner>: Debug {
     /// visitor. Typically `binders` starts as 0, but is adjusted when
     /// we encounter `Binders<T>` in the IR or other similar
     /// constructs.
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i;
 }
@@ -233,11 +229,11 @@ pub trait Visit<I: Interner>: Debug {
 /// the contents of the type.
 pub trait SuperVisit<I: Interner>: Visit<I> {
     /// Recursively visits the type contents.
-    fn super_visit_with<'i, R: VisitResult>(
+    fn super_visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i;
 }
@@ -246,11 +242,11 @@ pub trait SuperVisit<I: Interner>: Visit<I> {
 /// usually (in turn) invokes `super_visit_ty` to visit the individual
 /// parts.
 impl<I: Interner> Visit<I> for Ty<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -258,16 +254,16 @@ impl<I: Interner> Visit<I> for Ty<I> {
     }
 }
 
-/// "Super visit" for a type invokes te more detailed callbacks on the type
+/// "Super visit" for a type invokes the more detailed callbacks on the type
 impl<I> SuperVisit<I> for Ty<I>
 where
     I: Interner,
 {
-    fn super_visit_with<'i, R: VisitResult>(
+    fn super_visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -277,7 +273,7 @@ where
                 if let Some(_) = bound_var.shifted_out_to(outer_binder) {
                     visitor.visit_free_var(*bound_var, outer_binder)
                 } else {
-                    R::new()
+                    ControlFlow::CONTINUE
                 }
             }
             TyKind::Dyn(clauses) => clauses.visit_with(visitor, outer_binder),
@@ -290,52 +286,58 @@ where
                 substitution.visit_with(visitor, outer_binder)
             }
             TyKind::Scalar(scalar) => scalar.visit_with(visitor, outer_binder),
-            TyKind::Str => R::new(),
-            TyKind::Tuple(arity, substitution) => arity
-                .visit_with(visitor, outer_binder)
-                .combine(substitution.visit_with(visitor, outer_binder)),
-            TyKind::OpaqueType(opaque_ty, substitution) => opaque_ty
-                .visit_with(visitor, outer_binder)
-                .combine(substitution.visit_with(visitor, outer_binder)),
-            TyKind::Slice(substitution) => substitution.visit_with(visitor, outer_binder),
-            TyKind::FnDef(fn_def, substitution) => fn_def
-                .visit_with(visitor, outer_binder)
-                .combine(substitution.visit_with(visitor, outer_binder)),
-            TyKind::Ref(mutability, lifetime, ty) => {
-                mutability.visit_with(visitor, outer_binder).combine(
-                    lifetime
-                        .visit_with(visitor, outer_binder)
-                        .combine(ty.visit_with(visitor, outer_binder)),
-                )
+            TyKind::Str => ControlFlow::CONTINUE,
+            TyKind::Tuple(arity, substitution) => {
+                try_break!(arity.visit_with(visitor, outer_binder));
+                substitution.visit_with(visitor, outer_binder)
             }
-            TyKind::Raw(mutability, ty) => mutability
-                .visit_with(visitor, outer_binder)
-                .combine(ty.visit_with(visitor, outer_binder)),
-            TyKind::Never => R::new(),
-            TyKind::Array(ty, const_) => ty
-                .visit_with(visitor, outer_binder)
-                .combine(const_.visit_with(visitor, outer_binder)),
-            TyKind::Closure(id, substitution) => id
-                .visit_with(visitor, outer_binder)
-                .combine(substitution.visit_with(visitor, outer_binder)),
-            TyKind::Generator(generator, substitution) => generator
-                .visit_with(visitor, outer_binder)
-                .combine(substitution.visit_with(visitor, outer_binder)),
-            TyKind::GeneratorWitness(witness, substitution) => witness
-                .visit_with(visitor, outer_binder)
-                .combine(substitution.visit_with(visitor, outer_binder)),
+            TyKind::OpaqueType(opaque_ty, substitution) => {
+                try_break!(opaque_ty.visit_with(visitor, outer_binder));
+                substitution.visit_with(visitor, outer_binder)
+            }
+            TyKind::Slice(substitution) => substitution.visit_with(visitor, outer_binder),
+            TyKind::FnDef(fn_def, substitution) => {
+                try_break!(fn_def.visit_with(visitor, outer_binder));
+                substitution.visit_with(visitor, outer_binder)
+            }
+            TyKind::Ref(mutability, lifetime, ty) => {
+                try_break!(mutability.visit_with(visitor, outer_binder));
+                try_break!(lifetime.visit_with(visitor, outer_binder));
+                ty.visit_with(visitor, outer_binder)
+            }
+            TyKind::Raw(mutability, ty) => {
+                try_break!(mutability.visit_with(visitor, outer_binder));
+                ty.visit_with(visitor, outer_binder)
+            }
+            TyKind::Never => ControlFlow::CONTINUE,
+            TyKind::Array(ty, const_) => {
+                try_break!(ty.visit_with(visitor, outer_binder));
+                const_.visit_with(visitor, outer_binder)
+            }
+            TyKind::Closure(id, substitution) => {
+                try_break!(id.visit_with(visitor, outer_binder));
+                substitution.visit_with(visitor, outer_binder)
+            }
+            TyKind::Generator(generator, substitution) => {
+                try_break!(generator.visit_with(visitor, outer_binder));
+                substitution.visit_with(visitor, outer_binder)
+            }
+            TyKind::GeneratorWitness(witness, substitution) => {
+                try_break!(witness.visit_with(visitor, outer_binder));
+                substitution.visit_with(visitor, outer_binder)
+            }
             TyKind::Foreign(foreign_ty) => foreign_ty.visit_with(visitor, outer_binder),
-            TyKind::Error => R::new(),
+            TyKind::Error => ControlFlow::CONTINUE,
         }
     }
 }
 
 impl<I: Interner> Visit<I> for Lifetime<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -344,11 +346,11 @@ impl<I: Interner> Visit<I> for Lifetime<I> {
 }
 
 impl<I: Interner> SuperVisit<I> for Lifetime<I> {
-    fn super_visit_with<'i, R: VisitResult>(
+    fn super_visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -358,25 +360,25 @@ impl<I: Interner> SuperVisit<I> for Lifetime<I> {
                 if let Some(_) = bound_var.shifted_out_to(outer_binder) {
                     visitor.visit_free_var(*bound_var, outer_binder)
                 } else {
-                    R::new()
+                    ControlFlow::CONTINUE
                 }
             }
             LifetimeData::InferenceVar(var) => visitor.visit_inference_var(*var, outer_binder),
             LifetimeData::Placeholder(universe) => {
                 visitor.visit_free_placeholder(*universe, outer_binder)
             }
-            LifetimeData::Static => R::new(),
+            LifetimeData::Static => ControlFlow::CONTINUE,
             LifetimeData::Phantom(..) => unreachable!(),
         }
     }
 }
 
 impl<I: Interner> Visit<I> for Const<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -385,11 +387,11 @@ impl<I: Interner> Visit<I> for Const<I> {
 }
 
 impl<I: Interner> SuperVisit<I> for Const<I> {
-    fn super_visit_with<'i, R: VisitResult>(
+    fn super_visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -399,24 +401,24 @@ impl<I: Interner> SuperVisit<I> for Const<I> {
                 if let Some(_) = bound_var.shifted_out_to(outer_binder) {
                     visitor.visit_free_var(*bound_var, outer_binder)
                 } else {
-                    R::new()
+                    ControlFlow::CONTINUE
                 }
             }
             ConstValue::InferenceVar(var) => visitor.visit_inference_var(*var, outer_binder),
             ConstValue::Placeholder(universe) => {
                 visitor.visit_free_placeholder(*universe, outer_binder)
             }
-            ConstValue::Concrete(_) => R::new(),
+            ConstValue::Concrete(_) => ControlFlow::CONTINUE,
         }
     }
 }
 
 impl<I: Interner> Visit<I> for Goal<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -425,11 +427,11 @@ impl<I: Interner> Visit<I> for Goal<I> {
 }
 
 impl<I: Interner> SuperVisit<I> for Goal<I> {
-    fn super_visit_with<'i, R: VisitResult>(
+    fn super_visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -439,11 +441,11 @@ impl<I: Interner> SuperVisit<I> for Goal<I> {
 }
 
 impl<I: Interner> Visit<I> for ProgramClause<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -452,11 +454,11 @@ impl<I: Interner> Visit<I> for ProgramClause<I> {
 }
 
 impl<I: Interner> Visit<I> for WhereClause<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -465,11 +467,11 @@ impl<I: Interner> Visit<I> for WhereClause<I> {
 }
 
 impl<I: Interner> Visit<I> for DomainGoal<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {

--- a/chalk-ir/src/visit/binder_impls.rs
+++ b/chalk-ir/src/visit/binder_impls.rs
@@ -4,14 +4,14 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::interner::HasInterner;
-use crate::{Binders, Canonical, DebruijnIndex, FnPointer, Interner, Visit, VisitResult, Visitor};
+use crate::{Binders, Canonical, ControlFlow, DebruijnIndex, FnPointer, Interner, Visit, Visitor};
 
 impl<I: Interner> Visit<I> for FnPointer<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -26,11 +26,11 @@ impl<T, I: Interner> Visit<I> for Binders<T>
 where
     T: HasInterner + Visit<I>,
 {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -43,11 +43,11 @@ where
     I: Interner,
     T: HasInterner<Interner = I> + Visit<I>,
 {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {

--- a/chalk-ir/src/visit/visitors.rs
+++ b/chalk-ir/src/visit/visitors.rs
@@ -1,6 +1,6 @@
 //! Visitor helpers
 
-use crate::{BoundVar, DebruijnIndex, Interner, Visit, VisitResult, Visitor};
+use crate::{BoundVar, ControlFlow, DebruijnIndex, Interner, Visit, Visitor};
 
 /// Visitor extensions.
 pub trait VisitExt<I: Interner>: Visit<I> {
@@ -10,52 +10,18 @@ pub trait VisitExt<I: Interner>: Visit<I> {
             &mut FindFreeVarsVisitor { interner },
             DebruijnIndex::INNERMOST,
         )
-        .to_bool()
+        .is_break()
     }
 }
 
 impl<T, I: Interner> VisitExt<I> for T where T: Visit<I> {}
-
-/// Helper visitor for finding a specific value.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(missing_docs)]
-pub struct FindAny {
-    pub found: bool,
-}
-
-impl FindAny {
-    /// Visitor has found the value.
-    pub const FOUND: FindAny = FindAny { found: true };
-
-    /// Checks whether the value has been found.
-    pub fn to_bool(&self) -> bool {
-        self.found
-    }
-}
-
-impl VisitResult for FindAny {
-    fn new() -> Self {
-        FindAny { found: false }
-    }
-
-    fn return_early(&self) -> bool {
-        self.found
-    }
-    fn combine(self, other: Self) -> Self {
-        FindAny {
-            found: self.found || other.found,
-        }
-    }
-}
 
 struct FindFreeVarsVisitor<'i, I: Interner> {
     interner: &'i I,
 }
 
 impl<'i, I: Interner> Visitor<'i, I> for FindFreeVarsVisitor<'i, I> {
-    type Result = FindAny;
-
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, Result = Self::Result> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
         self
     }
 
@@ -67,7 +33,7 @@ impl<'i, I: Interner> Visitor<'i, I> for FindFreeVarsVisitor<'i, I> {
         &mut self,
         _bound_var: BoundVar,
         _outer_binder: DebruijnIndex,
-    ) -> Self::Result {
-        FindAny::FOUND
+    ) -> ControlFlow<()> {
+        ControlFlow::BREAK
     }
 }

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -8,7 +8,7 @@ use crate::RustIrDatabase;
 use crate::Ty;
 use crate::{debug_span, TyKind};
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::{Visit, Visitor};
+use chalk_ir::visit::{ControlFlow, Visit, Visitor};
 use chalk_ir::{DebruijnIndex, Environment};
 use rustc_hash::FxHashSet;
 use tracing::instrument;
@@ -54,9 +54,7 @@ impl<'me, I: Interner> EnvElaborator<'me, I> {
 }
 
 impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
-    type Result = ();
-
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'me, I, Result = Self::Result> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'me, I> {
         self
     }
 
@@ -64,7 +62,7 @@ impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
         self.db.interner()
     }
     #[instrument(level = "debug", skip(self, _outer_binder))]
-    fn visit_ty(&mut self, ty: &Ty<I>, _outer_binder: DebruijnIndex) {
+    fn visit_ty(&mut self, ty: &Ty<I>, _outer_binder: DebruijnIndex) -> ControlFlow<()> {
         match ty.kind(self.interner()) {
             TyKind::Alias(alias_ty) => {
                 match_alias_ty(&mut self.builder, self.environment, alias_ty)
@@ -84,9 +82,14 @@ impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
                     .unwrap()
             }
         }
+        ControlFlow::CONTINUE
     }
 
-    fn visit_domain_goal(&mut self, domain_goal: &DomainGoal<I>, outer_binder: DebruijnIndex) {
+    fn visit_domain_goal(
+        &mut self,
+        domain_goal: &DomainGoal<I>,
+        outer_binder: DebruijnIndex,
+    ) -> ControlFlow<()> {
         if let DomainGoal::FromEnv(from_env) = domain_goal {
             debug_span!("visit_domain_goal", ?from_env);
             match from_env {
@@ -103,9 +106,12 @@ impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
                             .associated_ty_data(associated_ty_id)
                             .to_program_clauses(&mut self.builder, self.environment);
                     }
+                    ControlFlow::CONTINUE
                 }
                 FromEnv::Ty(ty) => ty.visit_with(self, outer_binder),
             }
+        } else {
+            ControlFlow::CONTINUE
         }
     }
 }

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,7 +1,7 @@
 use crate::debug_span;
 use chalk_ir::fold::{Fold, Folder};
 use chalk_ir::interner::{HasInterner, Interner};
-use chalk_ir::visit::{Visit, Visitor};
+use chalk_ir::visit::{ControlFlow, Visit, Visitor};
 use chalk_ir::*;
 
 use super::InferenceTable;
@@ -205,14 +205,17 @@ impl<'i, I: Interner> Visitor<'i, I> for UCollector<'_, 'i, I>
 where
     I: 'i,
 {
-    type Result = ();
-
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, Result = ()> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
         self
     }
 
-    fn visit_free_placeholder(&mut self, universe: PlaceholderIndex, _outer_binder: DebruijnIndex) {
+    fn visit_free_placeholder(
+        &mut self,
+        universe: PlaceholderIndex,
+        _outer_binder: DebruijnIndex,
+    ) -> ControlFlow<()> {
         self.universes.add(universe.ui);
+        ControlFlow::CONTINUE
     }
 
     fn forbid_inference_vars(&self) -> bool {

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -2,7 +2,7 @@
 
 use crate::infer::InferenceTable;
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::{SuperVisit, Visit, Visitor};
+use chalk_ir::visit::{ControlFlow, SuperVisit, Visit, Visitor};
 use chalk_ir::*;
 use std::cmp::max;
 
@@ -39,16 +39,14 @@ impl<'infer, 'i, I: Interner> TySizeVisitor<'infer, 'i, I> {
 }
 
 impl<'infer, 'i, I: Interner> Visitor<'i, I> for TySizeVisitor<'infer, 'i, I> {
-    type Result = ();
-
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, Result = Self::Result> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
         self
     }
 
-    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) {
+    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         if let Some(normalized_ty) = self.infer.normalize_ty_shallow(self.interner, ty) {
             normalized_ty.visit_with(self, outer_binder);
-            return;
+            return ControlFlow::CONTINUE;
         }
 
         self.size += 1;
@@ -63,6 +61,7 @@ impl<'infer, 'i, I: Interner> Visitor<'i, I> for TySizeVisitor<'infer, 'i, I> {
         if self.depth == 0 {
             self.size = 0;
         }
+        ControlFlow::CONTINUE
     }
 
     fn interner(&self) -> &'i I {


### PR DESCRIPTION
This PR (almost) resolves one of the differences between rustc's `TypeVisitor` and chalk's `Visitor` by adopting rustc's design with `std::ops::ControlFlow`.

However as `std::ops::ControlFlow` is still unstable, this PR defines a duplicate of `ControlFlow` in `chalk_ir` along with a `try_break!` macro which behaves like `try!`.