### PR TITLE
Coinduction handler for the recursive solver

### DIFF
--- a/book/src/recursive/coinduction.md
+++ b/book/src/recursive/coinduction.md
@@ -7,7 +7,7 @@ It follows the description in [this GitHub comment](https://github.com/rust-lang
 The general idea for the handling of coinductive cycles in the recursive solver is to start by assuming the goal is provable and then try to find evidence that it is not.
 This search for a disproof is done by the standard recursive solving process described in the sub-chapters before.
 
-Albeit this approach would allow for the handling of mixed inductive/co-inductive cycles, these are actually handled as errors to prevent propagation of the assumed provability outside of the coinductive cycle.
+Its is important to note that mixed inductive/co-inductive cycles are treated as errors to prevent propagation of the assumptions outside of the coinductive cycle.
 This propagation of the assumed solution might also happen in pure coinductive cycles and can potentially lead to false positives.
 
 ## Prevention of False Positives
@@ -56,12 +56,12 @@ Results for other goals are labeled premature if at least one subgoal has a prem
 Finished goals that have a premature result are then stored in the temporary cache.
 For the caches the following invariant holds: results stored in the temporary cache are by definition premature whereas all results in the standard cache are mature.
 
-For each premature result, all coinductive assumptions that result depends upon are collected and stored alongside the result in the temporary cache.
-With this information, it is possible to track the concrete dependencies of each result even if nested coinductive cycles occur.
+For each premature result, lower and upper bounds (i.e. the outermost and innermost dependencies) are collected and stored alongside the result in the temporary cache.
+With this information, it is possible to over-approximate the precise dependencies for each result even if nested coinductive cycles occur.
 If such a nested cycle is finished, all results that depend on it can either be dropped if the assumption for this cycle was disproved or they become mature and can be moved to the standard cache.
 
 A special case occurs if a cycle start depends on the coinductive assumption of an enclosing active cycle.
-In this case, the result for the cycle start is still premature after finishing the cycle and needs to be kept in the temporary cache.
+In this case, the result for the cycle start is still premature after finishing the cycle and must be dropped alongside all results that depend on it.
 The following is an example where this happens. `C5` depends indirectly on the cycle start `C1` but is itself also a cycle start. 
 Thus, these two cycles are nested and interconnected, as the cycle starting with `C1` can't be finished without the cycle starting with `C5` be finished first, which in turn depends on the first one again.
 

--- a/book/src/recursive/coinduction.md
+++ b/book/src/recursive/coinduction.md
@@ -1,3 +1,92 @@
 # Coinduction
 
-TBD
+This sub-chapter is meant to describe the current handling of coinductive goals in the recursive solver rather than providing an extensive overview over the theoretical backgrounds and ideas.
+It follows the description in [this GitHub comment](https://github.com/rust-lang/chalk/issues/399#issuecomment-643420016) and the Zulip topic linked there.
+
+## General Idea
+The general idea for the handling of coinductive cycles in the recursive solver is to start by assuming the goal is provable and then try to find evidence that it is not.
+This search for a disproof is done by the standard recursive solving process described in the sub-chapters before.
+
+Albeit this approach would allow for the handling of mixed inductive/co-inductive cycles, these are actually handled as errors to prevent propagation of the assumed provability outside of the coinductive cycle.
+This propagation of the assumed solution might also happen in pure coinductive cycles and can potentially lead to false positives.
+
+## Prevention of False Positives
+The problem of false positives propagated outside of the coinductive cycle is also described in the [Coinduction chapter](../engine/logic/coinduction.md) for the SLG solver alongside the rather complex handling used with it.
+
+### The Problem
+The problem arises if a solution that is purely based on the positive starting value for the coinductive cycle is cached and as such propagated to other goals that are possibly reliant on this. An example may look like this (cf. the test case `coinduction::coinductive_unsound1`):
+
+```notrust
+C :- C1.
+C :- C2.
+C1 :- C2, C3.
+C2 :- C1.
+```
+
+Here `C` may be proved by either showing `C1` or `C2`.
+Assuming the solver starts evaluating the branch with `C1` first, it then recursively tries to prove `C2` and `C3`.
+For proving `C2` it needs to show `C1` again, the coinductive cycle becomes evident.
+Therefore, `C1` is assumed to be provable and the solver proves `C2` with this information.
+Assuming, the solve does not handle this case specifically, the solution for `C2` is cached. 
+Now it tries solving `C3` but fails due to the lack of information about it.
+As such, `C1` can also not be proven for this program.
+The recursive solver will now attempt to prove the initial goal `C` by solving `C2`.
+Unfortunately, it finds the invalidly cached solution and returns it as proof for `C`.
+
+By visualizing this path of computation, the problem becomes evident:
+* Start proving `C` with `C1`:
+    * For `C1` prove `C2` and `C3`:
+        * For `C2` prove `C1`:
+            * This is a coinductive cycle. Assume that `C1` holds.
+        * Thus `C2` also holds. Store this result about `C2` in the cache.
+        * There is no way to prove `C3`. Lift this failure up.
+    * Due to the failure of `C3` there is also no solution for `C1`.
+* Try proving `C` with `C2`:
+    * Find the cached result that `C2` has a solution and return it as the solution for `C`.
+* Stop with the invalid result for `C`.
+
+### The Solution
+The above example should make it evident that the caching of found solutions in coinductive cycles can lead to false positives and should therefore be prevented.
+One approach to achieve this is to use a second dedicated cache for results that depend on the initial assumption of a coinductive cycle.
+This cache can then either be deleted if the assumption did not hold or moved to the standard cache if it did hold.
+
+The tricky part about this two-leveled cache is tracking which results are generally valid and can thus be cached (these is called "mature" results in the following) and which results depend on an assumption ("premature" results).
+For each coinductive cycle, the first result that is determined to be premature is the assumption itself, i.e. the result for the cycle start (`C1` in the above example).
+Results for other goals are labeled premature if at least one subgoal has a premature result (e.g. `C2` depends on `C1`, thus `C2` is also premature).
+Finished goals that have a premature result are then stored in the temporary cache.
+For the caches the following invariant holds: results stored in the temporary cache are by definition premature whereas all results in the standard cache are mature.
+
+For each premature result, all coinductive assumptions that result depends upon are collected and stored alongside the result in the temporary cache.
+With this information, it is possible to track the concrete dependencies of each result even if nested coinductive cycles occur.
+If such a nested cycle is finished, all results that depend on it can either be dropped if the assumption for this cycle was disproved or they become mature and can be moved to the standard cache.
+
+A special case occurs if a cycle start depends on the coinductive assumption of an enclosing active cycle.
+In this case, the result for the cycle start is still premature after finishing the cycle and needs to be kept in the temporary cache.
+The following is an example where this happens. `C5` depends indirectly on the cycle start `C1` but is itself also a cycle start. 
+Thus, these two cycles are nested and interconnected, as the cycle starting with `C1` can't be finished without the cycle starting with `C5` be finished first, which in turn depends on the first one again.
+
+```notrust
+C :- C1, C2.
+C1 :- C3. 
+C3 :- C4.
+C3 :- C5.
+C4 :- C1. // First cycle
+C5 :- C6.
+C6 :- C2, C7.
+C2 :- C5, C1. // Second cycle and dependency to first cycle
+```
+
+```mermaid
+graph TD
+  C-->C1;
+  C1-->C3;
+  C3-.->C5;
+  C3-.->C4;
+  C4-->C1;
+  C5-->C6;
+  C-->C2;
+  C2-->C5;
+  C2-->C1;
+  C6-->C7;
+  C6-->C2;
+```

--- a/chalk-recursive/src/coinduction.rs
+++ b/chalk-recursive/src/coinduction.rs
@@ -1,0 +1,161 @@
+use chalk_ir::{interner::Interner, Canonical, ConstrainedSubst, Constraints, Fallible};
+use chalk_solve::Solution;
+use rustc_hash::{FxHashMap, FxHashSet};
+use tracing::debug;
+
+use crate::{
+    search_graph::{DepthFirstNumber, SearchGraph},
+    Minimums, UCanonicalGoal,
+};
+
+#[derive(Debug)]
+pub(crate) struct PrematureResult<I: Interner> {
+    result: Fallible<Solution<I>>,
+
+    /// All coinductive cycle assumptions this result depends on.
+    /// Must not be empty.
+    dependencies: FxHashSet<DepthFirstNumber>,
+}
+
+pub(crate) struct CoinductionHandler<I: Interner> {
+    /// Stack of cycle start DFNs for nested cycles.
+    cycle_start_dfns: Vec<DepthFirstNumber>,
+
+    /// Temporary cache for premature results with
+    /// corresponding cycle start DFNs.
+    temp_cache: FxHashMap<UCanonicalGoal<I>, PrematureResult<I>>,
+}
+
+impl<I: Interner> CoinductionHandler<I> {
+    pub fn start_cycle(&mut self, start_dfn: DepthFirstNumber) {
+        self.cycle_start_dfns.push(start_dfn);
+    }
+
+    pub fn in_coinductive_cycle(&self) -> bool {
+        !self.cycle_start_dfns.is_empty()
+    }
+
+    pub fn get_current_cycle_start(&self) -> Option<DepthFirstNumber> {
+        self.cycle_start_dfns.last().copied()
+    }
+
+    /// Get a cached result from the temporary cache
+    /// or an assumption if the requested goal corresponds
+    /// to the start of a coinductive cycle.
+    pub fn get_assumption_or_cached(
+        &mut self,
+        goal: &UCanonicalGoal<I>,
+        dfn: Option<DepthFirstNumber>,
+        minimums: &mut Minimums,
+        interner: &I,
+    ) -> Option<Fallible<Solution<I>>> {
+        if dfn.is_some() && self.cycle_start_dfns.contains(&dfn.unwrap()) {
+            minimums.add_cycle_start(dfn.unwrap());
+            Some(Ok(Self::generate_assumption(goal, interner)))
+        } else {
+            self.temp_cache.get(goal).map(
+                |PrematureResult {
+                     result,
+                     dependencies,
+                 }| {
+                    minimums.add_cycle_starts(dependencies);
+                    result.clone()
+                },
+            )
+        }
+    }
+
+    pub fn handle_coinductive_result(
+        &mut self,
+        dfn: DepthFirstNumber,
+        cache: &mut FxHashMap<UCanonicalGoal<I>, Fallible<Solution<I>>>,
+        search_graph: &mut SearchGraph<I>,
+        minimums: &mut Minimums,
+    ) {
+        if minimums.is_mature() {
+            // If the result is mature, it can be directly cached in the standard cache.
+            search_graph.move_to_cache(dfn, cache, move |result| result);
+        } else if let Some(start_dfn) = self.get_current_cycle_start() {
+            if dfn == start_dfn {
+                // If the handled result belongs to the current innermost cycle
+                // this cycle can be finished.
+                minimums.coinductive_cycle_starts.remove(&dfn);
+                self.finish_cycle(cache, search_graph, minimums);
+            } else {
+                search_graph.move_to_cache(dfn, &mut self.temp_cache, move |result| {
+                    PrematureResult {
+                        result,
+                        dependencies: minimums.coinductive_cycle_starts.clone(),
+                    }
+                });
+            }
+        }
+    }
+
+    fn finish_cycle(
+        &mut self,
+        cache: &mut FxHashMap<UCanonicalGoal<I>, Fallible<Solution<I>>>,
+        search_graph: &mut SearchGraph<I>,
+        minimums: &Minimums,
+    ) {
+        if let Some(start_dfn) = self.cycle_start_dfns.pop() {
+            if search_graph[start_dfn].solution.is_ok() {
+                for (
+                    goal,
+                    PrematureResult {
+                        result,
+                        dependencies,
+                    },
+                ) in self.temp_cache.iter_mut()
+                {
+                    dependencies.remove(&start_dfn);
+                    if dependencies.is_empty() {
+                        // The result has no pending dependencies anymore and can be moved to the standard cache.
+                        cache.insert(goal.clone(), result.clone());
+                    }
+                }
+            }
+            if minimums.is_mature() {
+                search_graph.move_to_cache(start_dfn, cache, |result| result);
+            } else {
+                search_graph.move_to_cache(start_dfn, &mut self.temp_cache, move |result| {
+                    PrematureResult {
+                        result,
+                        dependencies: minimums.coinductive_cycle_starts.clone(),
+                    }
+                });
+            }
+
+            self.temp_cache.retain(
+                |_k,
+                 PrematureResult {
+                     result: _,
+                     dependencies,
+                 }| !(dependencies.is_empty() || dependencies.contains(&start_dfn)), // Remove all moved or invalidated results.
+            );
+        }
+        debug!(
+            "Coinductive cycle finished. Caches: {:?} {:?}",
+            cache, self.temp_cache
+        );
+    }
+
+    fn generate_assumption(goal: &UCanonicalGoal<I>, interner: &I) -> Solution<I> {
+        Solution::Unique(Canonical {
+            value: ConstrainedSubst {
+                subst: goal.trivial_substitution(interner),
+                constraints: Constraints::empty(interner),
+            },
+            binders: goal.canonical.binders.clone(),
+        })
+    }
+}
+
+impl<I: Interner> Default for CoinductionHandler<I> {
+    fn default() -> Self {
+        CoinductionHandler {
+            cycle_start_dfns: Vec::new(),
+            temp_cache: FxHashMap::default(),
+        }
+    }
+}

--- a/chalk-recursive/src/lib.rs
+++ b/chalk-recursive/src/lib.rs
@@ -3,6 +3,7 @@ use chalk_ir::{Goal, InEnvironment, UCanonical};
 
 pub type UCanonicalGoal<I> = UCanonical<InEnvironment<Goal<I>>>;
 
+mod coinduction;
 mod combine;
 mod fulfill;
 mod recursive;
@@ -11,22 +12,38 @@ pub mod solve;
 mod stack;
 
 pub use recursive::RecursiveSolver;
+use rustc_hash::FxHashSet;
 
 /// The `minimums` struct is used while solving to track whether we encountered
 /// any cycles in the process.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Minimums {
     pub(crate) positive: DepthFirstNumber,
+    pub(crate) coinductive_cycle_starts: FxHashSet<DepthFirstNumber>,
 }
 
 impl Minimums {
     pub fn new() -> Self {
         Minimums {
             positive: DepthFirstNumber::MAX,
+            coinductive_cycle_starts: FxHashSet::default(),
         }
     }
 
-    pub fn update_from(&mut self, minimums: Minimums) {
+    pub fn update_from(&mut self, minimums: &Minimums) {
         self.positive = ::std::cmp::min(self.positive, minimums.positive);
+        self.add_cycle_starts(&minimums.coinductive_cycle_starts);
+    }
+
+    pub fn add_cycle_start(&mut self, start: DepthFirstNumber) {
+        self.coinductive_cycle_starts.insert(start);
+    }
+
+    pub fn add_cycle_starts(&mut self, starts: &FxHashSet<DepthFirstNumber>) {
+        self.coinductive_cycle_starts.extend(starts.iter());
+    }
+
+    pub fn is_mature(&self) -> bool {
+        self.coinductive_cycle_starts.is_empty()
     }
 }

--- a/chalk-recursive/src/lib.rs
+++ b/chalk-recursive/src/lib.rs
@@ -3,7 +3,7 @@ use chalk_ir::{Goal, InEnvironment, UCanonical};
 
 pub type UCanonicalGoal<I> = UCanonical<InEnvironment<Goal<I>>>;
 
-mod coinduction;
+mod coinduction_handler;
 mod combine;
 mod fulfill;
 mod recursive;

--- a/chalk-recursive/src/search_graph.rs
+++ b/chalk-recursive/src/search_graph.rs
@@ -7,7 +7,7 @@ use super::stack::StackDepth;
 use crate::{Minimums, UCanonicalGoal};
 use chalk_ir::{interner::Interner, ClausePriority, Fallible, NoSolution};
 use chalk_solve::Solution;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use tracing::{debug, instrument};
 
 /// The "search graph" stores in-progress goals that are still
@@ -72,7 +72,7 @@ impl<I: Interner> SearchGraph<I> {
             stack_depth: Some(stack_depth),
             links: Minimums {
                 positive: dfn,
-                coinductive_cycle_starts: FxHashSet::default(),
+                coinductive_cycle_boundaries: None,
             },
         };
         self.nodes.push(node);

--- a/tests/test/coinduction.rs
+++ b/tests/test/coinduction.rs
@@ -213,15 +213,8 @@ fn coinductive_unsound1() {
 
         goal {
             forall<X> { X: C1orC2 }
-        } yields[SolverChoice::slg(3, None)] {
+        } yields {
             "No possible solution"
-        }
-
-        goal {
-            forall<X> { X: C1orC2 }
-        } yields[SolverChoice::recursive_default()] {
-            // FIXME(chalk#399) recursive solver doesn't handle coinduction correctly
-            "Unique; substitution [], lifetime constraints []"
         }
     }
 }
@@ -262,6 +255,172 @@ fn coinductive_unsound2() {
 
         goal {
             forall<X> { X: C1orC2 }
+        } yields {
+            "No possible solution"
+        }
+    }
+}
+
+/// Same as the two before but needs to show T: C2 in both
+// branches of T: C1 :- T: C2, T: C3.
+#[test]
+fn coinductive_unsound3() {
+    test! {
+        program {
+            trait C1orC2 { }
+
+            #[coinductive]
+            trait C1 { }
+
+            #[coinductive]
+            trait C2 { }
+
+            #[coinductive]
+            trait C3 { }
+
+            #[coinductive]
+            trait C4 { }
+
+            forall<T> {
+                T: C3 if T: C2, T: C4
+            }
+
+            forall<T> {
+                T: C1 if T: C2, T: C3
+            }
+
+            forall<T> {
+                T: C2 if T: C1
+            }
+
+            forall<T> {
+                T: C1orC2 if T: C1
+            }
+
+            forall<T> {
+                T: C1orC2 if T: C2
+            }
+        }
+
+        goal {
+            forall<X> { X: C1orC2 }
+        } yields {
+            "No possible solution"
+        }
+    }
+}
+
+/// Tests whether a nested coinductive cycle
+/// that is also unsound is handled correctly.
+#[test]
+fn coinductive_unsound_nested() {
+    test! {
+        program {
+            trait C1orC2 { }
+
+            #[coinductive]
+            trait C1 { }
+
+            #[coinductive]
+            trait C2 { }
+
+            #[coinductive]
+            trait C3 { }
+
+            #[coinductive]
+            trait C4 { }
+
+            forall<T> {
+                T: C4 if T:C2, T: C3
+            }
+
+            forall<T> {
+                T: C1 if T: C2, T: C3
+            }
+
+            forall<T> {
+                T: C2 if T: C1, T: C4
+            }
+
+            forall<T> {
+                T: C1orC2 if T: C1
+            }
+
+            forall<T> {
+                T: C1orC2 if T: C2
+            }
+        }
+
+        goal {
+            forall<X> { X: C1orC2 }
+        } yields {
+            "No possible solution"
+        }
+    }
+}
+
+#[test]
+fn coinductive_unsound_nested2() {
+    test! {
+        program {
+            trait C1andC7 { }
+
+            #[coinductive]
+            trait C1 { }
+
+            #[coinductive]
+            trait C2 { }
+
+            #[coinductive]
+            trait C3 { }
+
+            #[coinductive]
+            trait C4 { }
+
+            #[coinductive]
+            trait C5 { }
+
+            #[coinductive]
+            trait C6 { }
+
+            #[coinductive]
+            trait C7 { }
+
+            forall<T> {
+                T: C7 if T: C3
+            }
+
+            forall<T> {
+                T: C4 if T: C7, T: C5
+            }
+
+            forall<T> {
+                T: C3 if T:C4
+            }
+
+            forall<T> {
+                T: C6 if T: C1
+            }
+
+            forall<T> {
+                T: C2 if T: C6
+            }
+
+            forall<T> {
+                T: C2 if T: C3
+            }
+
+            forall<T> {
+                T: C1 if T: C2
+            }
+
+            forall<T> {
+                T: C1andC7 if T: C1, T: C7
+            }
+        }
+
+        goal {
+            forall<X> { X: C1andC7 }
         } yields {
             "No possible solution"
         }
@@ -450,14 +609,8 @@ fn coinductive_multicycle4() {
 
         goal {
             forall<X> { X: Any }
-        } yields_all[SolverChoice::slg(3, None)] {
-        }
-
-        goal {
-            forall<X> { X: Any }
-        } yields[SolverChoice::recursive_default()] {
-            // FIXME(chalk#399) recursive solver doesn't handle coinduction correctly
-            "Unique; substitution [], lifetime constraints []"
+        } yields {
+            "No possible solution"
         }
     }
 }

--- a/tests/test/coinduction.rs
+++ b/tests/test/coinduction.rs
@@ -359,11 +359,14 @@ fn coinductive_unsound_nested() {
     }
 }
 
