### PR TITLE
Introduce `Folder::Error`

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -295,11 +295,11 @@ fn derive_fold(mut s: synstructure::Structure) -> TokenStream {
         quote! {
             type Result = #result;
 
-            fn fold_with<'i>(
+            fn fold_with<'i, E>(
                 self,
-                folder: &mut dyn ::chalk_ir::fold::Folder < 'i, #interner >,
+                folder: &mut dyn ::chalk_ir::fold::Folder < 'i, #interner, Error = E >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
-            ) -> ::chalk_ir::Fallible<Self::Result>
+            ) -> ::std::result::Result<Self::Result, E>
             where
                 #interner: 'i,
             {

--- a/chalk-engine/src/normalize_deep.rs
+++ b/chalk-engine/src/normalize_deep.rs
@@ -39,7 +39,9 @@ impl<'i, I: Interner> Folder<'i, I> for DeepNormalizer<'_, 'i, I>
 where
     I: 'i,
 {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use chalk_derive::HasInterner;
 use chalk_ir::fold::{Fold, Folder};
 use chalk_ir::interner::Interner;
-use chalk_ir::{Canonical, DebruijnIndex, Fallible, UniverseMap};
+use chalk_ir::{Canonical, DebruijnIndex, UniverseMap};
 
 #[derive(Clone, Debug, HasInterner)]
 pub(crate) struct Strand<I: Interner> {
@@ -37,11 +37,11 @@ pub(crate) struct SelectedSubgoal {
 
 impl<I: Interner> Fold<I> for Strand<I> {
     type Result = Strand<I>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -7,11 +7,11 @@ use crate::*;
 
 impl<I: Interner> Fold<I> for FnPointer<I> {
     type Result = FnPointer<I>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -39,11 +39,11 @@ where
     I: Interner,
 {
     type Result = Binders<T::Result>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -66,11 +66,11 @@ where
     <T as Fold<I>>::Result: HasInterner<Interner = I>,
 {
     type Result = Canonical<T::Result>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -10,11 +10,11 @@ use std::marker::PhantomData;
 
 impl<T: Fold<I>, I: Interner> Fold<I> for Vec<T> {
     type Result = Vec<T::Result>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -24,11 +24,11 @@ impl<T: Fold<I>, I: Interner> Fold<I> for Vec<T> {
 
 impl<T: Fold<I>, I: Interner> Fold<I> for Box<T> {
     type Result = Box<T::Result>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -40,7 +40,7 @@ macro_rules! tuple_fold {
     ($($n:ident),*) => {
         impl<$($n: Fold<I>,)* I: Interner> Fold<I> for ($($n,)*) {
             type Result = ($($n::Result,)*);
-            fn fold_with<'i>(self, folder: &mut dyn Folder<'i, I>, outer_binder: DebruijnIndex) -> Fallible<Self::Result>
+            fn fold_with<'i, Error>(self, folder: &mut dyn Folder<'i, I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self::Result, Error>
             where
                 I: 'i,
             {
@@ -59,11 +59,11 @@ tuple_fold!(A, B, C, D, E);
 
 impl<T: Fold<I>, I: Interner> Fold<I> for Option<T> {
     type Result = Option<T::Result>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -76,11 +76,11 @@ impl<T: Fold<I>, I: Interner> Fold<I> for Option<T> {
 
 impl<I: Interner> Fold<I> for GenericArg<I> {
     type Result = GenericArg<I>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -96,11 +96,11 @@ impl<I: Interner> Fold<I> for GenericArg<I> {
 
 impl<I: Interner> Fold<I> for Substitution<I> {
     type Result = Substitution<I>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -116,11 +116,11 @@ impl<I: Interner> Fold<I> for Substitution<I> {
 
 impl<I: Interner> Fold<I> for Goals<I> {
     type Result = Goals<I>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -135,11 +135,11 @@ impl<I: Interner> Fold<I> for Goals<I> {
 
 impl<I: Interner> Fold<I> for ProgramClauses<I> {
     type Result = ProgramClauses<I>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -154,11 +154,11 @@ impl<I: Interner> Fold<I> for ProgramClauses<I> {
 
 impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
     type Result = QuantifiedWhereClauses<I>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -173,11 +173,11 @@ impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
 
 impl<I: Interner> Fold<I> for Constraints<I> {
     type Result = Constraints<I>;
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Self::Result>
+    ) -> Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -196,11 +196,11 @@ macro_rules! copy_fold {
     ($t:ty) => {
         impl<I: Interner> $crate::fold::Fold<I> for $t {
             type Result = Self;
-            fn fold_with<'i>(
+            fn fold_with<'i, E>(
                 self,
-                _folder: &mut dyn ($crate::fold::Folder<'i, I>),
+                _folder: &mut dyn ($crate::fold::Folder<'i, I, Error = E>),
                 _outer_binder: DebruijnIndex,
-            ) -> ::chalk_ir::Fallible<Self::Result>
+            ) -> ::std::result::Result<Self::Result, E>
             where
                 I: 'i,
             {
@@ -231,11 +231,11 @@ macro_rules! id_fold {
     ($t:ident) => {
         impl<I: Interner> $crate::fold::Fold<I> for $t<I> {
             type Result = $t<I>;
-            fn fold_with<'i>(
+            fn fold_with<'i, E>(
                 self,
-                _folder: &mut dyn ($crate::fold::Folder<'i, I>),
+                _folder: &mut dyn ($crate::fold::Folder<'i, I, Error = E>),
                 _outer_binder: DebruijnIndex,
-            ) -> ::chalk_ir::Fallible<Self::Result>
+            ) -> ::std::result::Result<Self::Result, E>
             where
                 I: 'i,
             {
@@ -256,11 +256,11 @@ id_fold!(GeneratorId);
 id_fold!(ForeignDefId);
 
 impl<I: Interner> SuperFold<I> for ProgramClauseData<I> {
-    fn super_fold_with<'i>(
+    fn super_fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> ::chalk_ir::Fallible<Self::Result>
+    ) -> ::std::result::Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -269,11 +269,11 @@ impl<I: Interner> SuperFold<I> for ProgramClauseData<I> {
 }
 
 impl<I: Interner> SuperFold<I> for ProgramClause<I> {
-    fn super_fold_with<'i>(
+    fn super_fold_with<'i, E>(
         self,
-        folder: &mut dyn Folder<'i, I>,
+        folder: &mut dyn Folder<'i, I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> ::chalk_ir::Fallible<Self::Result>
+    ) -> ::std::result::Result<Self::Result, E>
     where
         I: 'i,
     {
@@ -287,11 +287,11 @@ impl<I: Interner> SuperFold<I> for ProgramClause<I> {
 impl<I: Interner> Fold<I> for PhantomData<I> {
     type Result = PhantomData<I>;
 
-    fn fold_with<'i>(
+    fn fold_with<'i, E>(
         self,
-        _folder: &mut dyn Folder<'i, I>,
+        _folder: &mut dyn Folder<'i, I, Error = E>,
         _outer_binder: DebruijnIndex,
-    ) -> ::chalk_ir::Fallible<Self::Result>
+    ) -> ::std::result::Result<Self::Result, E>
     where
         I: 'i,
     {

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -72,7 +72,9 @@ impl<I> Shifter<'_, I> {
 }
 
 impl<'i, I: Interner> Folder<'i, I> for Shifter<'i, I> {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 
@@ -140,7 +142,9 @@ impl<I> DownShifter<'_, I> {
 }
 
 impl<'i, I: Interner> Folder<'i, I> for DownShifter<'i, I> {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -26,7 +26,9 @@ impl<I: Interner> Subst<'_, '_, I> {
 }
 
 impl<'i, I: Interner> Folder<'i, I> for Subst<'_, 'i, I> {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -2841,7 +2841,9 @@ impl<'a, I: Interner> ToGenericArg<I> for (usize, &'a VariableKind<I>) {
 }
 
 impl<'i, I: Interner, A: AsParameters<I>> Folder<'i, I> for &SubstFolder<'i, I, A> {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -9,8 +9,8 @@
 use chalk_ir::{
     fold::{Fold, Folder},
     interner::{HasInterner, Interner},
-    Binders, BoundVar, DebruijnIndex, Fallible, Lifetime, LifetimeData, Ty, TyKind, TyVariableKind,
-    VariableKind, VariableKinds,
+    Binders, BoundVar, DebruijnIndex, Fallible, Lifetime, LifetimeData, NoSolution, Ty, TyKind,
+    TyVariableKind, VariableKind, VariableKinds,
 };
 use rustc_hash::FxHashMap;
 
@@ -42,7 +42,9 @@ impl<I: Interner> Generalize<'_, I> {
 }
 
 impl<'i, I: Interner> Folder<'i, I> for Generalize<'i, I> {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -111,7 +111,9 @@ impl<'i, I: Interner> Folder<'i, I> for Canonicalizer<'i, I>
 where
     I: 'i,
 {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -135,7 +135,9 @@ impl<'i, I: Interner> Folder<'i, I> for Inverter<'i, I>
 where
     I: 'i,
 {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -236,7 +236,9 @@ impl<'i, I: Interner> Folder<'i, I> for UMapToCanonical<'i, I>
 where
     I: 'i,
 {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 
@@ -309,7 +311,9 @@ impl<'i, I: Interner> Folder<'i, I> for UMapFromCanonical<'i, I>
 where
     I: 'i,
 {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -1260,7 +1260,9 @@ impl<'i, I: Interner> Folder<'i, I> for OccursCheck<'_, 'i, I>
 where
     I: 'i,
 {
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I> {
+    type Error = NoSolution;
+
+    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
         self
     }
 


### PR DESCRIPTION
Equivalent to rust-lang/rust#85469, cc rust-lang/compiler-team#432 rust-lang/wg-traits#16.

This compiles, but there are implementations of `Folder` that still use `Fallible<T>` instead of `Result<T, Self::Error>`. I can make that change if it is deemed beneficial.

r? @jackh726