### PR TITLE
Subst canonical environment clauses

### DIFF
--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -259,6 +259,7 @@ impl<I: Interner> Forest<I> {
 
                 match clauses {
                     Ok(clauses) => {
+                        let clauses = subst.apply(clauses, context.program().interner());
                         for clause in clauses {
                             info!("program clause = {:#?}", clause);
                             let mut infer = infer.clone();

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -385,7 +385,7 @@ where
                     // This variable was bound within the binders that
                     // we folded over, so just return a bound
                     // variable.
-                    TyKind::<I>::BoundVar(*bound_var).intern(folder.interner())
+                    self
                 }
             }
             TyKind::Dyn(clauses) => TyKind::Dyn(clauses.clone().fold_with(folder, outer_binder)?)
@@ -514,7 +514,7 @@ where
                     // This variable was bound within the binders that
                     // we folded over, so just return a bound
                     // variable.
-                    Ok(LifetimeData::<I>::BoundVar(*bound_var).intern(folder.interner()))
+                    Ok(self)
                 }
             }
             LifetimeData::InferenceVar(var) => folder.fold_inference_lifetime(*var, outer_binder),
@@ -567,7 +567,7 @@ where
                 if let Some(bound_var1) = bound_var.shifted_out_to(outer_binder) {
                     folder.fold_free_var_const(ty.clone(), bound_var1, outer_binder)
                 } else {
-                    Ok(bound_var.to_const(interner, fold_ty()?))
+                    Ok(self)
                 }
             }
             ConstValue::InferenceVar(var) => {

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -174,7 +174,8 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
         minimums: &mut Minimums,
     ) -> (Fallible<Solution<I>>, ClausePriority) {
         let (infer, subst, goal) = self.new_inference_table(canonical_goal);
-        match Fulfill::new_with_clause(self, infer, subst, goal, clause) {
+        let clause = subst.apply(clause.clone(), self.interner());
+        match Fulfill::new_with_clause(self, infer, subst, goal, &clause) {
             Ok(fulfill) => (fulfill.solve(minimums), clause.skip_binders().priority),
             Err(e) => (Err(e), ClausePriority::High),
         }

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -949,6 +949,7 @@ fn match_alias_ty<I: Interner>(
     }
 }
 
+#[instrument(level = "debug", skip(db))]
 pub fn program_clauses_for_env<'db, I: Interner>(
     db: &'db dyn RustIrDatabase<I>,
     environment: &Environment<I>,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -378,7 +378,7 @@ pub fn program_clauses_for_goal<'db, I: Interner>(
 /// more precise you can make it, the more efficient solving will
 /// be.
 #[instrument(level = "debug", skip(db))]
-fn program_clauses_that_could_match<I: Interner>(
+pub fn program_clauses_that_could_match<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
 ) -> Result<Vec<ProgramClause<I>>, Floundered> {
@@ -873,18 +873,41 @@ fn match_ty<I: Interner>(
             .db
             .fn_def_datum(*fn_def_id)
             .to_program_clauses(builder, environment),
+        TyKind::Str | TyKind::Never | TyKind::Scalar(_) | TyKind::Foreign(_) => {
+            // These have no substitutions, so they are trivially WF
+            builder.push_fact(WellFormed::Ty(ty.clone()));
+        }
+        TyKind::Raw(mutbl, _) => {
+            builder.push_bound_ty(|builder, ty| {
+                builder.push_fact(WellFormed::Ty(
+                    TyKind::Raw(*mutbl, ty).intern(builder.interner()),
+                ));
+            });
+        }
+        TyKind::Ref(mutbl, _, _) => {
+            builder.push_bound_ty(|builder, ty| {
+                builder.push_bound_lifetime(|builder, lifetime| {
+                    builder.push_fact(WellFormed::Ty(
+                        TyKind::Ref(*mutbl, lifetime, ty).intern(builder.interner()),
+                    ));
+                })
+            });
+        }
+        TyKind::Slice(_) => {
+            builder.push_bound_ty(|builder, ty| {
+                builder.push_fact(WellFormed::Ty(TyKind::Slice(ty).intern(builder.interner())));
+            });
+        }
         TyKind::Tuple(_, _)
-        | TyKind::Scalar(_)
-        | TyKind::Str
-        | TyKind::Slice(_)
-        | TyKind::Raw(_, _)
-        | TyKind::Ref(_, _, _)
         | TyKind::Array(_, _)
-        | TyKind::Never
         | TyKind::Closure(_, _)
-        | TyKind::Foreign(_)
         | TyKind::Generator(_, _)
-        | TyKind::GeneratorWitness(_, _) => builder.push_fact(WellFormed::Ty(ty.clone())),
+        | TyKind::GeneratorWitness(_, _) => {
+            let ty = generalize::Generalize::apply(builder.db.interner(), ty.clone());
+            builder.push_binders(ty, |builder, ty| {
+                builder.push_fact(WellFormed::Ty(ty.clone()));
+            });
+        }
         TyKind::Placeholder(_) => {
             builder.push_clause(WellFormed::Ty(ty.clone()), Some(FromEnv::Ty(ty.clone())));
         }
@@ -897,7 +920,10 @@ fn match_ty<I: Interner>(
             .opaque_ty_data(opaque_ty.opaque_ty_id)
             .to_program_clauses(builder, environment),
         TyKind::Function(_quantified_ty) => {
-            builder.push_fact(WellFormed::Ty(ty.clone()));
+            let ty = generalize::Generalize::apply(builder.db.interner(), ty.clone());
+            builder.push_binders(ty, |builder, ty| {
+                builder.push_fact(WellFormed::Ty(ty.clone()))
+            });
         }
         TyKind::BoundVar(_) => return Err(Floundered),
         TyKind::Dyn(dyn_ty) => {

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -16,7 +16,6 @@ pub struct ClauseBuilder<'me, I: Interner> {
     clauses: &'me mut Vec<ProgramClause<I>>,
     binders: Vec<VariableKind<I>>,
     parameters: Vec<GenericArg<I>>,
-    binder_depth: usize,
 }
 
 impl<'me, I: Interner> ClauseBuilder<'me, I> {
@@ -26,7 +25,6 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
             clauses,
             binders: vec![],
             parameters: vec![],
-            binder_depth: 0,
         }
     }
 
@@ -91,7 +89,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
             priority,
         };
 
-        let clause = if self.binder_depth == 0 {
+        let clause = if self.binders.is_empty() {
             // Compensate for the added empty binder
             clause.shifted_in(interner)
         } else {
@@ -150,14 +148,12 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
                 .zip(old_len..)
                 .map(|(pk, i)| (i, pk).to_generic_arg(interner)),
         );
-        self.binder_depth += 1;
         let value = binders.substitute(self.interner(), &self.parameters[old_len..]);
         debug!(?value);
         let res = op(self, value);
 
         self.binders.truncate(old_len);
         self.parameters.truncate(old_len);
-        self.binder_depth -= 1;
         res
     }
 

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -9,7 +9,7 @@ use crate::Ty;
 use crate::{debug_span, TyKind};
 use chalk_ir::interner::Interner;
 use chalk_ir::visit::{ControlFlow, Visit, Visitor};
-use chalk_ir::{DebruijnIndex, Environment};
+use chalk_ir::{Binders, DebruijnIndex, Environment};
 use rustc_hash::FxHashSet;
 use tracing::instrument;
 
@@ -26,34 +26,29 @@ pub(super) fn elaborate_env_clauses<I: Interner>(
     environment: &Environment<I>,
 ) {
     let mut this_round = vec![];
-    in_clauses.visit_with(
-        &mut EnvElaborator::new(db, &mut this_round, environment),
-        DebruijnIndex::INNERMOST,
+    let mut builder = ClauseBuilder::new(db, &mut this_round);
+    // There's an implicit binders around the environment (from Canonical)
+    builder.push_binders(
+        Binders::empty(db.interner(), chalk_ir::Substitution::empty(db.interner())),
+        |builder, _| {
+            let mut elaborater = EnvElaborator {
+                db,
+                builder,
+                environment,
+            };
+            in_clauses.visit_with(&mut elaborater, DebruijnIndex::INNERMOST);
+        },
     );
     out.extend(this_round);
 }
 
-struct EnvElaborator<'me, I: Interner> {
+struct EnvElaborator<'me, 'builder, I: Interner> {
     db: &'me dyn RustIrDatabase<I>,
-    builder: ClauseBuilder<'me, I>,
+    builder: &'builder mut ClauseBuilder<'me, I>,
     environment: &'me Environment<I>,
 }
 
-impl<'me, I: Interner> EnvElaborator<'me, I> {
-    fn new(
-        db: &'me dyn RustIrDatabase<I>,
-        out: &'me mut Vec<ProgramClause<I>>,
-        environment: &'me Environment<I>,
-    ) -> Self {
-        EnvElaborator {
-            db,
-            builder: ClauseBuilder::new(db, out),
-            environment,
-        }
-    }
-}
-
-impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
+impl<'me, 'builder, I: Interner> Visitor<'me, I> for EnvElaborator<'me, 'builder, I> {
     type BreakTy = ();
 
     fn as_dyn(&mut self) -> &mut dyn Visitor<'me, I, BreakTy = Self::BreakTy> {
@@ -66,9 +61,7 @@ impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
     #[instrument(level = "debug", skip(self, _outer_binder))]
     fn visit_ty(&mut self, ty: &Ty<I>, _outer_binder: DebruijnIndex) -> ControlFlow<()> {
         match ty.kind(self.interner()) {
-            TyKind::Alias(alias_ty) => {
-                match_alias_ty(&mut self.builder, self.environment, alias_ty)
-            }
+            TyKind::Alias(alias_ty) => match_alias_ty(self.builder, self.environment, alias_ty),
             TyKind::Placeholder(_) => {}
 
             // FIXME(#203) -- We haven't fully figured out the implied
@@ -79,7 +72,7 @@ impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
 
             _ => {
                 // This shouldn't fail because of the above clauses
-                match_ty(&mut self.builder, self.environment, &ty)
+                match_ty(self.builder, self.environment, &ty)
                     .map_err(|_| ())
                     .unwrap()
             }
@@ -98,7 +91,7 @@ impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
                 FromEnv::Trait(trait_ref) => {
                     let trait_datum = self.db.trait_datum(trait_ref.trait_id);
 
-                    trait_datum.to_program_clauses(&mut self.builder, self.environment);
+                    trait_datum.to_program_clauses(self.builder, self.environment);
 
                     // If we know that `T: Iterator`, then we also know
                     // things about `<T as Iterator>::Item`, so push those
@@ -106,7 +99,7 @@ impl<'me, I: Interner> Visitor<'me, I> for EnvElaborator<'me, I> {
                     for &associated_ty_id in &trait_datum.associated_ty_ids {
                         self.db
                             .associated_ty_data(associated_ty_id)
-                            .to_program_clauses(&mut self.builder, self.environment);
+                            .to_program_clauses(self.builder, self.environment);
                     }
                     ControlFlow::CONTINUE
                 }

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -817,5 +817,14 @@ fn env_bound_vars() {
         } yields {
             "Unique"
         }
+        goal {
+            exists<'a> {
+                if (FromEnv(&'a ())) {
+                    WellFormed(&'a ())
+                }
+            }
+        } yields {
+            "Unique"
+        }
     }
 }

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -803,3 +803,19 @@ fn endless_loop() {
         }
     }
 }
+
+#[test]
+fn env_bound_vars() {
+    test! {
+        program {}
+        goal {
+            exists<'a> {
+                if (WellFormed(&'a ())) {
+                    WellFormed(&'a ())
+                }
+            }
+        } yields {
+            "Unique"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #670 

I'm not sure if this is the right approach. Recursive solver gets substed later because clauses get instantiated later. There's also a `clone` there which would be nice to get rid of.