### PR TITLE
Skip crate publishing if there have been no changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           # Check if we can skip releasing a new version
           # (there are no changes and the job was not manually triggered)
-          export CHANGED=$(cargo workspaces changed --ignore-changes "**/Cargo.toml")
+          export CHANGED=$(cargo workspaces changed --include-merged-tags --ignore-changes "**/Cargo.toml")
           if [[ -z "$CHANGED" && "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
             # Nothing has changed, so don't publish a new version
             exit 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,10 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
+          # Check if we can skip releasing a new version
+          # (there are no changes and the job was not manually triggered)
           export CHANGED=$(cargo workspaces changed --ignore-changes "**/Cargo.toml")
-          if [[ -z "$CHANGED" ]]; then
+          if [[ -z "$CHANGED" && "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
             # Nothing has changed, so don't publish a new version
             exit 0
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,12 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
+          export CHANGED=$(cargo workspaces changed --ignore-changes "**/Cargo.toml")
+          if [[ -z "$CHANGED" ]]; then
+            # Nothing has changed, so don't publish a new version
+            exit 0
+          fi
+
           # Update version
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"


### PR DESCRIPTION
The last few crate releases have not introduced any changes, but the weekly publishing job has still pumped out new versions:
![image](https://user-images.githubusercontent.com/4417660/120943604-f2f37880-c6fd-11eb-8034-662830f950a8.png)

Now, using the [`cargo workspaces changed`](https://github.com/pksunkara/cargo-workspaces#changed) command, new crate versions are only published if there has been a change in one of the crates.

One interesting effect of using this method is that changes to sections of the project such as the book or main readme (which do not affect the crates) do not trigger crate releases. I don't expect that this will be an issue, but it's important to note.

Edit: I've updated the code to skip the empty release check if the job is manually triggered. This should be a sufficient workaround.