### PR TITLE
Use `Result` as a replacement for `ControlFlow` in `Visitor`

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -162,10 +162,7 @@ fn derive_any_visit(
 
     let body = s.each(|bi| {
         quote! {
-            result = result.combine(::chalk_ir::visit::Visit::visit_with(#bi, visitor, outer_binder));
-            if result.return_early() {
-                return result;
-            }
+            ::chalk_ir::visit::Visit::visit_with(#bi, visitor, outer_binder)?;
         }
     });
 
@@ -178,19 +175,18 @@ fn derive_any_visit(
     s.bound_impl(
         quote!(::chalk_ir::visit:: #trait_name <#interner>),
         quote! {
-            fn #method_name <'i, R: ::chalk_ir::visit::VisitResult>(
+            fn #method_name <'i>(
                 &self,
-                visitor: &mut dyn ::chalk_ir::visit::Visitor < 'i, #interner, Result = R >,
+                visitor: &mut dyn ::chalk_ir::visit::Visitor < 'i, #interner >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
-            ) -> R
+            ) -> ::chalk_ir::visit::ControlFlow<()>
             where
                 #interner: 'i
             {
-                let mut result = R::new();
                 match *self {
                     #body
                 }
-                return result;
+                ::chalk_ir::visit::ControlFlow::Ok(())
             }
         },
     )

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -58,7 +58,7 @@ use std::usize;
 
 use chalk_derive::{Fold, HasInterner, Visit};
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::VisitResult;
+use chalk_ir::visit::ControlFlow;
 use chalk_ir::{
     AnswerSubst, Canonical, ConstrainedSubst, Constraint, DebruijnIndex, Goal, InEnvironment,
     Substitution,

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -9,7 +9,7 @@ extern crate self as chalk_ir;
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
 use crate::fold::{Fold, Folder, Subst, SuperFold};
-use crate::visit::{SuperVisit, Visit, VisitExt, VisitResult, Visitor};
+use crate::visit::{ControlFlow, SuperVisit, Visit, VisitExt, Visitor};
 use chalk_derive::{Fold, HasInterner, SuperVisit, Visit, Zip};
 use std::marker::PhantomData;
 

--- a/chalk-ir/src/visit/binder_impls.rs
+++ b/chalk-ir/src/visit/binder_impls.rs
@@ -4,14 +4,14 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::interner::HasInterner;
-use crate::{Binders, Canonical, DebruijnIndex, FnPointer, Interner, Visit, VisitResult, Visitor};
+use crate::{Binders, Canonical, ControlFlow, DebruijnIndex, FnPointer, Interner, Visit, Visitor};
 
 impl<I: Interner> Visit<I> for FnPointer<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -26,11 +26,11 @@ impl<T, I: Interner> Visit<I> for Binders<T>
 where
     T: HasInterner + Visit<I>,
 {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -43,11 +43,11 @@ where
     I: Interner,
     T: HasInterner<Interner = I> + Visit<I>,
 {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -5,41 +5,20 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::{
-    AdtId, AssocTypeId, ClausePriority, ClosureId, Constraints, DebruijnIndex, FloatTy, FnDefId,
-    ForeignDefId, GeneratorId, GenericArg, Goals, ImplId, IntTy, Interner, Mutability, OpaqueTyId,
-    PlaceholderIndex, ProgramClause, ProgramClauses, QuantifiedWhereClauses, QuantifierKind,
-    Safety, Scalar, Substitution, SuperVisit, TraitId, UintTy, UniverseIndex, Visit, VisitResult,
-    Visitor,
+    AdtId, AssocTypeId, ClausePriority, ClosureId, Constraints, ControlFlow, DebruijnIndex,
+    FloatTy, FnDefId, ForeignDefId, GeneratorId, GenericArg, Goals, ImplId, IntTy, Interner,
+    Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauses,
+    QuantifiedWhereClauses, QuantifierKind, Safety, Scalar, Substitution, SuperVisit, TraitId,
+    UintTy, UniverseIndex, Visit, Visitor,
 };
 use std::{marker::PhantomData, sync::Arc};
 
-/// Convenience function to visit all the items in the iterator it.
-pub fn visit_iter<'i, T, I, R>(
-    it: impl Iterator<Item = T>,
-    visitor: &mut dyn Visitor<'i, I, Result = R>,
-    outer_binder: DebruijnIndex,
-) -> R
-where
-    T: Visit<I>,
-    I: 'i + Interner,
-    R: VisitResult,
-{
-    let mut result = R::new();
-    for e in it {
-        result = result.combine(e.visit_with(visitor, outer_binder));
-        if result.return_early() {
-            return result;
-        }
-    }
-    result
-}
-
 impl<T: Visit<I>, I: Interner> Visit<I> for &T {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -48,37 +27,39 @@ impl<T: Visit<I>, I: Interner> Visit<I> for &T {
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for Vec<T> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
-        visit_iter(self.iter(), visitor, outer_binder)
+        self.iter()
+            .try_for_each(|e| e.visit_with(visitor, outer_binder))
     }
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for &[T] {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
-        visit_iter(self.iter(), visitor, outer_binder)
+        self.iter()
+            .try_for_each(|e| e.visit_with(visitor, outer_binder))
     }
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for Box<T> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -87,11 +68,11 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Box<T> {
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for Arc<T> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -102,16 +83,14 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Arc<T> {
 macro_rules! tuple_visit {
     ($($n:ident),*) => {
         impl<$($n: Visit<I>,)* I: Interner> Visit<I> for ($($n,)*) {
-            fn visit_with<'i, R: VisitResult>(&self, visitor: &mut dyn Visitor<'i, I, Result = R>, outer_binder: DebruijnIndex) -> R where I: 'i
+            fn visit_with<'i>(&self, visitor: &mut dyn Visitor<'i, I>, outer_binder: DebruijnIndex) -> ControlFlow<()> where I: 'i
             {
                 #[allow(non_snake_case)]
                 let &($(ref $n),*) = self;
-                let mut result = R::new();
                 $(
-                    result = result.combine($n.visit_with(visitor, outer_binder));
-                    if result.return_early() { return result; }
+                    $n.visit_with(visitor, outer_binder)?;
                 )*
-                result
+                ControlFlow::Ok(())
             }
         }
     }
@@ -123,27 +102,27 @@ tuple_visit!(A, B, C, D);
 tuple_visit!(A, B, C, D, E);
 
 impl<T: Visit<I>, I: Interner> Visit<I> for Option<T> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
         match self {
             Some(e) => e.visit_with(visitor, outer_binder),
-            None => R::new(),
+            None => ControlFlow::Ok(()),
         }
     }
 }
 
 impl<I: Interner> Visit<I> for GenericArg<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -153,30 +132,32 @@ impl<I: Interner> Visit<I> for GenericArg<I> {
 }
 
 impl<I: Interner> Visit<I> for Substitution<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
         let interner = visitor.interner();
-        visit_iter(self.iter(interner), visitor, outer_binder)
+        self.iter(interner)
+            .try_for_each(|e| e.visit_with(visitor, outer_binder))
     }
 }
 
 impl<I: Interner> Visit<I> for Goals<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
         let interner = visitor.interner();
-        visit_iter(self.iter(interner), visitor, outer_binder)
+        self.iter(interner)
+            .try_for_each(|e| e.visit_with(visitor, outer_binder))
     }
 }
 
@@ -185,15 +166,15 @@ impl<I: Interner> Visit<I> for Goals<I> {
 macro_rules! const_visit {
     ($t:ty) => {
         impl<I: Interner> $crate::visit::Visit<I> for $t {
-            fn visit_with<'i, R: VisitResult>(
+            fn visit_with<'i>(
                 &self,
-                _visitor: &mut dyn ($crate::visit::Visitor<'i, I, Result = R>),
+                _visitor: &mut dyn ($crate::visit::Visitor<'i, I>),
                 _outer_binder: DebruijnIndex,
-            ) -> R
+            ) -> ControlFlow<()>
             where
                 I: 'i,
             {
-                R::new()
+                ControlFlow::Ok(())
             }
         }
     };
@@ -219,15 +200,15 @@ const_visit!(Safety);
 macro_rules! id_visit {
     ($t:ident) => {
         impl<I: Interner> $crate::visit::Visit<I> for $t<I> {
-            fn visit_with<'i, R: VisitResult>(
+            fn visit_with<'i>(
                 &self,
-                _visitor: &mut dyn ($crate::visit::Visitor<'i, I, Result = R>),
+                _visitor: &mut dyn ($crate::visit::Visitor<'i, I>),
                 _outer_binder: DebruijnIndex,
-            ) -> R
+            ) -> ControlFlow<()>
             where
                 I: 'i,
             {
-                R::new()
+                ControlFlow::Ok(())
             }
         }
     };
@@ -244,11 +225,11 @@ id_visit!(GeneratorId);
 id_visit!(ForeignDefId);
 
 impl<I: Interner> SuperVisit<I> for ProgramClause<I> {
-    fn super_visit_with<'i, R: VisitResult>(
+    fn super_visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
@@ -259,59 +240,62 @@ impl<I: Interner> SuperVisit<I> for ProgramClause<I> {
 }
 
 impl<I: Interner> Visit<I> for ProgramClauses<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
         let interner = visitor.interner();
 
-        visit_iter(self.iter(interner), visitor, outer_binder)
+        self.iter(interner)
+            .try_for_each(|e| e.visit_with(visitor, outer_binder))
     }
 }
 
 impl<I: Interner> Visit<I> for Constraints<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
         let interner = visitor.interner();
 
-        visit_iter(self.iter(interner), visitor, outer_binder)
+        self.iter(interner)
+            .try_for_each(|e| e.visit_with(visitor, outer_binder))
     }
 }
 
 impl<I: Interner> Visit<I> for QuantifiedWhereClauses<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, Result = R>,
+        visitor: &mut dyn Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
         let interner = visitor.interner();
 
-        visit_iter(self.iter(interner), visitor, outer_binder)
+        self.iter(interner)
+            .try_for_each(|e| e.visit_with(visitor, outer_binder))
     }
 }
 
 impl<I: Interner> Visit<I> for PhantomData<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        _visitor: &mut dyn Visitor<'i, I, Result = R>,
