### PR TITLE
Fix automatic changelog generation to include current version's changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,17 +38,21 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
-          # Update changelog
-          npm install auto-changelog@2.2.1
-          auto-changelog --output RELEASES.md \
-                         --starting-version v0.11.0 \
-                         --merge-pattern 'Auto merge of #(\d+) - .+\n\n(.+)' \
-                         --template releases-template.hbs
-
+          # Update version
           git config --global user.email "runner@gha.local"
           git config --global user.name "Github Action"
           cargo workspaces -v version -ay --force '*' --include-merged-tags --no-git-commit --exact patch
           export VERSION=$(cargo pkgid | sed -E 's/.*#(.*)/\1/g')
+
+          # Update changelog
+          npm install auto-changelog@2.2.1
+          auto-changelog --output RELEASES.md \
+                         --starting-version v0.11.0 \
+                         --latest-version "$VERSION" \
+                         --merge-pattern 'Auto merge of #(\d+) - .+\n\n(.+)' \
+                         --template releases-template.hbs
+
+          # Commit and publish
           git commit -am "Release $VERSION"
           git tag "v$VERSION"
           cargo workspaces -v publish --from-git --skip-published


### PR DESCRIPTION
The changelog generation as it was written would not include the latest "unreleased" changes since the git tag for the new release hadn't been created yet. This change fixes that issue by using the `--latest-version` flag of [`auto-changelog`](https://github.com/CookPete/auto-changelog).

The `--latest-version` flag replaces the "Unreleased" section with the given version, allowing us to generate a changelog before creating the git tag it references. Ex. `--latest-version 0.70.0` will create a `v0.70.0` entry in the changelog even though the latest tag is `v0.69.0`.