### PR TITLE
fix(chalk-recursive): allow chalk-solve's default-features to be disabled

### DIFF
--- a/chalk-recursive/Cargo.toml
+++ b/chalk-recursive/Cargo.toml
@@ -15,7 +15,7 @@ tracing = "0.1"
 
 chalk-derive = { version = "0.66.0-dev.0", path = "../chalk-derive" }
 chalk-ir = { version = "0.66.0-dev.0", path = "../chalk-ir" }
-chalk-solve = { version = "0.66.0-dev.0", path = "../chalk-solve" }
+chalk-solve = { version = "0.66.0-dev.0", path = "../chalk-solve", default-features = false }
 
 [dev-dependencies]
 chalk-integration = { path = "../chalk-integration" }
@@ -23,4 +23,4 @@ chalk-integration = { path = "../chalk-integration" }
 [features]
 default = ["tracing-full"]
 
-tracing-full = ["chalk-solve/tracing-subscriber", "chalk-solve/tracing-tree"]
+tracing-full = ["chalk-solve/tracing-full"]


### PR DESCRIPTION
Without this change, one of the issues mentioned in #686 continue to persist after #687 because `chalk-solve`'s features were enabled unconditionally when depending on `chalk-recursive`.

Now `chalk-solve`'s `tracing-full` feature is enabled when `chalk-recursive`'s `tracing-full` feature is enabled (which it continues to be by default; it may be worth considering disabling these by default in the future, as #686 suggested, to minimize this sort of issue).