+        _visitor: &mut dyn Visitor<'i, I>,
         _outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
-        R::new()
+        ControlFlow::Ok(())
     }
 }

--- a/chalk-solve/src/clauses/builtin_traits/unsize.rs
+++ b/chalk-solve/src/clauses/builtin_traits/unsize.rs
@@ -7,7 +7,7 @@ use crate::{Interner, RustIrDatabase, TraitRef, WellKnownTrait};
 use chalk_ir::{
     cast::Cast,
     interner::HasInterner,
-    visit::{visitors::FindAny, SuperVisit, Visit, VisitResult, Visitor},
+    visit::{ControlFlow, SuperVisit, Visit, Visitor},
     Binders, Const, ConstValue, DebruijnIndex, DomainGoal, DynTy, EqGoal, Goal, LifetimeOutlives,
     QuantifiedWhereClauses, Substitution, TraitId, Ty, TyKind, TypeOutlives, WhereClause,
 };
@@ -19,13 +19,11 @@ struct UnsizeParameterCollector<'a, I: Interner> {
 }
 
 impl<'a, I: Interner> Visitor<'a, I> for UnsizeParameterCollector<'a, I> {
-    type Result = ();
-
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I, Result = Self::Result> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I> {
         self
     }
 
-    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> Self::Result {
+    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         let interner = self.interner;
 
         match ty.kind(interner) {
@@ -34,12 +32,13 @@ impl<'a, I: Interner> Visitor<'a, I> for UnsizeParameterCollector<'a, I> {
                 if bound_var.debruijn.shifted_in() == outer_binder {
                     self.parameters.insert(bound_var.index);
                 }
+                ControlFlow::Ok(())
             }
             _ => ty.super_visit_with(self, outer_binder),
         }
     }
 
