### PR TITLE
Fix boats' coherence talk link in the book

### DIFF
--- a/book/src/clauses/coherence.md
+++ b/book/src/clauses/coherence.md
@@ -16,7 +16,7 @@ To check for coherence, the Rust compiler completes two separate but related che
 - overlap check - ensures that no two impls overlap in your program **or** **in any** ***compatible*** **world**
     - **compatible** - any semver compatible world
 # Resources About Coherence
-- [Coherence - talk by withoutboats](https://air.mozilla.org/rust-meetup-march-2017/)
+- [Coherence - talk by withoutboats](https://www.youtube.com/watch?v=AI7SLCubTnk&t=43m19s)
 - [Little Orphan Impls](https://smallcultfollowing.com/babysteps/blog/2015/01/14/little-orphan-impls/)
 - [RFC 1023 Rebalancing Coherence](https://rust-lang.github.io/rfcs/1023-rebalancing-coherence.html)
 - [Type classes: confluence, coherence and global uniqueness](http://blog.ezyang.com/2014/07/type-classes-confluence-coherence-global-uniqueness/)


### PR DESCRIPTION
Mozilla Air sometimes fails to linkcheck, for example in the recent https://github.com/rust-lang/chalk/runs/1400914953, so let's use the official Rust youtube account version instead