### PR TITLE
Update mdbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,12 @@ jobs:
       - name: Install mdbook
         run: |
           cd book
-          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.3.7/mdbook-v0.3.7-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.5/mdbook-v0.4.5-x86_64-unknown-linux-gnu.tar.gz | tar xz
           # Add the book directory to the $PATH
           echo "$GITHUB_WORKSPACE/book" >> $GITHUB_PATH
 
-      - name: Install mdbook-toc
-        run: cd book && curl -L https://github.com/badboy/mdbook-toc/releases/download/0.2.4/mdbook-toc-0.2.4-x86_64-unknown-linux-gnu.tar.gz | tar xz
-
       - name: Install mdbook-mermaid
-        run: cd book && curl -L https://github.com/badboy/mdbook-mermaid/releases/download/0.2.2/mdbook-mermaid-0.2.2-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        run: cargo install mdbook-mermaid --locked --version 0.6.1
 
       - name: Execute tests for Chalk book
         run: cd book && ./mdbook test
@@ -104,12 +101,12 @@ jobs:
       - name: Install mdbook
         run: |
           cd book
-          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.3.7/mdbook-v0.3.7-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.5/mdbook-v0.4.5-x86_64-unknown-linux-gnu.tar.gz | tar xz
           # Add the book directory to the $PATH
           echo "$GITHUB_WORKSPACE/book" >> $GITHUB_PATH
 
       - name: Install mdbook-linkcheck
-        run: cd book && curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.5.0/mdbook-linkcheck-v0.5.0-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        run: cd book && curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.0/mdbook-linkcheck-v0.7.0-x86_64-unknown-linux-gnu.tar.gz | tar xz
 
       - name: Build Chalk book
         run: cd book && ./mdbook build

--- a/book/book.toml
+++ b/book/book.toml
@@ -15,6 +15,4 @@ additional-js = ["mermaid.min.js", "mermaid-init.js"]
 [output.linkcheck]
 follow-web-links = true
 warning-policy = "error"
-
-[preprocessor.toc]
-command = "mdbook-toc"
+optional = true


### PR DESCRIPTION
Changelog to 0.4.5: https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-045

I removed mdbook-toc instead of updating it, because it does not appear to be used anywhere.

mdbook-mermaid is no longer publishing pre-compiled binaries, so it needs to be built locally.

Newer versions of mdbook require the `optional` flag for missing backends, so I added it for mdbook-linkcheck.  This means that if mdbook-linkcheck is not installed, it will just display a warning instead of failing.

I could add some caching for mdbook-mermaid if you want.  Caching can be fussy, so I'm not sure if you actually want it, but I think it would look something like this (untested):

```yml
      - uses: actions/cache@v2
        with:
          path: |
            ~/.cargo/registry
            ~/.cargo/bin/mdbook-mermaid
            ~/.cargo/.crates.toml
            ~/.cargo/.crates2.json
          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.github/workflows/*.yml') }}
          restore-keys: ${{ runner.os }}-cargo-
```