-    fn visit_const(&mut self, constant: &Const<I>, outer_binder: DebruijnIndex) -> Self::Result {
+    fn visit_const(&mut self, constant: &Const<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         let interner = self.interner;
 
         if let ConstValue::BoundVar(bound_var) = constant.data(interner).value {
@@ -48,6 +47,7 @@ impl<'a, I: Interner> Visitor<'a, I> for UnsizeParameterCollector<'a, I> {
                 self.parameters.insert(bound_var.index);
             }
         }
+        ControlFlow::Ok(())
     }
 
     fn interner(&self) -> &'a I {
@@ -74,13 +74,11 @@ struct ParameterOccurenceCheck<'a, 'p, I: Interner> {
 }
 
 impl<'a, 'p, I: Interner> Visitor<'a, I> for ParameterOccurenceCheck<'a, 'p, I> {
-    type Result = FindAny;
-
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I, Result = Self::Result> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I> {
         self
     }
 
-    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> Self::Result {
+    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         let interner = self.interner;
 
         match ty.kind(interner) {
@@ -88,16 +86,16 @@ impl<'a, 'p, I: Interner> Visitor<'a, I> for ParameterOccurenceCheck<'a, 'p, I> 
                 if bound_var.debruijn.shifted_in() == outer_binder
                     && self.parameters.contains(&bound_var.index)
                 {
-                    FindAny::FOUND
+                    ControlFlow::Err(())
                 } else {
-                    FindAny::new()
+                    ControlFlow::Ok(())
                 }
             }
             _ => ty.super_visit_with(self, outer_binder),
         }
     }
 
