### PR TITLE
Always relate with Invariant to non-General inference vars

### DIFF
--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -79,11 +79,6 @@ impl<I: Interner> Forest<I> {
                     Err(_) => return FallibleOrFloundered::NoSolution,
                 },
                 GoalData::SubtypeGoal(goal) => {
-                    if goal.a.inference_var(context.program().interner()).is_some()
-                        && goal.b.inference_var(context.program().interner()).is_some()
-                    {
-                        return FallibleOrFloundered::Floundered;
-                    }
                     match infer.relate_tys_into_ex_clause(
                         context.program().interner(),
                         context.unification_database(),
@@ -93,8 +88,13 @@ impl<I: Interner> Forest<I> {
                         &goal.b,
                         &mut ex_clause,
                     ) {
-                        Ok(()) => {}
-                        Err(_) => return FallibleOrFloundered::NoSolution,
+                        FallibleOrFloundered::Ok(_) => {}
+                        FallibleOrFloundered::Floundered => {
+                            return FallibleOrFloundered::Floundered
+                        }
+                        FallibleOrFloundered::NoSolution => {
+                            return FallibleOrFloundered::NoSolution
+                        }
                     }
                 }
                 GoalData::DomainGoal(domain_goal) => {

--- a/chalk-integration/src/interner.rs
+++ b/chalk-integration/src/interner.rs
@@ -28,10 +28,23 @@ impl Debug for RawId {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ChalkFnAbi {
     Rust,
     C,
+}
+
+impl Debug for ChalkFnAbi {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            fmt,
+            "{}",
+            match self {
+                ChalkFnAbi::Rust => "\"rust\"",
+                ChalkFnAbi::C => "\"c\"",
+            },
+        )
+    }
 }
 
 /// The default "interner" and the only interner used by chalk

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -273,8 +273,14 @@ impl<I: Interner> Debug for FnPointer<I> {
         } = self;
         write!(
             fmt,
-            "for<{}> {:?} {:?} {:?}",
-            num_binders, sig.safety, sig.abi, substitution
+            "{}{:?} for<{}> {:?}",
+            match sig.safety {
+                Safety::Unsafe => "unsafe ",
+                Safety::Safe => "",
+            },
+            sig.abi,
+            num_binders,
+            substitution
         )
     }
 }

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -8,7 +8,8 @@ use chalk_ir::zip::Zip;
 use chalk_ir::{
     Binders, Canonical, ClausePriority, DomainGoal, Environment, Fallible, Floundered, GenericArg,
     Goal, GoalData, InEnvironment, NoSolution, ProgramClause, ProgramClauseData,
-    ProgramClauseImplication, Substitution, UCanonical, UnificationDatabase, UniverseMap, Variance,
+    ProgramClauseImplication, Substitution, Ty, UCanonical, UnificationDatabase, UniverseMap,
+    Variance,
 };
 use chalk_solve::clauses::program_clauses_for_goal;
 use chalk_solve::debug_span;
