### PR TITLE
Introduce `Visitor::BreakTy`

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -175,11 +175,11 @@ fn derive_any_visit(
     s.bound_impl(
         quote!(::chalk_ir::visit:: #trait_name <#interner>),
         quote! {
-            fn #method_name <'i>(
+            fn #method_name <'i, B>(
                 &self,
-                visitor: &mut dyn ::chalk_ir::visit::Visitor < 'i, #interner >,
+                visitor: &mut dyn ::chalk_ir::visit::Visitor < 'i, #interner, BreakTy = B >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
-            ) -> ::chalk_ir::visit::ControlFlow<()>
+            ) -> ::chalk_ir::visit::ControlFlow<B>
             where
                 #interner: 'i
             {

--- a/chalk-ir/src/visit/binder_impls.rs
+++ b/chalk-ir/src/visit/binder_impls.rs
@@ -7,11 +7,11 @@ use crate::interner::HasInterner;
 use crate::{Binders, Canonical, ControlFlow, DebruijnIndex, FnPointer, Interner, Visit, Visitor};
 
 impl<I: Interner> Visit<I> for FnPointer<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -26,11 +26,11 @@ impl<T, I: Interner> Visit<I> for Binders<T>
 where
     T: HasInterner + Visit<I>,
 {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -43,11 +43,11 @@ where
     I: Interner,
     T: HasInterner<Interner = I> + Visit<I>,
 {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -14,11 +14,11 @@ use crate::{
 use std::{marker::PhantomData, sync::Arc};
 
 /// Convenience function to visit all the items in the iterator it.
-pub fn visit_iter<'i, T, I>(
+pub fn visit_iter<'i, T, I, B>(
     it: impl Iterator<Item = T>,
-    visitor: &mut dyn Visitor<'i, I>,
+    visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
     outer_binder: DebruijnIndex,
-) -> ControlFlow<()>
+) -> ControlFlow<B>
 where
     T: Visit<I>,
     I: 'i + Interner,
@@ -30,11 +30,11 @@ where
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for &T {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -43,11 +43,11 @@ impl<T: Visit<I>, I: Interner> Visit<I> for &T {
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for Vec<T> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -56,11 +56,11 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Vec<T> {
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for &[T] {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -69,11 +69,11 @@ impl<T: Visit<I>, I: Interner> Visit<I> for &[T] {
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for Box<T> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -82,11 +82,11 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Box<T> {
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for Arc<T> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -97,7 +97,7 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Arc<T> {
 macro_rules! tuple_visit {
     ($($n:ident),*) => {
         impl<$($n: Visit<I>,)* I: Interner> Visit<I> for ($($n,)*) {
-            fn visit_with<'i>(&self, visitor: &mut dyn Visitor<'i, I>, outer_binder: DebruijnIndex) -> ControlFlow<()> where I: 'i
+            fn visit_with<'i, BT>(&self, visitor: &mut dyn Visitor<'i, I, BreakTy = BT>, outer_binder: DebruijnIndex) -> ControlFlow<BT> where I: 'i
             {
                 #[allow(non_snake_case)]
                 let &($(ref $n),*) = self;
@@ -116,11 +116,11 @@ tuple_visit!(A, B, C, D);
 tuple_visit!(A, B, C, D, E);
 
 impl<T: Visit<I>, I: Interner> Visit<I> for Option<T> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -132,11 +132,11 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Option<T> {
 }
 
 impl<I: Interner> Visit<I> for GenericArg<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -146,11 +146,11 @@ impl<I: Interner> Visit<I> for GenericArg<I> {
 }
 
 impl<I: Interner> Visit<I> for Substitution<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -160,11 +160,11 @@ impl<I: Interner> Visit<I> for Substitution<I> {
 }
 
 impl<I: Interner> Visit<I> for Goals<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -178,11 +178,11 @@ impl<I: Interner> Visit<I> for Goals<I> {
 macro_rules! const_visit {
     ($t:ty) => {
         impl<I: Interner> $crate::visit::Visit<I> for $t {
-            fn visit_with<'i>(
+            fn visit_with<'i, B>(
                 &self,
-                _visitor: &mut dyn ($crate::visit::Visitor<'i, I>),
+                _visitor: &mut dyn ($crate::visit::Visitor<'i, I, BreakTy = B>),
                 _outer_binder: DebruijnIndex,
-            ) -> ControlFlow<()>
+            ) -> ControlFlow<B>
             where
                 I: 'i,
             {
@@ -212,11 +212,11 @@ const_visit!(Safety);
 macro_rules! id_visit {
     ($t:ident) => {
         impl<I: Interner> $crate::visit::Visit<I> for $t<I> {
-            fn visit_with<'i>(
+            fn visit_with<'i, B>(
                 &self,
-                _visitor: &mut dyn ($crate::visit::Visitor<'i, I>),
+                _visitor: &mut dyn ($crate::visit::Visitor<'i, I, BreakTy = B>),
                 _outer_binder: DebruijnIndex,
-            ) -> ControlFlow<()>
+            ) -> ControlFlow<B>
             where
                 I: 'i,
             {
@@ -237,11 +237,11 @@ id_visit!(GeneratorId);
 id_visit!(ForeignDefId);
 
 impl<I: Interner> SuperVisit<I> for ProgramClause<I> {
-    fn super_visit_with<'i>(
+    fn super_visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -252,11 +252,11 @@ impl<I: Interner> SuperVisit<I> for ProgramClause<I> {
 }
 
 impl<I: Interner> Visit<I> for ProgramClauses<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -267,11 +267,11 @@ impl<I: Interner> Visit<I> for ProgramClauses<I> {
 }
 
 impl<I: Interner> Visit<I> for Constraints<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -282,11 +282,11 @@ impl<I: Interner> Visit<I> for Constraints<I> {
 }
 
 impl<I: Interner> Visit<I> for QuantifiedWhereClauses<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I>,
+        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -297,11 +297,11 @@ impl<I: Interner> Visit<I> for QuantifiedWhereClauses<I> {
 }
 
 impl<I: Interner> Visit<I> for PhantomData<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        _visitor: &mut dyn Visitor<'i, I>,
+        _visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
         _outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {

--- a/chalk-ir/src/visit/visitors.rs
+++ b/chalk-ir/src/visit/visitors.rs
@@ -21,7 +21,9 @@ struct FindFreeVarsVisitor<'i, I: Interner> {
 }
 
 impl<'i, I: Interner> Visitor<'i, I> for FindFreeVarsVisitor<'i, I> {
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
+    type BreakTy = ();
+
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/clauses/builtin_traits/unsize.rs
+++ b/chalk-solve/src/clauses/builtin_traits/unsize.rs
@@ -19,7 +19,9 @@ struct UnsizeParameterCollector<'a, I: Interner> {
 }
 
 impl<'a, I: Interner> Visitor<'a, I> for UnsizeParameterCollector<'a, I> {
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I> {
+    type BreakTy = ();
+
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I, BreakTy = Self::BreakTy> {
         self
     }
 
@@ -74,7 +76,9 @@ struct ParameterOccurenceCheck<'a, 'p, I: Interner> {
 }
 
 impl<'a, 'p, I: Interner> Visitor<'a, I> for ParameterOccurenceCheck<'a, 'p, I> {
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I> {
+    type BreakTy = ();
+
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -54,7 +54,9 @@ impl<'me, I: Interner> EnvElaborator<'me, I> {
 }
 
 impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'me, I> {
+    type BreakTy = ();
+
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'me, I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -205,7 +205,9 @@ impl<'i, I: Interner> Visitor<'i, I> for UCollector<'_, 'i, I>
 where
     I: 'i,
 {
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
+    type BreakTy = ();
+
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -108,7 +108,9 @@ impl<'i, I: Interner, DB: RustIrDatabase<I>> Visitor<'i, I> for IdCollector<'i, 
 where
     I: 'i,
 {
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
+    type BreakTy = ();
+
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
         self
     }
     fn interner(&self) -> &'i I {

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -142,11 +142,11 @@ pub struct FnDefDatum<I: Interner> {
 
 /// Avoids visiting `I::FnAbi`
 impl<I: Interner> Visit<I> for FnDefDatum<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn chalk_ir::visit::Visitor<'i, I>,
+        visitor: &mut dyn chalk_ir::visit::Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {
@@ -489,11 +489,11 @@ pub struct AssociatedTyDatum<I: Interner> {
 
 // Manual implementation to avoid I::Identifier type.
 impl<I: Interner> Visit<I> for AssociatedTyDatum<I> {
-    fn visit_with<'i>(
+    fn visit_with<'i, B>(
         &self,
-        visitor: &mut dyn chalk_ir::visit::Visitor<'i, I>,
+        visitor: &mut dyn chalk_ir::visit::Visitor<'i, I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<()>
+    ) -> ControlFlow<B>
     where
         I: 'i,
     {

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -39,7 +39,9 @@ impl<'infer, 'i, I: Interner> TySizeVisitor<'infer, 'i, I> {
 }
 
 impl<'infer, 'i, I: Interner> Visitor<'i, I> for TySizeVisitor<'infer, 'i, I> {
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
+    type BreakTy = ();
+
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -69,7 +69,8 @@ impl<'i, I: Interner> InputTypeCollector<'i, I> {
 }
 
 impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I> {
+    type BreakTy = ();
+    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
         self
     }
 


### PR DESCRIPTION
Implements the equivalent of MCP rust-lang/compiler-team#383 in chalk.
r? @jackh726

~~Should probably be blocked on rust-lang/compiler-team#383.~~