-    fn visit_const(&mut self, constant: &Const<I>, outer_binder: DebruijnIndex) -> Self::Result {
+    fn visit_const(&mut self, constant: &Const<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         let interner = self.interner;
 
         match constant.data(interner).value {
@@ -105,12 +103,12 @@ impl<'a, 'p, I: Interner> Visitor<'a, I> for ParameterOccurenceCheck<'a, 'p, I> 
                 if bound_var.debruijn.shifted_in() == outer_binder
                     && self.parameters.contains(&bound_var.index)
                 {
-                    FindAny::FOUND
+                    ControlFlow::Err(())
                 } else {
-                    FindAny::new()
+                    ControlFlow::Ok(())
                 }
             }
-            _ => FindAny::new(),
+            _ => ControlFlow::Ok(()),
         }
     }
 
@@ -128,7 +126,8 @@ fn uses_outer_binder_params<I: Interner>(
         interner,
         parameters,
     };
-    v.visit_with(&mut visitor, DebruijnIndex::INNERMOST) == FindAny::FOUND
+    v.visit_with(&mut visitor, DebruijnIndex::INNERMOST)
+        .is_err()
 }
 
 fn principal_id<'a, I: Interner>(

--- a/chalk-solve/src/clauses/builtin_traits/unsize.rs
+++ b/chalk-solve/src/clauses/builtin_traits/unsize.rs
@@ -63,7 +63,7 @@ fn outer_binder_parameters_used<I: Interner>(
         interner,
         parameters: HashSet::new(),
     };