@@ -316,5 +317,9 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
 
     fn needs_truncation(&mut self, interner: &I, max_size: usize, value: impl Visit<I>) -> bool {
         truncate::needs_truncation(interner, &mut self.infer, max_size, value)
+    }
+
+    fn normalize_ty_shallow(&mut self, interner: &I, leaf: &Ty<I>) -> Option<Ty<I>> {
+        self.infer.normalize_ty_shallow(interner, leaf)
     }
 }

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -96,33 +96,43 @@ impl<'t, I: Interner> Unifier<'t, I> {
 
         match (a.kind(interner), b.kind(interner)) {
             // Relating two inference variables:
+            // First, if either variable is a float or int kind, then we always
+            // unify if they match. This is because float and ints don't have
+            // subtype relationships.
+            // If both kinds are general then:
             // If `Invariant`, unify them in the underlying ena table.
             // If `Covariant` or `Contravariant`, push `SubtypeGoal`
             (&TyKind::InferenceVar(var1, kind1), &TyKind::InferenceVar(var2, kind2)) => {
-                match variance {
-                    Variance::Invariant => {
-                        if kind1 == kind2 {
-                            self.unify_var_var(var1, var2)
-                        } else if kind1 == TyVariableKind::General {
-                            self.unify_general_var_specific_ty(var1, b.clone())
-                        } else if kind2 == TyVariableKind::General {
-                            self.unify_general_var_specific_ty(var2, a.clone())
-                        } else {
-                            debug!(
-                                "Tried to unify mis-matching inference variables: {:?} and {:?}",
-                                kind1, kind2
-                            );
-                            Err(NoSolution)
+                if matches!(kind1, TyVariableKind::General)
+                    && matches!(kind2, TyVariableKind::General)
+                {
+                    // Both variable kinds are general; so unify if invariant, otherwise push subtype goal
+                    match variance {
+                        Variance::Invariant => self.unify_var_var(var1, var2),
+                        Variance::Covariant => {
+                            self.push_subtype_goal(a.clone(), b.clone());
+                            Ok(())
+                        }
+                        Variance::Contravariant => {
+                            self.push_subtype_goal(b.clone(), a.clone());
+                            Ok(())
                         }
                     }
-                    Variance::Covariant => {
-                        self.push_subtype_goal(a.clone(), b.clone());
-                        Ok(())
-                    }
-                    Variance::Contravariant => {
-                        self.push_subtype_goal(b.clone(), a.clone());
-                        Ok(())
-                    }
+                } else if kind1 == kind2 {
+                    // At least one kind is not general, but they match, so unify
+                    self.unify_var_var(var1, var2)
+                } else if kind1 == TyVariableKind::General {
+                    // First kind is general, second isn't, unify
+                    self.unify_general_var_specific_ty(var1, b.clone())
+                } else if kind2 == TyVariableKind::General {
+                    // Second kind is general, first isn't, unify
+                    self.unify_general_var_specific_ty(var2, a.clone())
+                } else {
+                    debug!(
+                        "Tried to unify mis-matching inference variables: {:?} and {:?}",
+                        kind1, kind2
+                    );
+                    Err(NoSolution)
                 }
             }
 
@@ -1071,23 +1081,9 @@ impl<'t, I: Interner> Unifier<'t, I> {
 
     /// Pushes a goal of `a` being a subtype of `b`.
     fn push_subtype_goal(&mut self, a: Ty<I>, b: Ty<I>) {
-        let inverse = self.goals.iter().position(|g| {
-            if g.environment != *self.environment {
-                return false;
-            }
-            match g.goal.data(self.interner()) {
-                GoalData::SubtypeGoal(SubtypeGoal { a: a1, b: b1 }) => a == *b1 && b == *a1,
-                _ => false,
-            }
-        });
-        if let Some(inverse) = inverse {
-            self.goals.remove(inverse);
-            self.relate_ty_ty(Variance::Invariant, &a, &b).unwrap();
-        } else {
-            let subtype_goal = GoalData::SubtypeGoal(SubtypeGoal { a, b }).intern(self.interner());
-            self.goals
-                .push(InEnvironment::new(self.environment, subtype_goal));
-        }
+        let subtype_goal = GoalData::SubtypeGoal(SubtypeGoal { a, b }).intern(self.interner());
+        self.goals
+            .push(InEnvironment::new(self.environment, subtype_goal));
     }
 }
 

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -759,3 +759,22 @@ fn empty_definite_guidance() {
         }
     }
 }
+
+#[test]
+fn ambiguous_unification_in_fn() {
+    test! {
+        program {
+            trait FnOnce<Args> {}
+
+            struct MyClosure<T> {}
+            impl<T> FnOnce<T> for MyClosure<fn(T) -> ()> {}
+        }
+        goal {
+            exists<T, U> {
+                MyClosure<fn(U) -> ()>: FnOnce<T>
+            }
+        } yields {
+            "Unique"
+        }
+    }
+}

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -764,14 +764,18 @@ fn empty_definite_guidance() {
 fn ambiguous_unification_in_fn() {
     test! {
         program {
-            trait FnOnce<Args> {}
+            trait FnOnce<Args> {
+                type Output;
+            }
 
             struct MyClosure<T> {}
-            impl<T> FnOnce<T> for MyClosure<fn(T) -> ()> {}
+            impl<T> FnOnce<(T,)> for MyClosure<fn(T) -> ()> {
+                type Output = ();
+            }
         }
         goal {
-            exists<T, U> {
-                MyClosure<fn(U) -> ()>: FnOnce<T>
+            exists<int T, U> {
+                MyClosure<fn(&'static U) -> ()>: FnOnce<(&'static T,)>
             }
         } yields {
             "Unique"


### PR DESCRIPTION
Fixes #658 

An alternative way to approach this is to always unify inference variables as `Invariant`, which is how it's implemented in rustc right now. We should think about if we want that long term though (and possibly come up with tests that hit that).