### PR TITLE
Fix handling of variables in goal for new alias clauses

### DIFF
--- a/tests/test/opaque_types.rs
+++ b/tests/test/opaque_types.rs
@@ -173,6 +173,27 @@ fn opaque_generics() {
 }
 
 #[test]
+fn opaque_trait_generic() {
+    test! {
+        program {
+            trait Trait<T> {}
+            struct Foo {}
+            impl Trait<u32> for Foo {}
+
+            opaque type Bar: Trait<u32> = Foo;
+        }
+
+        goal {
+            exists<T> {
+                Bar: Trait<T>
+            }
+        } yields {
+            "Unique; substitution [?0 := Uint(U32)]"
+        }
+    }
+}
+
+#[test]
 fn opaque_auto_traits() {
     test! {
         program {


### PR DESCRIPTION
The new clauses for alias types (`<X as Y>::Z: Trait :- T: Trait, <X as Y>::Z ==
T` etc.) were generated using the provided goal, without regard for bound variables. This led to e.g. the new test failing in the recursive solver. Alternatively, it might be better to generate the clauses without using the specific types in the goal.

(CC #568.)