### PR TITLE
Update occurences of outdated ProjectionEq predicate in Chalk book

### DIFF
--- a/book/src/clauses/goals_and_clauses.md
+++ b/book/src/clauses/goals_and_clauses.md
@@ -96,7 +96,7 @@ DomainGoal = Holds(WhereClause)
             | Normalize(Projection -> Type)
 
 WhereClause = Implemented(TraitRef)
-            | ProjectionEq(Projection = Type)
+            | AliasEq(Projection = Type)
             | Outlives(Type: Region)
             | Outlives(Region: Region)
 ```
@@ -113,25 +113,25 @@ e.g. `Implemented(i32: Copy)`
 
 True if the given trait is implemented for the given input types and lifetimes.
 
-#### ProjectionEq(Projection = Type)
-e.g. `ProjectionEq<T as Iterator>::Item = u8`
+#### AliasEq(Projection = Type)
+e.g. `AliasEq<T as Iterator>::Item = u8`
 
 The given associated type `Projection` is equal to `Type`; this can be proved
-with either normalization or using placeholder associated types. See
+with either normalization or using placeholder associated types and is handled
+as a special kind of type aliases. See
 [the section on associated types](./type_equality.html).
 
 #### Normalize(Projection -> Type)
-e.g. `ProjectionEq<T as Iterator>::Item -> u8`
+e.g. `Normalize<T as Iterator>::Item -> u8`
 
 The given associated type `Projection` can be [normalized][n] to `Type`.
 
 As discussed in [the section on associated
-types](./type_equality.html), `Normalize` implies `ProjectionEq`,
+types](./type_equality.html), `Normalize` implies `AliasEq`,
 but not vice versa. In general, proving `Normalize(<T as Trait>::Item -> U)`
 also requires proving `Implemented(T: Trait)`.
 
 [n]: ./type_equality.html#normalize
-[at]: ./type_equality.html
 
 #### FromEnv(TraitRef)
 e.g. `FromEnv(Self: Add<i32>)`

--- a/book/src/clauses/lowering_rules.md
+++ b/book/src/clauses/lowering_rules.md
@@ -44,7 +44,7 @@ the `Holds` variant of [domain goals][dg], as follows:
 - `'a: 'b` maps to `Outlives('a, 'b)`
 - `A0: Foo<A1..An, Item = T>` is a bit special and expands to two distinct
   goals, namely `Implemented(A0: Foo<A1..An>)` and
-  `ProjectionEq(<A0 as Foo<A1..An>>::Item = T)`
+  `AliasEq(<A0 as Foo<A1..An>>::Item = T)`
 
 In the rules below, we will use `WC` to indicate where clauses that
 appear in Rust syntax; we will then use the same `WC` to indicate
@@ -271,27 +271,27 @@ where WC
 ```
 
 We will produce a number of program clauses. The first two define
-the rules by which `ProjectionEq` can succeed; these two clauses are discussed
+the rules by which `AliasEq` for associated type projections can succeed; these two clauses are discussed
 in detail in the [section on associated types](./type_equality.html),
 but reproduced here for reference:
 
 ```text
-// Rule ProjectionEq-Normalize
+// Rule AliasEq-Normalize
 //
-// ProjectionEq can succeed by normalizing:
+// AliasEq can succeed by normalizing:
 forall<Self, P1..Pn, Pn+1..Pm, U> {
-  ProjectionEq(<Self as Trait<P1..Pn>>::AssocType<Pn+1..Pm> = U) :-
+  AliasEq(<Self as Trait<P1..Pn>>::AssocType<Pn+1..Pm> = U) :-
       Normalize(<Self as Trait<P1..Pn>>::AssocType<Pn+1..Pm> -> U)
 }
 ```
 
 ```text
-// Rule ProjectionEq-Placeholder
+// Rule AliasEq-Placeholder
 //
-// ProjectionEq can succeed through the placeholder associated type,
+// AliasEq can succeed through the placeholder associated type,
 // see "associated type" chapter for more:
 forall<Self, P1..Pn, Pn+1..Pm> {
-  ProjectionEq(
+  AliasEq(
     <Self as Trait<P1..Pn>>::AssocType<Pn+1..Pm> =
     (Trait::AssocType)<Self, P1..Pn, Pn+1..Pm>
   )

--- a/book/src/types/rust_types/alias.md
+++ b/book/src/types/rust_types/alias.md
@@ -20,12 +20,12 @@ equivalent type is not always known:
   where we *can't* normalize, because we don't know what `T` is. Even in that
   case, though, we still know that `T::Item: Sized`, because that bound is
   [declared in the `Iterator` trait][Iterator::Item] (by default, as it
-  happens).
+  happens). We describe how both cases are handled in more detail in the [section on associated types](../../clauses/type_equality.html).
 * In an opaque type like `type Foo = impl Iterator<Item = u32>`, the user might
   write `Foo` (which indirectly references the opaque type) but they never get
   to rely on the precise underlying type. However, when generating code, the
   *compiler* does need to be able to normalize `Foo` to the precise underlying
-  type, so normalization still does occur.
+  type, so normalization still does occur. We describe this in more detail in the [opaque types](../../clauses/opaque_types.html) section.
 
 [Iterator::Item]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#associatedtype.Item
 


### PR DESCRIPTION
`ProjectionEq` was remodelled to be only one variant of `AliasEq` some time ago. This change to the source code (mostly in chalk-solve and chalk-ir, chalk-parse still uses the old name) is now also reflected in the according sections of the Chalk book.
In addition, some new cross-references regarding aliases are added to allow for simpler navigation through these related sections.