### PR TITLE
Fold by value, not by reference

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -296,14 +296,14 @@ fn derive_fold(mut s: synstructure::Structure) -> TokenStream {
             type Result = #result;
 
             fn fold_with<'i>(
-                &self,
+                self,
                 folder: &mut dyn ::chalk_ir::fold::Folder < 'i, #interner >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
             ) -> ::chalk_ir::Fallible<Self::Result>
             where
                 #interner: 'i,
             {
-                Ok(match *self { #body })
+                Ok(match self { #body })
             }
         },
     )

--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -258,7 +258,7 @@ fn derive_zip(mut s: synstructure::Structure) -> TokenStream {
 /// - There is a single parameter `T: HasInterner` (does not have to be named `T`)
 /// - There is a single parameter `I: Interner` (does not have to be named `I`)
 fn derive_fold(mut s: synstructure::Structure) -> TokenStream {
-    let input = s.ast();
+    s.bind_with(|_| synstructure::BindStyle::Move);
 
     let (interner, kind) = find_interner(&mut s);
 
@@ -272,6 +272,7 @@ fn derive_fold(mut s: synstructure::Structure) -> TokenStream {
         })
     });
 
+    let input = s.ast();
     let type_name = &input.ident;
 
     let result = if kind == DeriveKind::FromHasInterner {

--- a/chalk-engine/src/simplify.rs
+++ b/chalk-engine/src/simplify.rs
@@ -37,13 +37,17 @@ impl<I: Interner> Forest<I> {
         while let Some((environment, goal)) = pending_goals.pop() {
             match goal.data(context.program().interner()) {
                 GoalData::Quantified(QuantifierKind::ForAll, subgoal) => {
-                    let subgoal = infer
-                        .instantiate_binders_universally(context.program().interner(), &subgoal);
+                    let subgoal = infer.instantiate_binders_universally(
+                        context.program().interner(),
+                        subgoal.clone(),
+                    );
                     pending_goals.push((environment, subgoal.clone()));
                 }
                 GoalData::Quantified(QuantifierKind::Exists, subgoal) => {
-                    let subgoal = infer
-                        .instantiate_binders_existentially(context.program().interner(), &subgoal);
+                    let subgoal = infer.instantiate_binders_existentially(
+                        context.program().interner(),
+                        subgoal.clone(),
+                    );
                     pending_goals.push((environment, subgoal.clone()));
                 }
                 GoalData::Implies(wc, subgoal) => {

--- a/chalk-engine/src/slg.rs
+++ b/chalk-engine/src/slg.rs
@@ -507,7 +507,7 @@ impl<I: Interner> MayInvalidate<'_, I> {
         }
     }
 
-    /// Returns true if the two consts could be unequal.    
+    /// Returns true if the two consts could be unequal.
     fn aggregate_lifetimes(&mut self, _: &Lifetime<I>, _: &Lifetime<I>) -> bool {
         true
     }

--- a/chalk-engine/src/slg.rs
+++ b/chalk-engine/src/slg.rs
@@ -61,12 +61,12 @@ impl<I: Interner> SlgContextOps<'_, I> {
         let (mut infer, subst, _) = InferenceTable::from_canonical(
             self.program.interner(),
             goal.universes,
-            &goal.canonical,
+            goal.canonical.clone(),
         );
         infer
             .canonicalize(
                 self.program.interner(),
-                &ConstrainedSubst {
+                ConstrainedSubst {
                     subst,
                     constraints: Constraints::empty(self.program.interner()),
                 },
@@ -130,21 +130,18 @@ pub trait ResolventOps<I: Interner> {
         ex_clause: &mut ExClause<I>,
         selected_goal: &InEnvironment<Goal<I>>,
         answer_table_goal: &Canonical<InEnvironment<Goal<I>>>,
-        canonical_answer_subst: &Canonical<AnswerSubst<I>>,
+        canonical_answer_subst: Canonical<AnswerSubst<I>>,
     ) -> Fallible<()>;
 }
 
 /// Methods for unifying and manipulating terms and binders.
 pub trait UnificationOps<I: Interner> {
     // Used by: simplify
-    fn instantiate_binders_universally(&mut self, interner: &I, arg: &Binders<Goal<I>>) -> Goal<I>;
+    fn instantiate_binders_universally(&mut self, interner: &I, arg: Binders<Goal<I>>) -> Goal<I>;
 
     // Used by: simplify
-    fn instantiate_binders_existentially(
-        &mut self,
-        interner: &I,
-        arg: &Binders<Goal<I>>,
-    ) -> Goal<I>;
+    fn instantiate_binders_existentially(&mut self, interner: &I, arg: Binders<Goal<I>>)
+        -> Goal<I>;
 
     // Used by: logic (but for debugging only)
     fn debug_ex_clause<'v>(&mut self, interner: &I, value: &'v ExClause<I>) -> Box<dyn Debug + 'v>;
@@ -153,14 +150,14 @@ pub trait UnificationOps<I: Interner> {
     fn fully_canonicalize_goal(
         &mut self,
         interner: &I,
-        value: &InEnvironment<Goal<I>>,
+        value: InEnvironment<Goal<I>>,
     ) -> (UCanonical<InEnvironment<Goal<I>>>, UniverseMap);
 
     // Used by: logic
     fn canonicalize_ex_clause(
         &mut self,
         interner: &I,
-        value: &ExClause<I>,
+        value: ExClause<I>,
     ) -> Canonical<ExClause<I>>;
 
     // Used by: logic
@@ -184,7 +181,7 @@ pub trait UnificationOps<I: Interner> {
     fn invert_goal(
         &mut self,
         interner: &I,
-        value: &InEnvironment<Goal<I>>,
+        value: InEnvironment<Goal<I>>,
     ) -> Option<InEnvironment<Goal<I>>>;
 
     /// First unify the parameters, then add the residual subgoals
@@ -239,14 +236,14 @@ impl<I: Interner> TruncateOps<I> for TruncatingInferenceTable<I> {
 }
 
 impl<I: Interner> UnificationOps<I> for TruncatingInferenceTable<I> {
-    fn instantiate_binders_universally(&mut self, interner: &I, arg: &Binders<Goal<I>>) -> Goal<I> {
+    fn instantiate_binders_universally(&mut self, interner: &I, arg: Binders<Goal<I>>) -> Goal<I> {
         self.infer.instantiate_binders_universally(interner, arg)
     }
 
     fn instantiate_binders_existentially(
         &mut self,
         interner: &I,
-        arg: &Binders<Goal<I>>,
+        arg: Binders<Goal<I>>,
     ) -> Goal<I> {
         self.infer.instantiate_binders_existentially(interner, arg)
     }
@@ -255,14 +252,14 @@ impl<I: Interner> UnificationOps<I> for TruncatingInferenceTable<I> {
         Box::new(DeepNormalizer::normalize_deep(
             &mut self.infer,
             interner,
-            value,
+            value.clone(),
         ))
     }
 
     fn fully_canonicalize_goal(
         &mut self,
         interner: &I,
-        value: &InEnvironment<Goal<I>>,
+        value: InEnvironment<Goal<I>>,
     ) -> (UCanonical<InEnvironment<Goal<I>>>, UniverseMap) {
         let canonicalized_goal = self.infer.canonicalize(interner, value).quantified;
         let UCanonicalized {
@@ -275,7 +272,7 @@ impl<I: Interner> UnificationOps<I> for TruncatingInferenceTable<I> {
     fn canonicalize_ex_clause(
         &mut self,
         interner: &I,
-        value: &ExClause<I>,
+        value: ExClause<I>,
     ) -> Canonical<ExClause<I>> {
         self.infer.canonicalize(interner, value).quantified
     }
@@ -289,7 +286,7 @@ impl<I: Interner> UnificationOps<I> for TruncatingInferenceTable<I> {
         self.infer
             .canonicalize(
                 interner,
-                &ConstrainedSubst {
+                ConstrainedSubst {
                     subst,
                     constraints: Constraints::from_iter(interner, constraints),
                 },
@@ -307,7 +304,7 @@ impl<I: Interner> UnificationOps<I> for TruncatingInferenceTable<I> {
         self.infer
             .canonicalize(
                 interner,
-                &AnswerSubst {
+                AnswerSubst {
                     subst,
                     constraints: Constraints::from_iter(interner, constraints),
                     delayed_subgoals,
@@ -319,7 +316,7 @@ impl<I: Interner> UnificationOps<I> for TruncatingInferenceTable<I> {
     fn invert_goal(
         &mut self,
         interner: &I,
-        value: &InEnvironment<Goal<I>>,
+        value: InEnvironment<Goal<I>>,
     ) -> Option<InEnvironment<Goal<I>>> {
         self.infer.invert(interner, value)
     }

--- a/chalk-engine/src/slg/aggregate.rs
+++ b/chalk-engine/src/slg/aggregate.rs
@@ -181,7 +181,7 @@ fn merge_into_guidance<I: Interner>(
 
     let aggr_subst = Substitution::from_iter(interner, aggr_generic_args);
 
-    infer.canonicalize(interner, &aggr_subst).quantified
+    infer.canonicalize(interner, aggr_subst).quantified
 }
 
 fn is_trivial<I: Interner>(interner: &I, subst: &Canonical<Substitution<I>>) -> bool {

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -70,7 +70,7 @@ where
     /// encountered when folding. By default, invokes
     /// `super_fold_with`, which will in turn invoke the more
     /// specialized folding methods below, like `fold_free_var_ty`.
-    fn fold_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> Fallible<Ty<I>> {
+    fn fold_ty(&mut self, ty: Ty<I>, outer_binder: DebruijnIndex) -> Fallible<Ty<I>> {
         ty.super_fold_with(self.as_dyn(), outer_binder)
     }
 
@@ -80,7 +80,7 @@ where
     /// specialized folding methods below, like `fold_free_var_lifetime`.
     fn fold_lifetime(
         &mut self,
-        lifetime: &Lifetime<I>,
+        lifetime: Lifetime<I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Lifetime<I>> {
         lifetime.super_fold_with(self.as_dyn(), outer_binder)
@@ -92,7 +92,7 @@ where
     /// specialized folding methods below, like `fold_free_var_const`.
     fn fold_const(
         &mut self,
-        constant: &Const<I>,
+        constant: Const<I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>> {
         constant.super_fold_with(self.as_dyn(), outer_binder)
@@ -101,14 +101,14 @@ where
     /// Invoked for every program clause. By default, recursively folds the goals contents.
     fn fold_program_clause(
         &mut self,
-        clause: &ProgramClause<I>,
+        clause: ProgramClause<I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<ProgramClause<I>> {
         clause.super_fold_with(self.as_dyn(), outer_binder)
     }
 
     /// Invoked for every goal. By default, recursively folds the goals contents.
-    fn fold_goal(&mut self, goal: &Goal<I>, outer_binder: DebruijnIndex) -> Fallible<Goal<I>> {
+    fn fold_goal(&mut self, goal: Goal<I>, outer_binder: DebruijnIndex) -> Fallible<Goal<I>> {
         goal.super_fold_with(self.as_dyn(), outer_binder)
     }
 
@@ -164,7 +164,7 @@ where
     /// As `fold_free_var_ty`, but for constants.
     fn fold_free_var_const(
         &mut self,
-        ty: &Ty<I>,
+        ty: Ty<I>,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>> {
@@ -176,7 +176,7 @@ where
         } else {
             let bound_var = bound_var.shifted_in_from(outer_binder);
             Ok(ConstData {
-                ty: ty.fold_with(self.as_dyn(), outer_binder)?,
+                ty: ty.clone().fold_with(self.as_dyn(), outer_binder)?,
                 value: ConstValue::<I>::BoundVar(bound_var),
             }
             .intern(self.interner()))
@@ -227,7 +227,7 @@ where
     #[allow(unused_variables)]
     fn fold_free_placeholder_const(
         &mut self,
-        ty: &Ty<I>,
+        ty: Ty<I>,
         universe: PlaceholderIndex,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>> {
@@ -284,7 +284,7 @@ where
     #[allow(unused_variables)]
     fn fold_inference_const(
         &mut self,
-        ty: &Ty<I>,
+        ty: Ty<I>,
         var: InferenceVar,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>> {
@@ -318,7 +318,7 @@ pub trait Fold<I: Interner>: Debug {
     /// we encounter `Binders<T>` in the IR or other similar
     /// constructs.
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -332,7 +332,7 @@ pub trait Fold<I: Interner>: Debug {
 pub trait SuperFold<I: Interner>: Fold<I> {
     /// Recursively folds the value.
     fn super_fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -347,7 +347,7 @@ impl<I: Interner> Fold<I> for Ty<I> {
     type Result = Ty<I>;
 
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -364,7 +364,7 @@ where
     I: Interner,
 {
     fn super_fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Ty<I>>
@@ -388,26 +388,26 @@ where
                 }
             }
             TyKind::Dyn(clauses) => {
-                TyKind::Dyn(clauses.fold_with(folder, outer_binder)?).intern(folder.interner())
+                TyKind::Dyn(clauses.clone().fold_with(folder, outer_binder)?).intern(folder.interner())
             }
             TyKind::InferenceVar(var, kind) => {
                 folder.fold_inference_ty(*var, *kind, outer_binder)?
             }
             TyKind::Placeholder(ui) => folder.fold_free_placeholder_ty(*ui, outer_binder)?,
             TyKind::Alias(proj) => {
-                TyKind::Alias(proj.fold_with(folder, outer_binder)?).intern(folder.interner())
+                TyKind::Alias(proj.clone().fold_with(folder, outer_binder)?).intern(folder.interner())
             }
             TyKind::Function(fun) => {
-                TyKind::Function(fun.fold_with(folder, outer_binder)?).intern(folder.interner())
+                TyKind::Function(fun.clone().fold_with(folder, outer_binder)?).intern(folder.interner())
             }
             TyKind::Adt(id, substitution) => TyKind::Adt(
                 id.fold_with(folder, outer_binder)?,
-                substitution.fold_with(folder, outer_binder)?,
+                substitution.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::AssociatedType(assoc_ty, substitution) => TyKind::AssociatedType(
                 assoc_ty.fold_with(folder, outer_binder)?,
-                substitution.fold_with(folder, outer_binder)?,
+                substitution.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::Scalar(scalar) => {
@@ -415,53 +415,53 @@ where
             }
             TyKind::Str => TyKind::Str.intern(folder.interner()),
             TyKind::Tuple(arity, substitution) => {
-                TyKind::Tuple(*arity, substitution.fold_with(folder, outer_binder)?)
+                TyKind::Tuple(*arity, substitution.clone().fold_with(folder, outer_binder)?)
                     .intern(folder.interner())
             }
             TyKind::OpaqueType(opaque_ty, substitution) => TyKind::OpaqueType(
                 opaque_ty.fold_with(folder, outer_binder)?,
-                substitution.fold_with(folder, outer_binder)?,
+                substitution.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::Slice(substitution) => {
-                TyKind::Slice(substitution.fold_with(folder, outer_binder)?)
+                TyKind::Slice(substitution.clone().fold_with(folder, outer_binder)?)
                     .intern(folder.interner())
             }
             TyKind::FnDef(fn_def, substitution) => TyKind::FnDef(
                 fn_def.fold_with(folder, outer_binder)?,
-                substitution.fold_with(folder, outer_binder)?,
+                substitution.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::Ref(mutability, lifetime, ty) => TyKind::Ref(
                 mutability.fold_with(folder, outer_binder)?,
-                lifetime.fold_with(folder, outer_binder)?,
-                ty.fold_with(folder, outer_binder)?,
+                lifetime.clone().fold_with(folder, outer_binder)?,
+                ty.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::Raw(mutability, ty) => TyKind::Raw(
                 mutability.fold_with(folder, outer_binder)?,
-                ty.fold_with(folder, outer_binder)?,
+                ty.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::Never => TyKind::Never.intern(folder.interner()),
             TyKind::Array(ty, const_) => TyKind::Array(
-                ty.fold_with(folder, outer_binder)?,
-                const_.fold_with(folder, outer_binder)?,
+                ty.clone().fold_with(folder, outer_binder)?,
+                const_.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::Closure(id, substitution) => TyKind::Closure(
                 id.fold_with(folder, outer_binder)?,
-                substitution.fold_with(folder, outer_binder)?,
+                substitution.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::Generator(id, substitution) => TyKind::Generator(
                 id.fold_with(folder, outer_binder)?,
-                substitution.fold_with(folder, outer_binder)?,
+                substitution.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::GeneratorWitness(id, substitution) => TyKind::GeneratorWitness(
                 id.fold_with(folder, outer_binder)?,
-                substitution.fold_with(folder, outer_binder)?,
+                substitution.clone().fold_with(folder, outer_binder)?,
             )
             .intern(folder.interner()),
             TyKind::Foreign(id) => {
@@ -479,7 +479,7 @@ impl<I: Interner> Fold<I> for Lifetime<I> {
     type Result = Lifetime<I>;
 
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -495,7 +495,7 @@ where
     I: Interner,
 {
     fn super_fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Lifetime<I>>
@@ -537,7 +537,7 @@ impl<I: Interner> Fold<I> for Const<I> {
     type Result = Const<I>;
 
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -553,7 +553,7 @@ where
     I: Interner,
 {
     fn super_fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>>
@@ -562,18 +562,18 @@ where
     {
         let interner = folder.interner();
         let ConstData { ref ty, ref value } = self.data(interner);
-        let mut fold_ty = || ty.fold_with(folder, outer_binder);
+        let mut fold_ty = || ty.clone().fold_with(folder, outer_binder);
         match value {
             ConstValue::BoundVar(bound_var) => {
                 if let Some(bound_var1) = bound_var.shifted_out_to(outer_binder) {
-                    folder.fold_free_var_const(ty, bound_var1, outer_binder)
+                    folder.fold_free_var_const(ty.clone(), bound_var1, outer_binder)
                 } else {
                     Ok(bound_var.to_const(interner, fold_ty()?))
                 }
             }
-            ConstValue::InferenceVar(var) => folder.fold_inference_const(ty, *var, outer_binder),
+            ConstValue::InferenceVar(var) => folder.fold_inference_const(ty.clone(), *var, outer_binder),
             ConstValue::Placeholder(universe) => {
-                folder.fold_free_placeholder_const(ty, *universe, outer_binder)
+                folder.fold_free_placeholder_const(ty.clone(), *universe, outer_binder)
             }
             ConstValue::Concrete(ev) => Ok(ConstData {
                 ty: fold_ty()?,
@@ -592,7 +592,7 @@ impl<I: Interner> Fold<I> for Goal<I> {
     type Result = Goal<I>;
 
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -606,7 +606,7 @@ impl<I: Interner> Fold<I> for Goal<I> {
 /// Superfold folds recursively.
 impl<I: Interner> SuperFold<I> for Goal<I> {
     fn super_fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -616,7 +616,7 @@ impl<I: Interner> SuperFold<I> for Goal<I> {
         let interner = folder.interner();
         Ok(Goal::new(
             interner,
-            self.data(interner).fold_with(folder, outer_binder)?,
+            self.data(interner).clone().fold_with(folder, outer_binder)?,
         ))
     }
 }
@@ -628,7 +628,7 @@ impl<I: Interner> Fold<I> for ProgramClause<I> {
     type Result = ProgramClause<I>;
 
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -387,19 +387,16 @@ where
                     TyKind::<I>::BoundVar(*bound_var).intern(folder.interner())
                 }
             }
-            TyKind::Dyn(clauses) => {
-                TyKind::Dyn(clauses.clone().fold_with(folder, outer_binder)?).intern(folder.interner())
-            }
+            TyKind::Dyn(clauses) => TyKind::Dyn(clauses.clone().fold_with(folder, outer_binder)?)
+                .intern(folder.interner()),
             TyKind::InferenceVar(var, kind) => {
                 folder.fold_inference_ty(*var, *kind, outer_binder)?
             }
             TyKind::Placeholder(ui) => folder.fold_free_placeholder_ty(*ui, outer_binder)?,
-            TyKind::Alias(proj) => {
-                TyKind::Alias(proj.clone().fold_with(folder, outer_binder)?).intern(folder.interner())
-            }
-            TyKind::Function(fun) => {
-                TyKind::Function(fun.clone().fold_with(folder, outer_binder)?).intern(folder.interner())
-            }
+            TyKind::Alias(proj) => TyKind::Alias(proj.clone().fold_with(folder, outer_binder)?)
+                .intern(folder.interner()),
+            TyKind::Function(fun) => TyKind::Function(fun.clone().fold_with(folder, outer_binder)?)
+                .intern(folder.interner()),
             TyKind::Adt(id, substitution) => TyKind::Adt(
                 id.fold_with(folder, outer_binder)?,
                 substitution.clone().fold_with(folder, outer_binder)?,
@@ -414,10 +411,11 @@ where
                 TyKind::Scalar(scalar.fold_with(folder, outer_binder)?).intern(folder.interner())
             }
             TyKind::Str => TyKind::Str.intern(folder.interner()),
-            TyKind::Tuple(arity, substitution) => {
-                TyKind::Tuple(*arity, substitution.clone().fold_with(folder, outer_binder)?)
-                    .intern(folder.interner())
-            }
+            TyKind::Tuple(arity, substitution) => TyKind::Tuple(
+                *arity,
+                substitution.clone().fold_with(folder, outer_binder)?,
+            )
+            .intern(folder.interner()),
             TyKind::OpaqueType(opaque_ty, substitution) => TyKind::OpaqueType(
                 opaque_ty.fold_with(folder, outer_binder)?,
                 substitution.clone().fold_with(folder, outer_binder)?,
@@ -571,7 +569,9 @@ where
                     Ok(bound_var.to_const(interner, fold_ty()?))
                 }
             }
-            ConstValue::InferenceVar(var) => folder.fold_inference_const(ty.clone(), *var, outer_binder),
+            ConstValue::InferenceVar(var) => {
+                folder.fold_inference_const(ty.clone(), *var, outer_binder)
+            }
             ConstValue::Placeholder(universe) => {
                 folder.fold_free_placeholder_const(ty.clone(), *universe, outer_binder)
             }
@@ -616,7 +616,9 @@ impl<I: Interner> SuperFold<I> for Goal<I> {
         let interner = folder.interner();
         Ok(Goal::new(
             interner,
-            self.data(interner).clone().fold_with(folder, outer_binder)?,
+            self.data(interner)
+                .clone()
+                .fold_with(folder, outer_binder)?,
         ))
     }
 }

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -8,7 +8,7 @@ use crate::*;
 impl<I: Interner> Fold<I> for FnPointer<I> {
     type Result = FnPointer<I>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -21,7 +21,7 @@ impl<I: Interner> Fold<I> for FnPointer<I> {
             sig,
         } = self;
         Ok(FnPointer {
-            num_binders: *num_binders,
+            num_binders,
             substitution: substitution.fold_with(folder, outer_binder.shifted_in())?,
             sig: FnSig {
                 abi: sig.abi,
@@ -40,7 +40,7 @@ where
 {
     type Result = Binders<T::Result>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -67,7 +67,7 @@ where
 {
     type Result = Canonical<T::Result>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -7,6 +7,9 @@
 use crate::*;
 use std::marker::PhantomData;
 
+// FIXME: Reuse memory owned by `Box`, `Vec` and others when `T` has the same layout as
+// `T::Result`.
+// See <https://github.com/rust-lang/rust/blob/5be3f9f10e9fd59ea03816840a6051413fbdefae/compiler/rustc_data_structures/src/functor.rs#L13>
 
 impl<T: Fold<I>, I: Interner> Fold<I> for Vec<T> {
     type Result = Vec<T::Result>;

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -6,21 +6,7 @@
 
 use crate::*;
 use std::marker::PhantomData;
-use std::sync::Arc;
 
-impl<'a, T: Fold<I>, I: Interner> Fold<I> for &'a T {
-    type Result = T::Result;
-    fn fold_with<'i>(
-        &self,
-        folder: &mut dyn Folder<'i, I>,
-        outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
-    where
-        I: 'i,
-    {
-        (**self).fold_with(folder, outer_binder)
-    }
-}
 
 impl<T: Fold<I>, I: Interner> Fold<I> for Vec<T> {
     type Result = Vec<T::Result>;
@@ -49,20 +35,6 @@ impl<T: Fold<I>, I: Interner> Fold<I> for Box<T> {
         I: 'i,
     {
         Ok(Box::new((**self).fold_with(folder, outer_binder)?))
-    }
-}
-
-impl<T: Fold<I>, I: Interner> Fold<I> for Arc<T> {
-    type Result = Arc<T::Result>;
-    fn fold_with<'i>(
-        &self,
-        folder: &mut dyn Folder<'i, I>,
-        outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
-    where
-        I: 'i,
-    {
-        Ok(Arc::new((**self).fold_with(folder, outer_binder)?))
     }
 }
 

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -14,14 +14,14 @@ use std::marker::PhantomData;
 impl<T: Fold<I>, I: Interner> Fold<I> for Vec<T> {
     type Result = Vec<T::Result>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
     where
         I: 'i,
     {
-        self.iter()
+        self.into_iter()
             .map(|e| e.fold_with(folder, outer_binder))
             .collect()
     }
@@ -30,14 +30,14 @@ impl<T: Fold<I>, I: Interner> Fold<I> for Vec<T> {
 impl<T: Fold<I>, I: Interner> Fold<I> for Box<T> {
     type Result = Box<T::Result>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
     where
         I: 'i,
     {
-        Ok(Box::new((**self).fold_with(folder, outer_binder)?))
+        Ok(Box::new((*self).fold_with(folder, outer_binder)?))
     }
 }
 
@@ -45,12 +45,12 @@ macro_rules! tuple_fold {
     ($($n:ident),*) => {
         impl<$($n: Fold<I>,)* I: Interner> Fold<I> for ($($n,)*) {
             type Result = ($($n::Result,)*);
-            fn fold_with<'i>(&self, folder: &mut dyn Folder<'i, I>, outer_binder: DebruijnIndex) -> Fallible<Self::Result>
+            fn fold_with<'i>(self, folder: &mut dyn Folder<'i, I>, outer_binder: DebruijnIndex) -> Fallible<Self::Result>
             where
                 I: 'i,
             {
                 #[allow(non_snake_case)]
-                let &($(ref $n),*) = self;
+                let ($($n),*) = self;
                 Ok(($($n.fold_with(folder, outer_binder)?,)*))
             }
         }
@@ -65,7 +65,7 @@ tuple_fold!(A, B, C, D, E);
 impl<T: Fold<I>, I: Interner> Fold<I> for Option<T> {
     type Result = Option<T::Result>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -82,7 +82,7 @@ impl<T: Fold<I>, I: Interner> Fold<I> for Option<T> {
 impl<I: Interner> Fold<I> for GenericArg<I> {
     type Result = GenericArg<I>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -91,7 +91,7 @@ impl<I: Interner> Fold<I> for GenericArg<I> {
     {
         let interner = folder.interner();
 
-        let data = self.data(interner).fold_with(folder, outer_binder)?;
+        let data = self.data(interner).clone().fold_with(folder, outer_binder)?;
         Ok(GenericArg::new(interner, data))
     }
 }
@@ -99,7 +99,7 @@ impl<I: Interner> Fold<I> for GenericArg<I> {
 impl<I: Interner> Fold<I> for Substitution<I> {
     type Result = Substitution<I>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -110,6 +110,7 @@ impl<I: Interner> Fold<I> for Substitution<I> {
 
         let folded = self
             .iter(interner)
+            .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
         Ok(Substitution::from_fallible(interner, folded)?)
     }
@@ -118,7 +119,7 @@ impl<I: Interner> Fold<I> for Substitution<I> {
 impl<I: Interner> Fold<I> for Goals<I> {
     type Result = Goals<I>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -128,6 +129,7 @@ impl<I: Interner> Fold<I> for Goals<I> {
         let interner = folder.interner();
         let folded = self
             .iter(interner)
+            .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
         Ok(Goals::from_fallible(interner, folded)?)
     }
@@ -136,7 +138,7 @@ impl<I: Interner> Fold<I> for Goals<I> {
 impl<I: Interner> Fold<I> for ProgramClauses<I> {
     type Result = ProgramClauses<I>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -146,6 +148,7 @@ impl<I: Interner> Fold<I> for ProgramClauses<I> {
         let interner = folder.interner();
         let folded = self
             .iter(interner)
+            .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
         Ok(ProgramClauses::from_fallible(interner, folded)?)
     }
@@ -154,7 +157,7 @@ impl<I: Interner> Fold<I> for ProgramClauses<I> {
 impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
     type Result = QuantifiedWhereClauses<I>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -164,6 +167,7 @@ impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
         let interner = folder.interner();
         let folded = self
             .iter(interner)
+            .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
         Ok(QuantifiedWhereClauses::from_fallible(interner, folded)?)
     }
@@ -172,7 +176,7 @@ impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
 impl<I: Interner> Fold<I> for Constraints<I> {
     type Result = Constraints<I>;
     fn fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Self::Result>
@@ -182,6 +186,7 @@ impl<I: Interner> Fold<I> for Constraints<I> {
         let interner = folder.interner();
         let folded = self
             .iter(interner)
+            .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
         Ok(Constraints::from_fallible(interner, folded)?)
     }
@@ -194,14 +199,14 @@ macro_rules! copy_fold {
         impl<I: Interner> $crate::fold::Fold<I> for $t {
             type Result = Self;
             fn fold_with<'i>(
-                &self,
+                self,
                 _folder: &mut dyn ($crate::fold::Folder<'i, I>),
                 _outer_binder: DebruijnIndex,
             ) -> ::chalk_ir::Fallible<Self::Result>
             where
                 I: 'i,
             {
-                Ok(*self)
+                Ok(self)
             }
         }
     };
@@ -229,14 +234,14 @@ macro_rules! id_fold {
         impl<I: Interner> $crate::fold::Fold<I> for $t<I> {
             type Result = $t<I>;
             fn fold_with<'i>(
-                &self,
+                self,
                 _folder: &mut dyn ($crate::fold::Folder<'i, I>),
                 _outer_binder: DebruijnIndex,
             ) -> ::chalk_ir::Fallible<Self::Result>
             where
                 I: 'i,
             {
-                Ok(*self)
+                Ok(self)
             }
         }
     };
@@ -254,7 +259,7 @@ id_fold!(ForeignDefId);
 
 impl<I: Interner> SuperFold<I> for ProgramClauseData<I> {
     fn super_fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> ::chalk_ir::Fallible<Self::Result>
@@ -267,14 +272,14 @@ impl<I: Interner> SuperFold<I> for ProgramClauseData<I> {
 
 impl<I: Interner> SuperFold<I> for ProgramClause<I> {
     fn super_fold_with<'i>(
-        &self,
+        self,
         folder: &mut dyn Folder<'i, I>,
         outer_binder: DebruijnIndex,
     ) -> ::chalk_ir::Fallible<Self::Result>
     where
         I: 'i,
     {
-        let clause = self.data(folder.interner());
+        let clause = self.data(folder.interner()).clone();
         Ok(clause
             .super_fold_with(folder, outer_binder)?
             .intern(folder.interner()))
@@ -285,7 +290,7 @@ impl<I: Interner> Fold<I> for PhantomData<I> {
     type Result = PhantomData<I>;
 
     fn fold_with<'i>(
-        &self,
+        self,
         _folder: &mut dyn Folder<'i, I>,
         _outer_binder: DebruijnIndex,
     ) -> ::chalk_ir::Fallible<Self::Result>

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -91,7 +91,10 @@ impl<I: Interner> Fold<I> for GenericArg<I> {
     {
         let interner = folder.interner();
 
-        let data = self.data(interner).clone().fold_with(folder, outer_binder)?;
+        let data = self
+            .data(interner)
+            .clone()
+            .fold_with(folder, outer_binder)?;
         Ok(GenericArg::new(interner, data))
     }
 }

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -7,28 +7,28 @@ use crate::*;
 /// of binders.
 pub trait Shift<I: Interner>: Fold<I> {
     /// Shifts this term in one level of binders.
-    fn shifted_in(&self, interner: &I) -> Self::Result;
+    fn shifted_in(self, interner: &I) -> Self::Result;
 
     /// Shifts a term valid at `outer_binder` so that it is
     /// valid at the innermost binder. See [`DebruijnIndex::shifted_in_from`]
     /// for a detailed explanation.
-    fn shifted_in_from(&self, interner: &I, source_binder: DebruijnIndex) -> Self::Result;
+    fn shifted_in_from(self, interner: &I, source_binder: DebruijnIndex) -> Self::Result;
 
     /// Shifts this term out one level of binders.
-    fn shifted_out(&self, interner: &I) -> Fallible<Self::Result>;
+    fn shifted_out(self, interner: &I) -> Fallible<Self::Result>;
 
     /// Shifts a term valid at the innermost binder so that it is
     /// valid at `outer_binder`. See [`DebruijnIndex::shifted_out_to`]
     /// for a detailed explanation.
-    fn shifted_out_to(&self, interner: &I, target_binder: DebruijnIndex) -> Fallible<Self::Result>;
+    fn shifted_out_to(self, interner: &I, target_binder: DebruijnIndex) -> Fallible<Self::Result>;
 }
 
 impl<T: Fold<I>, I: Interner> Shift<I> for T {
-    fn shifted_in(&self, interner: &I) -> Self::Result {
+    fn shifted_in(self, interner: &I) -> Self::Result {
         self.shifted_in_from(interner, DebruijnIndex::ONE)
     }
 
-    fn shifted_in_from(&self, interner: &I, source_binder: DebruijnIndex) -> T::Result {
+    fn shifted_in_from(self, interner: &I, source_binder: DebruijnIndex) -> T::Result {
         self.fold_with(
             &mut Shifter {
                 source_binder,
@@ -39,7 +39,7 @@ impl<T: Fold<I>, I: Interner> Shift<I> for T {
         .unwrap()
     }
 
-    fn shifted_out_to(&self, interner: &I, target_binder: DebruijnIndex) -> Fallible<T::Result> {
+    fn shifted_out_to(self, interner: &I, target_binder: DebruijnIndex) -> Fallible<T::Result> {
         self.fold_with(
             &mut DownShifter {
                 target_binder,
@@ -49,7 +49,7 @@ impl<T: Fold<I>, I: Interner> Shift<I> for T {
         )
     }
 
-    fn shifted_out(&self, interner: &I) -> Fallible<Self::Result> {
+    fn shifted_out(self, interner: &I) -> Fallible<Self::Result> {
         self.shifted_out_to(interner, DebruijnIndex::ONE)
     }
 }
@@ -97,14 +97,14 @@ impl<'i, I: Interner> Folder<'i, I> for Shifter<'i, I> {
 
     fn fold_free_var_const(
         &mut self,
-        ty: &Ty<I>,
+        ty: Ty<I>,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>> {
         // const types don't have free variables, so we can skip folding `ty`
         Ok(self
             .adjust(bound_var, outer_binder)
-            .to_const(self.interner(), ty.clone()))
+            .to_const(self.interner(), ty))
     }
 
     fn interner(&self) -> &'i I {
@@ -165,14 +165,14 @@ impl<'i, I: Interner> Folder<'i, I> for DownShifter<'i, I> {
 
     fn fold_free_var_const(
         &mut self,
-        ty: &Ty<I>,
+        ty: Ty<I>,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>> {
         // const types don't have free variables, so we can skip folding `ty`
         Ok(self
             .adjust(bound_var, outer_binder)?
-            .to_const(self.interner(), ty.clone()))
+            .to_const(self.interner(), ty))
     }
 
     fn interner(&self) -> &'i I {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1915,6 +1915,13 @@ impl<T: HasInterner> HasInterner for Binders<T> {
     type Interner = T::Interner;
 }
 
+impl<T: Clone + HasInterner> Binders<&T> {
+    /// Converts a `Binders<&T>` to a `Binders<T>` by cloning `T`.
+    pub fn cloned(self) -> Binders<T> {
+        self.map(Clone::clone)
+    }
+}
+
 impl<T: HasInterner> Binders<T> {
     /// Create new binders.
     pub fn new(binders: VariableKinds<T::Interner>, value: T) -> Self {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1951,6 +1951,12 @@ impl<T: HasInterner> Binders<T> {
         &self.value
     }
 
+    /// Skips the binder and returns the "bound" value as well as the skipped free variables. This
+    /// is just as risky as [`skip_binders`].
+    pub fn into_value_and_skipped_binders(self) -> (T, VariableKinds<T::Interner>) {
+        (self.value, self.binders)
+    }
+
     /// Converts `&Binders<T>` to `Binders<&T>`. Produces new `Binders`
     /// with cloned quantifiers containing a reference to the original
     /// value, leaving the original in place.

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -44,7 +44,7 @@ pub trait Zipper<'i, I: Interner + 'i> {
         b: &Binders<T>,
     ) -> Fallible<()>
     where
-        T: HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>;
+        T: Clone + HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>;
 
     /// Zips two substs
     fn zip_substs(
@@ -98,7 +98,7 @@ where
 
     fn zip_binders<T>(&mut self, variance: Variance, a: &Binders<T>, b: &Binders<T>) -> Fallible<()>
     where
-        T: HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>,
+        T: Clone + HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>,
     {
         (**self).zip_binders(variance, a, b)
     }
@@ -278,8 +278,9 @@ impl<I: Interner> Zip<I> for Const<I> {
         zipper.zip_consts(variance, a, b)
     }
 }
-impl<I: Interner, T: HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>> Zip<I>
-    for Binders<T>
+impl<I: Interner, T> Zip<I> for Binders<T>
+where
+    T: Clone + HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>,
 {
     fn zip_with<'i, Z: Zipper<'i, I>>(
         zipper: &mut Z,

--- a/chalk-recursive/src/combine.rs
+++ b/chalk-recursive/src/combine.rs
@@ -69,7 +69,7 @@ fn calculate_inputs<I: Interner>(
     solution: &Solution<I>,
 ) -> Vec<GenericArg<I>> {
     if let Some(subst) = solution.constrained_subst(interner) {
-        let subst_goal = subst.value.subst.apply(&domain_goal, interner);
+        let subst_goal = subst.value.subst.apply(domain_goal.clone(), interner);
         subst_goal.inputs(interner)
     } else {
         domain_goal.inputs(interner)

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -194,7 +194,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
         let (infer, subst, canonical_goal) = InferenceTable::from_canonical(
             self.interner(),
             ucanonical_goal.universes,
-            &ucanonical_goal.canonical,
+            ucanonical_goal.canonical.clone(),
         );
         let infer = RecursiveInferenceTableImpl { infer };
         (infer, subst, canonical_goal)
@@ -228,7 +228,7 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
     fn instantiate_binders_universally<'a, T>(
         &mut self,
         interner: &'a I,
-        arg: &'a Binders<T>,
+        arg: Binders<T>,
     ) -> T::Result
     where
         T: Fold<I> + HasInterner<Interner = I>,
@@ -239,7 +239,7 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
     fn instantiate_binders_existentially<'a, T>(
         &mut self,
         interner: &'a I,
-        arg: &'a Binders<T>,
+        arg: Binders<T>,
     ) -> T::Result
     where
         T: Fold<I> + HasInterner<Interner = I>,
@@ -250,7 +250,7 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
     fn canonicalize<T>(
         &mut self,
         interner: &I,
-        value: &T,
+        value: T,
     ) -> (Canonical<T::Result>, Vec<GenericArg<I>>)
     where
         T: Fold<I>,
@@ -271,7 +271,7 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
         value0: &Canonical<T>,
     ) -> (UCanonical<T::Result>, UniverseMap)
     where
-        T: HasInterner<Interner = I> + Fold<I> + Visit<I>,
+        T: Clone + HasInterner<Interner = I> + Fold<I> + Visit<I>,
         T::Result: HasInterner<Interner = I>,
     {
         let res = self.infer.u_canonicalize(interner, value0);
@@ -296,7 +296,7 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
         Ok(res.goals)
     }
 
-    fn instantiate_canonical<T>(&mut self, interner: &I, bound: &Canonical<T>) -> T::Result
+    fn instantiate_canonical<T>(&mut self, interner: &I, bound: Canonical<T>) -> T::Result
     where
         T: HasInterner<Interner = I> + Fold<I> + Debug,
     {
@@ -306,7 +306,7 @@ impl<I: Interner> RecursiveInferenceTable<I> for RecursiveInferenceTableImpl<I> 
     fn invert_then_canonicalize<T>(
         &mut self,
         interner: &I,
-        value: &T,
+        value: T,
     ) -> Option<Canonical<T::Result>>
     where
         T: Fold<I, Result = T> + HasInterner<Interner = I>,

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -131,7 +131,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
     #[instrument(level = "debug", skip(self, op))]
     pub fn push_binders<R, V>(
         &mut self,
-        binders: &Binders<V>,
+        binders: Binders<V>,
         op: impl FnOnce(&mut Self, V::Result) -> R,
     ) -> R
     where
@@ -148,7 +148,6 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
                 .zip(old_len..)
                 .map(|(pk, i)| (i, pk).to_generic_arg(interner)),
         );
-
         let value = binders.substitute(self.interner(), &self.parameters[old_len..]);
         debug!(?value);
         let res = op(self, value);
@@ -169,7 +168,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
             VariableKinds::from1(interner, VariableKind::Ty(TyVariableKind::General)),
             PhantomData::<I>,
         );
-        self.push_binders(&binders, |this, PhantomData| {
+        self.push_binders(binders, |this, PhantomData| {
             let ty = this
                 .placeholders_in_scope()
                 .last()
@@ -191,7 +190,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
             VariableKinds::from1(interner, VariableKind::Lifetime),
             PhantomData::<I>,
         );
-        self.push_binders(&binders, |this, PhantomData| {
+        self.push_binders(binders, |this, PhantomData| {
             let lifetime = this
                 .placeholders_in_scope()
                 .last()

--- a/chalk-solve/src/clauses/builtin_traits/clone.rs
+++ b/chalk-solve/src/clauses/builtin_traits/clone.rs
@@ -7,8 +7,8 @@ use super::copy::add_copy_program_clauses;
 pub fn add_clone_program_clauses<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,
-    trait_ref: &TraitRef<I>,
-    ty: &TyKind<I>,
+    trait_ref: TraitRef<I>,
+    ty: TyKind<I>,
     binders: &CanonicalVarKinds<I>,
 ) {
     // Implement Clone for types that automaticly implement Copy

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -21,7 +21,7 @@ pub struct Generalize<'i, I: Interner> {
 }
 
 impl<I: Interner> Generalize<'_, I> {
-    pub fn apply<T>(interner: &I, value: &T) -> Binders<T::Result>
+    pub fn apply<T>(interner: &I, value: T) -> Binders<T::Result>
     where
         T: HasInterner<Interner = I> + Fold<I>,
         T::Result: HasInterner<Interner = I>,

--- a/chalk-solve/src/coherence/solve.rs
+++ b/chalk-solve/src/coherence/solve.rs
@@ -101,7 +101,7 @@ impl<I: Interner> CoherenceSolver<'_, I> {
             .substitution
             .as_slice(interner)
             .iter()
-            .map(|param| param.shifted_in(interner));
+            .map(|param| param.clone().shifted_in(interner));
 
         // Create an equality goal for every input type the trait, attempting
         // to unify the inputs to both impls with one another
@@ -114,7 +114,7 @@ impl<I: Interner> CoherenceSolver<'_, I> {
         let rhs_where_clauses = rhs_bound
             .where_clauses
             .iter()
-            .map(|wc| wc.shifted_in(interner));
+            .map(|wc| wc.clone().shifted_in(interner));
 
         // Create a goal for each clause in both where clauses
         let wc_goals = lhs_where_clauses
@@ -214,7 +214,7 @@ impl<I: Interner> CoherenceSolver<'_, I> {
                     // exists<Q0..Qn> { ... }
                     gb.exists(
                         &less_special.binders,
-                        &more_special_impl.trait_ref,
+                        more_special_impl.trait_ref.clone(),
                         |gb, _, less_special_impl, more_special_trait_ref| {
                             let interner = gb.interner();
 

--- a/chalk-solve/src/display/state.rs
+++ b/chalk-solve/src/display/state.rs
@@ -243,7 +243,7 @@ impl<'a, I: Interner> InternalWriterState<'a, I> {
     ///
     /// If `self_binding` is `Some`, then it will introduce a new variable named
     /// `Self` with the within-debrujin index given within and the innermost
-    /// debrujian index after increasing debrujin index.  
+    /// debrujian index after increasing debrujin index.
     #[must_use = "this returns a new `InternalWriterState`, and does not modify the existing one"]
     pub(super) fn add_debrujin_index(&self, self_binding: Option<IndexWithinBinding>) -> Self {
         let mut new_state = self.clone();

--- a/chalk-solve/src/ext.rs
+++ b/chalk-solve/src/ext.rs
@@ -42,9 +42,9 @@ where
         // `Canonical` type (indeed, its entire reason for existence).
         let mut infer = InferenceTable::new();
         let snapshot = infer.snapshot();
-        let instantiated_value = infer.instantiate_canonical(interner, &self);
+        let instantiated_value = infer.instantiate_canonical(interner, self);
         let mapped_value = op(instantiated_value);
-        let result = infer.canonicalize(interner, &mapped_value);
+        let result = infer.canonicalize(interner, mapped_value);
         infer.rollback_to(snapshot);
         result.quantified
     }
@@ -70,12 +70,14 @@ impl<I: Interner> GoalExt<I> for Goal<I> {
                 let InEnvironment { environment, goal } = env_goal;
                 match goal.data(interner) {
                     GoalData::Quantified(QuantifierKind::ForAll, subgoal) => {
-                        let subgoal = infer.instantiate_binders_universally(interner, subgoal);
+                        let subgoal =
+                            infer.instantiate_binders_universally(interner, subgoal.clone());
                         env_goal = InEnvironment::new(&environment, subgoal);
                     }
 
                     GoalData::Quantified(QuantifierKind::Exists, subgoal) => {
-                        let subgoal = infer.instantiate_binders_existentially(interner, subgoal);
+                        let subgoal =
+                            infer.instantiate_binders_existentially(interner, subgoal.clone());
                         env_goal = InEnvironment::new(&environment, subgoal);
                     }
 
@@ -89,7 +91,7 @@ impl<I: Interner> GoalExt<I> for Goal<I> {
                 }
             }
         };
-        let canonical = infer.canonicalize(interner, &peeled_goal).quantified;
+        let canonical = infer.canonicalize(interner, peeled_goal).quantified;
         infer.u_canonicalize(interner, &canonical).quantified
     }
 
@@ -105,7 +107,7 @@ impl<I: Interner> GoalExt<I> for Goal<I> {
     fn into_closed_goal(self, interner: &I) -> UCanonical<InEnvironment<Goal<I>>> {
         let mut infer = InferenceTable::new();
         let env_goal = InEnvironment::new(&Environment::new(interner), self);
-        let canonical_goal = infer.canonicalize(interner, &env_goal).quantified;
+        let canonical_goal = infer.canonicalize(interner, env_goal).quantified;
         infer.u_canonicalize(interner, &canonical_goal).quantified
     }
 }

--- a/chalk-solve/src/goal_builder.rs
+++ b/chalk-solve/src/goal_builder.rs
@@ -79,9 +79,8 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
         body: fn(&mut Self, Substitution<I>, &B, P::Result) -> G,
     ) -> Goal<I>
     where
-        B: Fold<I> + HasInterner<Interner = I>,
+        B: HasInterner<Interner = I>,
         P: Fold<I>,
-        B::Result: std::fmt::Debug,
         G: CastTo<Goal<I>>,
     {
         self.quantified(QuantifierKind::ForAll, binders, passthru, body)
@@ -95,9 +94,8 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
         body: fn(&mut Self, Substitution<I>, &B, P::Result) -> G,
     ) -> Goal<I>
     where
-        B: Fold<I> + HasInterner<Interner = I>,
+        B: HasInterner<Interner = I>,
         P: Fold<I>,
-        B::Result: std::fmt::Debug,
         G: CastTo<Goal<I>>,
     {
         self.quantified(QuantifierKind::Exists, binders, passthru, body)
@@ -118,9 +116,8 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
         body: fn(&mut Self, Substitution<I>, &B, P::Result) -> G,
     ) -> Goal<I>
     where
-        B: Fold<I> + HasInterner<Interner = I>,
+        B: HasInterner<Interner = I>,
         P: Fold<I>,
-        B::Result: std::fmt::Debug,
         G: CastTo<Goal<I>>,
     {
         let interner = self.interner();

--- a/chalk-solve/src/infer.rs
+++ b/chalk-solve/src/infer.rs
@@ -49,7 +49,7 @@ impl<I: Interner> InferenceTable<I> {
     pub fn from_canonical<T>(
         interner: &I,
         num_universes: usize,
-        canonical: &Canonical<T>,
+        canonical: Canonical<T>,
     ) -> (Self, Substitution<I>, T)
     where
         T: HasInterner<Interner = I> + Fold<I, Result = T> + Clone,
@@ -62,7 +62,7 @@ impl<I: Interner> InferenceTable<I> {
         }
 
         let subst = table.fresh_subst(interner, canonical.binders.as_slice(interner));
-        let value = subst.apply(&canonical.value, interner);
+        let value = subst.apply(canonical.value, interner);
         // let value = canonical.value.fold_with(&mut &subst, 0).unwrap();
 
         (table, subst, value)

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -71,7 +71,7 @@ impl<I: Interner> InferenceTable<I> {
     /// `?T: Clone` in the case where `?T = Vec<i32>`. The current
     /// version would delay processing the negative goal (i.e., return
     /// `None`) until the second unification has occurred.)
-    pub fn invert<T>(&mut self, interner: &I, value: &T) -> Option<T::Result>
+    pub fn invert<T>(&mut self, interner: &I, value: T) -> Option<T::Result>
     where
         T: Fold<I, Result = T> + HasInterner<Interner = I>,
     {
@@ -79,7 +79,7 @@ impl<I: Interner> InferenceTable<I> {
             free_vars,
             quantified,
             ..
-        } = self.canonicalize(interner, &value);
+        } = self.canonicalize(interner, value);
 
         // If the original contains free existential variables, give up.
         if !free_vars.is_empty() {
@@ -100,14 +100,14 @@ impl<I: Interner> InferenceTable<I> {
     pub fn invert_then_canonicalize<T>(
         &mut self,
         interner: &I,
-        value: &T,
+        value: T,
     ) -> Option<Canonical<T::Result>>
     where
         T: Fold<I, Result = T> + HasInterner<Interner = I>,
     {
         let snapshot = self.snapshot();
         let result = self.invert(interner, value);
-        let result = result.map(|r| self.canonicalize(interner, &r).quantified);
+        let result = result.map(|r| self.canonicalize(interner, r).quantified);
         self.rollback_to(snapshot);
         result
     }

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -263,7 +263,7 @@ fn quantify_simple() {
 
     assert_eq!(
         table
-            .canonicalize(interner, &ty!(apply (item 0) (infer 2) (infer 1) (infer 0)))
+            .canonicalize(interner, ty!(apply (item 0) (infer 2) (infer 1) (infer 0)))
             .quantified,
         Canonical {
             value: ty!(apply (item 0) (bound 0) (bound 1) (bound 2)),
@@ -305,7 +305,7 @@ fn quantify_bound() {
         table
             .canonicalize(
                 interner,
-                &ty!(apply (item 0) (expr v2b) (expr v2a) (expr v1) (expr v0))
+                ty!(apply (item 0) (expr v2b) (expr v2a) (expr v1) (expr v0))
             )
             .quantified,
         Canonical {
@@ -351,7 +351,7 @@ fn quantify_ty_under_binder() {
         table
             .canonicalize(
                 interner,
-                &ty!(function 3 (apply (item 0) (bound 1) (infer 0) (infer 1) (lifetime (infer 2))))
+                ty!(function 3 (apply (item 0) (bound 1) (infer 0) (infer 1) (lifetime (infer 2))))
             )
             .quantified,
         Canonical {

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -13,7 +13,7 @@ impl<I: Interner> InferenceTable<I> {
         value0: &Canonical<T>,
     ) -> UCanonicalized<T::Result>
     where
-        T: HasInterner<Interner = I> + Fold<I> + Visit<I>,
+        T: Clone + HasInterner<Interner = I> + Fold<I> + Visit<I>,
         T::Result: HasInterner<Interner = I>,
     {
         debug_span!("u_canonicalize", "{:#?}", value0);
@@ -38,6 +38,7 @@ impl<I: Interner> InferenceTable<I> {
         // full set of universes found in the original value.
         let value1 = value0
             .value
+            .clone()
             .fold_with(
                 &mut UMapToCanonical {
                     universes: &universes,
@@ -86,7 +87,7 @@ pub trait UniverseMapExt {
         canonical_value: &Canonical<T>,
     ) -> Canonical<T::Result>
     where
-        T: Fold<I> + HasInterner<Interner = I>,
+        T: Clone + Fold<I> + HasInterner<Interner = I>,
         T::Result: HasInterner<Interner = I>,
         I: Interner;
 }
@@ -165,7 +166,7 @@ impl UniverseMapExt for UniverseMap {
         canonical_value: &Canonical<T>,
     ) -> Canonical<T::Result>
     where
-        T: Fold<I> + HasInterner<Interner = I>,
+        T: Clone + Fold<I> + HasInterner<Interner = I>,
         T::Result: HasInterner<Interner = I>,
         I: Interner,
     {
@@ -178,6 +179,7 @@ impl UniverseMapExt for UniverseMap {
 
         let value = canonical_value
             .value
+            .clone()
             .fold_with(
                 &mut UMapFromCanonical {
                     interner,
@@ -281,7 +283,7 @@ where
 
     fn fold_free_placeholder_const(
         &mut self,
-        ty: &Ty<I>,
+        ty: Ty<I>,
         universe0: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>> {

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -1,7 +1,6 @@
 use super::var::*;
 use super::*;
 use crate::debug_span;
-use crate::infer::instantiate::IntoBindersAndValue;
 use chalk_ir::cast::Cast;
 use chalk_ir::fold::{Fold, Folder};
 use chalk_ir::interner::{HasInterner, Interner};
@@ -367,11 +366,11 @@ impl<'t, I: Interner> Unifier<'t, I> {
     fn relate_binders<'a, T, R>(
         &mut self,
         variance: Variance,
-        a: impl IntoBindersAndValue<'a, I, Value = T> + Copy + Debug,
-        b: impl IntoBindersAndValue<'a, I, Value = T> + Copy + Debug,
+        a: &Binders<T>,
+        b: &Binders<T>,
     ) -> Fallible<()>
     where
-        T: Fold<I, Result = R>,
+        T: Fold<I, Result = R> + HasInterner<Interner = I>,
         R: Zip<I> + Fold<I, Result = R>,
         't: 'a,
     {

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -370,7 +370,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
         b: &Binders<T>,
     ) -> Fallible<()>
     where
-        T: Fold<I, Result = R> + HasInterner<Interner = I>,
+        T: Clone + Fold<I, Result = R> + HasInterner<Interner = I>,
         R: Zip<I> + Fold<I, Result = R>,
         't: 'a,
     {
@@ -390,14 +390,22 @@ impl<'t, I: Interner> Unifier<'t, I> {
         let interner = self.interner;
 
         if let Variance::Invariant | Variance::Contravariant = variance {
-            let a_universal = self.table.instantiate_binders_universally(interner, a);
-            let b_existential = self.table.instantiate_binders_existentially(interner, b);
+            let a_universal = self
+                .table
+                .instantiate_binders_universally(interner, a.clone());
+            let b_existential = self
+                .table
+                .instantiate_binders_existentially(interner, b.clone());
             Zip::zip_with(self, Variance::Contravariant, &a_universal, &b_existential)?;
         }
 
         if let Variance::Invariant | Variance::Covariant = variance {
-            let b_universal = self.table.instantiate_binders_universally(interner, b);
-            let a_existential = self.table.instantiate_binders_existentially(interner, a);
+            let b_universal = self
+                .table
+                .instantiate_binders_universally(interner, b.clone());
+            let a_existential = self
+                .table
+                .instantiate_binders_existentially(interner, a.clone());
             Zip::zip_with(self, Variance::Covariant, &a_existential, &b_universal)?;
         }
 
@@ -774,6 +782,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
 
         debug!("trying fold_with on {:?}", ty);
         let ty1 = ty
+            .clone()
             .fold_with(
                 &mut OccursCheck::new(self, var, universe_index),
                 DebruijnIndex::INNERMOST,
@@ -1029,7 +1038,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
         // as the variable is unified.
         let universe_index = self.table.universe_of_unbound_var(var);
 
-        let c1 = c.fold_with(
+        let c1 = c.clone().fold_with(
             &mut OccursCheck::new(self, var, universe_index),
             DebruijnIndex::INNERMOST,
         )?;
@@ -1097,7 +1106,7 @@ impl<'i, I: Interner> Zipper<'i, I> for Unifier<'i, I> {
 
     fn zip_binders<T>(&mut self, variance: Variance, a: &Binders<T>, b: &Binders<T>) -> Fallible<()>
     where
-        T: HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>,
+        T: Clone + HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>,
     {
         // The binders that appear in types (apart from quantified types, which are
         // handled in `unify_ty`) appear as part of `dyn Trait` and `impl Trait` types.
@@ -1169,7 +1178,7 @@ where
 
     fn fold_free_placeholder_const(
         &mut self,
-        ty: &Ty<I>,
+        ty: Ty<I>,
         universe: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>> {
@@ -1228,7 +1237,9 @@ where
             // If this variable already has a value, fold over that value instead.
             InferenceValue::Bound(normalized_ty) => {
                 let normalized_ty = normalized_ty.assert_ty_ref(interner);
-                let normalized_ty = normalized_ty.fold_with(self, DebruijnIndex::INNERMOST)?;
+                let normalized_ty = normalized_ty
+                    .clone()
+                    .fold_with(self, DebruijnIndex::INNERMOST)?;
                 assert!(!normalized_ty.needs_shift(interner));
                 Ok(normalized_ty)
             }
@@ -1262,7 +1273,7 @@ where
 
     fn fold_inference_const(
         &mut self,
-        ty: &Ty<I>,
+        ty: Ty<I>,
         var: InferenceVar,
         _outer_binder: DebruijnIndex,
     ) -> Fallible<Const<I>> {
@@ -1272,8 +1283,9 @@ where
             // If this variable already has a value, fold over that value instead.
             InferenceValue::Bound(normalized_const) => {
                 let normalized_const = normalized_const.assert_const_ref(interner);
-                let normalized_const =
-                    normalized_const.fold_with(self, DebruijnIndex::INNERMOST)?;
+                let normalized_const = normalized_const
+                    .clone()
+                    .fold_with(self, DebruijnIndex::INNERMOST)?;
                 assert!(!normalized_const.needs_shift(interner));
                 Ok(normalized_const)
             }
@@ -1300,7 +1312,7 @@ where
                         .unwrap();
                 }
 
-                Ok(var.to_const(interner, ty.clone()))
+                Ok(var.to_const(interner, ty))
             }
         }
     }
@@ -1334,7 +1346,7 @@ where
 
             InferenceValue::Bound(l) => {
                 let l = l.assert_lifetime_ref(interner);
-                let l = l.fold_with(self, outer_binder)?;
+                let l = l.clone().fold_with(self, outer_binder)?;
                 assert!(!l.needs_shift(interner));
                 Ok(l)
             }

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -169,7 +169,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
     ///
     /// ```ignore (example)
     /// trait Foo<T> {
-    ///     type Assoc<'a>;   
+    ///     type Assoc<'a>;
     /// }
     /// ```
     ///

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -134,7 +134,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
         let (impl_parameters, atv_parameters) =
             self.split_associated_ty_value_parameters(&parameters, associated_ty_value);
         let trait_ref = {
-            let opaque_ty_ref = impl_datum.binders.map_ref(|b| &b.trait_ref);
+            let opaque_ty_ref = impl_datum.binders.map_ref(|b| &b.trait_ref).cloned();
             debug!(?opaque_ty_ref);
             opaque_ty_ref.substitute(interner, impl_parameters)
         };

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -100,7 +100,7 @@ impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
 
         let mut push_ty = || {
             self.types
-                .push(ty.shifted_out_to(interner, outer_binder).unwrap())
+                .push(ty.clone().shifted_out_to(interner, outer_binder).unwrap())
         };
         match ty.kind(interner) {
             TyKind::Adt(id, substitution) => {
@@ -362,8 +362,8 @@ where
 
             let subst = Substitution::from1(interner, gb.db().hidden_opaque_type(opaque_ty_id));
 
-            let bounds = bound.bounds.substitute(interner, &subst);
-            let where_clauses = bound.where_clauses.substitute(interner, &subst);
+            let bounds = bound.bounds.clone().substitute(interner, &subst);
+            let where_clauses = bound.where_clauses.clone().substitute(interner, &subst);
 
             let clauses = where_clauses
                 .iter()
@@ -581,7 +581,10 @@ fn compute_assoc_ty_goal<I: Interner>(
             let ImplDatumBound {
                 trait_ref: impl_trait_ref,
                 where_clauses: impl_where_clauses,
-            } = impl_datum.binders.substitute(interner, impl_parameters);
+            } = impl_datum
+                .binders
+                .clone()
+                .substitute(interner, impl_parameters);
             let impl_wf_clauses =
                 impl_wf_environment(interner, &impl_where_clauses, &impl_trait_ref);
             gb.implies(impl_wf_clauses, |gb| {
@@ -604,6 +607,7 @@ fn compute_assoc_ty_goal<I: Interner>(
                     where_clauses: defn_where_clauses,
                 } = assoc_ty_datum
                     .binders
+                    .clone()
                     .substitute(interner, &projection.substitution);
 
                 // Create `if (/* where clauses on associated type value */) { .. }`
@@ -753,6 +757,7 @@ impl WfWellKnownConstraints {
                         let goals = adt_datum
                             .binders
                             .map_ref(|b| &b.variants)
+                            .cloned()
                             .substitute(interner, substitution)
                             .into_iter()
                             .flat_map(|v| {
@@ -992,10 +997,11 @@ impl WfWellKnownConstraints {
 
                 let fields = adt_datum
                     .binders
-                    .map_ref(|bound| &bound.variants.last().unwrap().fields);
+                    .map_ref(|bound| &bound.variants.last().unwrap().fields)
+                    .cloned();
 
                 let (source_fields, target_fields) = (
-                    fields.substitute(interner, subst_a),
+                    fields.clone().substitute(interner, subst_a),
                     fields.substitute(interner, subst_b),
                 );
 

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -895,7 +895,7 @@ impl WfWellKnownConstraints {
     ///    and consider their types with both substitutes. We are looking to find
     ///    exactly one (non-phantom) field that has changed its type (from T to U), and
     ///    expect T to be unsizeable to U, i.e. T: CoerceUnsized<U>.
-    ///        
+    ///
     ///    As an example, consider a struct
     ///    ```rust
     ///    struct Foo<T, U> {
@@ -910,10 +910,10 @@ impl WfWellKnownConstraints {
     ///    impl<T, U: Unsize<V>, V> CoerceUnsized<Foo<T, V>> for Foo<T, U> {}
     ///    ```
     ///    In this case:
-    ///   
+    ///
     ///    - `extra` has type `T` before and type `T` after
     ///    - `ptr` has type `*mut U` before and type `*mut V` after
-    ///   
+    ///
     ///    Since just one field changed, we would then check that `*mut U: CoerceUnsized<*mut V>`
     ///    is implemented. This will work out because `U: Unsize<V>`, and we have a libcore rule
     ///    that `*mut U` can be coerced to `*mut V` if `U: Unsize<V>`.


### PR DESCRIPTION
Resolves #642.

This might need some more work. I suspect there are unnecessary clones. Without familiarity with the code base I found it hard to choose between changing a function signature versus cloning the argument in some places. It should be pretty close though.