-    v.visit_with(&mut visitor, DebruijnIndex::INNERMOST);
+    let _ = v.visit_with(&mut visitor, DebruijnIndex::INNERMOST);
     visitor.parameters
 }
 

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -26,7 +26,7 @@ pub(super) fn elaborate_env_clauses<I: Interner>(
     environment: &Environment<I>,
 ) {
     let mut this_round = vec![];
-    in_clauses.visit_with(
+    let _ = in_clauses.visit_with(
         &mut EnvElaborator::new(db, &mut this_round, environment),
         DebruijnIndex::INNERMOST,
     );

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,7 +1,7 @@
 use crate::debug_span;
 use chalk_ir::fold::{Fold, Folder};
 use chalk_ir::interner::{HasInterner, Interner};
-use chalk_ir::visit::{Visit, Visitor};
+use chalk_ir::visit::{ControlFlow, Visit, Visitor};
 use chalk_ir::*;
 
 use super::InferenceTable;
@@ -205,14 +205,17 @@ impl<'i, I: Interner> Visitor<'i, I> for UCollector<'_, 'i, I>
 where
     I: 'i,
 {
-    type Result = ();
-
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, Result = ()> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
         self
     }
 
-    fn visit_free_placeholder(&mut self, universe: PlaceholderIndex, _outer_binder: DebruijnIndex) {
+    fn visit_free_placeholder(
+        &mut self,
+        universe: PlaceholderIndex,
+        _outer_binder: DebruijnIndex,
+    ) -> ControlFlow<()> {
         self.universes.add(universe.ui);
+        ControlFlow::Ok(())
     }
 
     fn forbid_inference_vars(&self) -> bool {

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -25,7 +25,7 @@ impl<I: Interner> InferenceTable<I> {
             universes.add(*universe.skip_kind());
         }
 
-        value0.value.visit_with(
+        let _ = value0.value.visit_with(
             &mut UCollector {
                 universes: &mut universes,
                 interner,

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -31,6 +31,7 @@ use std::collections::BTreeSet;
 /// references parent. IdCollector solves this by collecting all of the directly
 /// related identifiers, allowing those to be rendered as well, ensuring name
 /// resolution is successful.
+#[allow(unused_must_use)] // unused `Result`s from `Visitor`s
 pub fn collect_unrecorded_ids<'i, I: Interner, DB: RustIrDatabase<I>>(
     db: &'i DB,
     identifiers: &'_ BTreeSet<RecordedItemId<I>>,

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -7,7 +7,7 @@ use chalk_ir::cast::Cast;
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    visit::{Visit, VisitResult},
+    visit::{ControlFlow, Visit},
     AdtId, AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, FnDefId, GenericArg, ImplId,
     OpaqueTyId, ProjectionTy, QuantifiedWhereClause, Substitution, ToGenericArg, TraitId, TraitRef,
     Ty, TyKind, VariableKind, WhereClause, WithKind,
@@ -141,19 +141,16 @@ pub struct FnDefDatum<I: Interner> {
 
 /// Avoids visiting `I::FnAbi`
 impl<I: Interner> Visit<I> for FnDefDatum<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn chalk_ir::visit::Visitor<'i, I, Result = R>,
+        visitor: &mut dyn chalk_ir::visit::Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
-        let result = R::new().combine(self.id.visit_with(visitor, outer_binder));
-        if result.return_early() {
-            return result;
-        }
-        result.combine(self.binders.visit_with(visitor, outer_binder))
+        self.id.visit_with(visitor, outer_binder)?;
+        self.binders.visit_with(visitor, outer_binder)
     }
 }
 
@@ -491,23 +488,17 @@ pub struct AssociatedTyDatum<I: Interner> {
 
 // Manual implementation to avoid I::Identifier type.
 impl<I: Interner> Visit<I> for AssociatedTyDatum<I> {
-    fn visit_with<'i, R: VisitResult>(
+    fn visit_with<'i>(
         &self,
-        visitor: &mut dyn chalk_ir::visit::Visitor<'i, I, Result = R>,
+        visitor: &mut dyn chalk_ir::visit::Visitor<'i, I>,
         outer_binder: DebruijnIndex,
-    ) -> R
+    ) -> ControlFlow<()>
     where
         I: 'i,
     {
-        let result = R::new().combine(self.trait_id.visit_with(visitor, outer_binder));
-        if result.return_early() {
-            return result;
-        }
-        let result = result.combine(self.id.visit_with(visitor, outer_binder));
-        if result.return_early() {
-            return result;
-        }
-        result.combine(self.binders.visit_with(visitor, outer_binder))
+        self.trait_id.visit_with(visitor, outer_binder)?;
+        self.id.visit_with(visitor, outer_binder)?;
+        self.binders.visit_with(visitor, outer_binder)
     }
 }
 

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -13,7 +13,7 @@ pub fn needs_truncation<I: Interner>(
     value: impl Visit<I>,
 ) -> bool {
     let mut visitor = TySizeVisitor::new(interner, infer);
-    value.visit_with(&mut visitor, DebruijnIndex::INNERMOST);
+    let _ = value.visit_with(&mut visitor, DebruijnIndex::INNERMOST);
 
     visitor.max_size > max_size
 }
@@ -45,7 +45,7 @@ impl<'infer, 'i, I: Interner> Visitor<'i, I> for TySizeVisitor<'infer, 'i, I> {
 
     fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         if let Some(normalized_ty) = self.infer.normalize_ty_shallow(self.interner, ty) {
-            normalized_ty.visit_with(self, outer_binder);
+            normalized_ty.visit_with(self, outer_binder)?;
             return ControlFlow::Ok(());
         }
 
@@ -53,7 +53,7 @@ impl<'infer, 'i, I: Interner> Visitor<'i, I> for TySizeVisitor<'infer, 'i, I> {
         self.max_size = max(self.size, self.max_size);
 
         self.depth += 1;
-        ty.super_visit_with(self, outer_binder);
+        ty.super_visit_with(self, outer_binder)?;
         self.depth -= 1;
 
         // When we get back to the first invocation, clear the counters.
@@ -89,7 +89,7 @@ mod tests {
                          (placeholder 1)))));
 
         let mut visitor = TySizeVisitor::new(interner, &mut table);
-        ty0.visit_with(&mut visitor, DebruijnIndex::INNERMOST);
+        let _ = ty0.visit_with(&mut visitor, DebruijnIndex::INNERMOST);
         assert!(visitor.max_size == 5);
     }
 
@@ -113,7 +113,7 @@ mod tests {
                         (placeholder 1))));
 
         let mut visitor = TySizeVisitor::new(interner, &mut table);