+/// Test with two nested coinductive cycles where the inner fails
+/// whereas the outer holds. No false positives should be kept from
+/// the inner cycle.
 #[test]
 fn coinductive_unsound_nested2() {
     test! {
         program {
-            trait C1andC7 { }
+            trait C1andC2 { }
 
             #[coinductive]
             trait C1 { }
@@ -387,40 +390,110 @@ fn coinductive_unsound_nested2() {
             trait C7 { }
 
             forall<T> {
-                T: C7 if T: C3
+                T: C2 if T: C5
             }
 
             forall<T> {
-                T: C4 if T: C7, T: C5
+                T: C6 if T: C2, T: C7
             }
 
             forall<T> {
-                T: C3 if T:C4
+                T: C5 if T:C6
             }
 
             forall<T> {
-                T: C6 if T: C1
+                T: C4 if T: C1
             }
 
             forall<T> {
-                T: C2 if T: C6
+                T: C3 if T: C5
             }
 
             forall<T> {
-                T: C2 if T: C3
+                T: C3 if T: C4
             }
 
             forall<T> {
-                T: C1 if T: C2
+                T: C1 if T: C3
             }
 
             forall<T> {
-                T: C1andC7 if T: C1, T: C7
+                T: C1andC2 if T: C1, T: C2
             }
         }
 
         goal {
-            forall<X> { X: C1andC7 }
+            forall<X> { X: C1andC2 }
+        } yields {
+            "No possible solution"
+        }
+    }
+}
+
+/// Another test with two nested coinductive cycles.
+/// Here the inner cycle is also dependent on the outer one.
+#[test]
+fn coinductive_unsound_inter_cycle_dependency() {
+    test! {
+        program {
+            trait C1andC2 { }
+
+            #[coinductive]
+            trait C1 { }
+
+            #[coinductive]
+            trait C2 { }
+
+            #[coinductive]
+            trait C3 { }
+
+            #[coinductive]
+            trait C4 { }
+
+            #[coinductive]
+            trait C5 { }
+
+            #[coinductive]
+            trait C6 { }
+
+            #[coinductive]
+            trait C7 { }
+
+            forall<T> {
+                T: C2 if T: C5, T: C1
+            }
+
+            forall<T> {
+                T: C6 if T: C2, T: C7
+            }
+
+            forall<T> {
+                T: C5 if T:C6
+            }
+
+            forall<T> {
+                T: C4 if T: C1
+            }
+
+            forall<T> {
+                T: C3 if T: C5
+            }
+
+            forall<T> {
+                T: C3 if T: C4
+            }
+
+            forall<T> {
+                T: C1 if T: C3
+            }
+
+            forall<T> {
+                T: C1andC2 if T: C1, T: C2
+            }
+        }
+
+        goal {
+            forall<X> { X: C1andC2 }
         } yields {
             "No possible solution"
         }


### PR DESCRIPTION
This PR is meant to address the issue of false positives in coinductive cycles as described in #399 . It also fixes the two coinduction tests related to that issue (i.e. `coinductive_unsound1` and `coinductive_multicycle4`). As such it is an improved version of #683 .

The PR adds a dedicated handler mechanisms for delaying insertion of results into the cache if they occur inside a coinductive cycle. This is done by tracking dependencies of result to coinductive assumptions (via the `Minimums`) and storing those "premature" results in a temporary cache. The exact mechanism is also described in the corresponding book chapter. In general, it follows the idea from #399 to start with a positive result instead of the negative one but delays its effects on other goals until it is know whether this assumption was correct.