### PR TITLE
Switch runner for publish job to Ubuntu from Mac

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: Publish
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Closes #721 

I ran this on my repo to verify (note: it eventually fails because I didn't set it up with actual publishing keys, and I added in the fix from #720 so it wouldn't immediately fail):
https://github.com/AzureMarker/chalk/runs/3187634249

Note: Merge #720 first so the book lint check passes.