-        vec![&ty0, &ty1].visit_with(&mut visitor, DebruijnIndex::INNERMOST);
+        let _ = vec![&ty0, &ty1].visit_with(&mut visitor, DebruijnIndex::INNERMOST);
         assert!(visitor.max_size == 5);
     }
 }

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -7,7 +7,7 @@ use chalk_ir::{
     cast::*,
     fold::shift::Shift,
     interner::Interner,
-    visit::{Visit, VisitResult, Visitor},
+    visit::{ControlFlow, Visit, Visitor},
     *,
 };
 use tracing::debug;
@@ -69,9 +69,7 @@ impl<'i, I: Interner> InputTypeCollector<'i, I> {
 }
 
 impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
-    type Result = ();
-
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, Result = Self::Result> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
         self
     }
 
@@ -79,22 +77,24 @@ impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
         self.interner
     }
 
-    fn visit_where_clause(&mut self, where_clause: &WhereClause<I>, outer_binder: DebruijnIndex) {
+    fn visit_where_clause(
+        &mut self,
+        where_clause: &WhereClause<I>,
+        outer_binder: DebruijnIndex,
+    ) -> ControlFlow<()> {
         match where_clause {
             WhereClause::AliasEq(alias_eq) => alias_eq
                 .alias
                 .clone()
                 .intern(self.interner)
                 .visit_with(self, outer_binder),
-            WhereClause::Implemented(trait_ref) => {
-                trait_ref.visit_with(self, outer_binder);
-            }
+            WhereClause::Implemented(trait_ref) => trait_ref.visit_with(self, outer_binder),
             WhereClause::TypeOutlives(TypeOutlives { ty, .. }) => ty.visit_with(self, outer_binder),
-            WhereClause::LifetimeOutlives(..) => {}
+            WhereClause::LifetimeOutlives(..) => ControlFlow::Ok(()),
         }
     }
 
-    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) {
+    fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         let interner = self.interner();
 
         let mut push_ty = || {
@@ -105,105 +105,110 @@ impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
             TyKind::Adt(id, substitution) => {
                 push_ty();
                 id.visit_with(self, outer_binder);
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::AssociatedType(assoc_ty, substitution) => {
                 push_ty();
                 assoc_ty.visit_with(self, outer_binder);
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::Scalar(scalar) => {
                 push_ty();
-                scalar.visit_with(self, outer_binder);
+                scalar.visit_with(self, outer_binder)
             }
             TyKind::Str => {
                 push_ty();
+                ControlFlow::Ok(())
             }
             TyKind::Tuple(arity, substitution) => {
                 push_ty();
                 arity.visit_with(self, outer_binder);
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::OpaqueType(opaque_ty, substitution) => {
                 push_ty();
                 opaque_ty.visit_with(self, outer_binder);
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::Slice(substitution) => {
                 push_ty();
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::FnDef(fn_def, substitution) => {
                 push_ty();
                 fn_def.visit_with(self, outer_binder);
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::Ref(mutability, lifetime, ty) => {
                 push_ty();
                 mutability.visit_with(self, outer_binder);
                 lifetime.visit_with(self, outer_binder);
-                ty.visit_with(self, outer_binder);
+                ty.visit_with(self, outer_binder)
             }
             TyKind::Raw(mutability, substitution) => {
                 push_ty();
                 mutability.visit_with(self, outer_binder);
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::Never => {
                 push_ty();
+                ControlFlow::Ok(())
             }
             TyKind::Array(ty, const_) => {
                 push_ty();
-                ty.visit_with(self, outer_binder)
-                    .combine(const_.visit_with(self, outer_binder))
+                ty.visit_with(self, outer_binder);
+                const_.visit_with(self, outer_binder)
             }
             TyKind::Closure(_id, substitution) => {
                 push_ty();
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::Generator(_generator, substitution) => {
                 push_ty();
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::GeneratorWitness(_witness, substitution) => {
                 push_ty();
-                substitution.visit_with(self, outer_binder);
+                substitution.visit_with(self, outer_binder)
             }
             TyKind::Foreign(_foreign_ty) => {
                 push_ty();
+                ControlFlow::Ok(())
             }
             TyKind::Error => {
                 push_ty();
+                ControlFlow::Ok(())
             }
 
             TyKind::Dyn(clauses) => {
                 push_ty();
-                clauses.visit_with(self, outer_binder);
+                clauses.visit_with(self, outer_binder)
             }
 
             TyKind::Alias(AliasTy::Projection(proj)) => {
                 push_ty();
-                proj.visit_with(self, outer_binder);
+                proj.visit_with(self, outer_binder)
             }
 
             TyKind::Alias(AliasTy::Opaque(opaque_ty)) => {
                 push_ty();
-                opaque_ty.visit_with(self, outer_binder);
+                opaque_ty.visit_with(self, outer_binder)
             }
 
             TyKind::Placeholder(_) => {
                 push_ty();
+                ControlFlow::Ok(())
             }
 
             // Type parameters do not carry any input types (so we can sort of assume they are
             // always WF).
-            TyKind::BoundVar(..) => (),
+            TyKind::BoundVar(..) => ControlFlow::Ok(()),
 
             // Higher-kinded types such as `for<'a> fn(&'a u32)` introduce their own implied
             // bounds, and these bounds will be enforced upon calling such a function. In some
             // sense, well-formedness requirements for the input types of an HKT will be enforced
             // lazily, so no need to include them here.
-            TyKind::Function(..) => (),
+            TyKind::Function(..) => ControlFlow::Ok(()),
 
             TyKind::InferenceVar(..) => {
                 panic!("unexpected inference variable in wf rules: {:?}", ty)

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -63,7 +63,7 @@ impl<'i, I: Interner> InputTypeCollector<'i, I> {
 
     fn types_in(interner: &'i I, value: impl Visit<I>) -> Vec<Ty<I>> {
         let mut collector = Self::new(interner);
-        value.visit_with(&mut collector, DebruijnIndex::INNERMOST);
+        let _ = value.visit_with(&mut collector, DebruijnIndex::INNERMOST);
         collector.types
     }
 }
@@ -104,12 +104,12 @@ impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
         match ty.kind(interner) {
             TyKind::Adt(id, substitution) => {
                 push_ty();
-                id.visit_with(self, outer_binder);
+                id.visit_with(self, outer_binder)?;
                 substitution.visit_with(self, outer_binder)
             }
             TyKind::AssociatedType(assoc_ty, substitution) => {
                 push_ty();
-                assoc_ty.visit_with(self, outer_binder);
+                assoc_ty.visit_with(self, outer_binder)?;
                 substitution.visit_with(self, outer_binder)
             }
             TyKind::Scalar(scalar) => {
@@ -122,12 +122,12 @@ impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
             }
             TyKind::Tuple(arity, substitution) => {
                 push_ty();
-                arity.visit_with(self, outer_binder);
+                arity.visit_with(self, outer_binder)?;
                 substitution.visit_with(self, outer_binder)
             }
             TyKind::OpaqueType(opaque_ty, substitution) => {
                 push_ty();
-                opaque_ty.visit_with(self, outer_binder);
+                opaque_ty.visit_with(self, outer_binder)?;
                 substitution.visit_with(self, outer_binder)
             }
             TyKind::Slice(substitution) => {
@@ -136,18 +136,18 @@ impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
             }
             TyKind::FnDef(fn_def, substitution) => {
                 push_ty();
-                fn_def.visit_with(self, outer_binder);
+                fn_def.visit_with(self, outer_binder)?;
                 substitution.visit_with(self, outer_binder)
             }
             TyKind::Ref(mutability, lifetime, ty) => {
                 push_ty();
-                mutability.visit_with(self, outer_binder);
-                lifetime.visit_with(self, outer_binder);
+                mutability.visit_with(self, outer_binder)?;
+                lifetime.visit_with(self, outer_binder)?;
                 ty.visit_with(self, outer_binder)
             }
             TyKind::Raw(mutability, substitution) => {
                 push_ty();
-                mutability.visit_with(self, outer_binder);
+                mutability.visit_with(self, outer_binder)?;
                 substitution.visit_with(self, outer_binder)
             }
             TyKind::Never => {
@@ -156,7 +156,7 @@ impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
             }
             TyKind::Array(ty, const_) => {
                 push_ty();
-                ty.visit_with(self, outer_binder);
+                ty.visit_with(self, outer_binder)?;
                 const_.visit_with(self, outer_binder)
             }
             TyKind::Closure(_id, substitution) => {


### PR DESCRIPTION
This PR (almost) resolves one of the differences between rustc's `TypeVisitor` and chalk's `Visitor` by adopting rustc's design with `std::ops::ControlFlow`.

Supersedes #645 with another approach suggested by @jackh726: instead of defining an `enum ControlFlow`, define a type alias `type ControlFlow = Result`, which allows to use `?` instead of a custom macro.