### PR TITLE
Install auto-changelog globally to fix command not found

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
           export VERSION=$(cargo pkgid | sed -E 's/.*#(.*)/\1/g')
 
           # Update changelog
-          npm install auto-changelog@2.2.1
+          npm install -g auto-changelog@2.2.1
           auto-changelog --output RELEASES.md \
                          --starting-version v0.11.0 \
                          --latest-version "$VERSION" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,7 @@ jobs:
           export CHANGED=$(cargo workspaces changed --include-merged-tags --ignore-changes "**/Cargo.toml")
           if [[ -z "$CHANGED" && "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
             # Nothing has changed, so don't publish a new version
+            echo "No changes detected, skipping publish."
             exit 0
           fi
 

--- a/book/src/recursive/search_graph.md
+++ b/book/src/recursive/search_graph.md
@@ -7,10 +7,10 @@ actually implement this? That's where the [`SearchGraph`] comes into play.
 [cycles]: ./inductive_cycles.md
 [coinduction]: ./coinduction.md
 [stack]: ./stack.md
-[`SearchGraph`]: https://rust-lang.github.io/chalk/chalk_recursive/search_graph/struct.SearchGraph.html
-[`DepthFirstNumber`]: https://rust-lang.github.io/chalk/chalk_recursive/search_graph/struct.DepthFirstNumber.html
-[`Node`]: https://rust-lang.github.io/chalk/chalk_recursive/search_graph/struct.Node.html
-[`stack_depth`]: https://rust-lang.github.io/chalk/chalk_recursive/search_graph/struct.Node.html#structfield.stack_depth
+[`SearchGraph`]: https://rust-lang.github.io/chalk/chalk_recursive/fixed_point/search_graph/struct.SearchGraph.html
+[`DepthFirstNumber`]: https://rust-lang.github.io/chalk/chalk_recursive/fixed_point/search_graph/struct.DepthFirstNumber.html
+[`Node`]: https://rust-lang.github.io/chalk/chalk_recursive/fixed_point/search_graph/struct.Node.html
+[`stack_depth`]: https://rust-lang.github.io/chalk/chalk_recursive/fixed_point/search_graph/struct.Node.html#structfield.stack_depth
 
 The role of the [`SearchGraph`] is to store information about each goal that we
 are currently solving. Typically, these are goals on the stack -- but other
@@ -183,7 +183,7 @@ recursively invoking some goal G2 that is in the search graph but *not* present
 on the stack, then we update the current [`Minimums`] with the values stored in
 the search graph.
 
-[`Minimums`]: https://rust-lang.github.io/chalk/chalk_recursive/struct.Minimums.html
+[`Minimums`]: https://rust-lang.github.io/chalk/chalk_recursive/fixed_point/struct.Minimums.html
 
 ## Removing nodes from the graph
 

--- a/book/src/recursive/stack.md
+++ b/book/src/recursive/stack.md
@@ -5,13 +5,13 @@ what it sounds like: a stack that stores each thing that the recursive solver is
 solving. Initially, it contains only one item, the root goal that was given by
 the user.
 
-[`Stack`]: https://rust-lang.github.io/chalk/chalk_recursive/stack/struct.Stack.html
+[`Stack`]: https://rust-lang.github.io/chalk/chalk_recursive/fixed_point/stack/struct.Stack.html
 
 Each frame on the stack has an associated [`StackDepth`], which is basically an
 index that increases (so 0 is the top of the stack, 1 is the next thing pushed,
 etc).
 
-[`StackDepth`]: https://rust-lang.github.io/chalk/chalk_recursive/stack/struct.StackDepth.html
+[`StackDepth`]: https://rust-lang.github.io/chalk/chalk_recursive/fixed_point/stack/struct.StackDepth.html
 
 ## How the recursive solver works at the highest level
 
@@ -74,4 +74,4 @@ detect a cycle by checking in the [search graph] to see whether G has an associa
 to learn more about that).
 
 [search graph]: ./search_graph.md
-[`cycle`]: https://rust-lang.github.io/chalk/chalk_recursive/stack/struct.StackEntry.html#structfield.cycle
+[`cycle`]: https://rust-lang.github.io/chalk/chalk_recursive/fixed_point/stack/struct.StackEntry.html#structfield.cycle


### PR DESCRIPTION
Installing auto-changelog globally will add it to the path.

I ran this on my repo to verify (note: it eventually fails because I didn't set it up with actual publishing keys):
https://github.com/AzureMarker/chalk/runs/3166751455?check_suite_focus=true#step:6:102

Fixes #719 