### PR TITLE
Update WellFormed-AssocTy rule in book

### DIFF
--- a/book/src/clauses/lowering_rules.md
+++ b/book/src/clauses/lowering_rules.md
@@ -320,7 +320,7 @@ type to be well-formed...
 // Rule WellFormed-AssocTy
 forall<Self, P1..Pn, Pn+1..Pm> {
     WellFormed((Trait::AssocType)<Self, P1..Pn, Pn+1..Pm>) :-
-      Implemented(Self: Trait<P1..Pn>) && WC1
+      WellFormed(Self: Trait<P1..Pn>) && WellFormed(WC1)
 }
 ```
 


### PR DESCRIPTION
Update the description of the WellFormed-AssocTy rule in the Chalk book to match the corresponding implementation [here](https://github.com/rust-lang/chalk/blob/23887fda56ff2f471d521bdef666aac8475781eb/chalk-solve/src/clauses/program_clauses.rs#L826) (it also defined with the same name [here](https://github.com/rust-lang/chalk/blob/23887fda56ff2f471d521bdef666aac8475781eb/chalk-solve/src/clauses/program_clauses.rs#L764)).