### PR TITLE
Improve compile times

### DIFF
--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 
 [dependencies]
 rustc-hash = { version = "1.1.0" }
-tracing = "0.1"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 chalk-derive = { version = "0.71.0-dev.0", path = "../chalk-derive" }
 chalk-ir = { version = "0.71.0-dev.0", path = "../chalk-ir" }

--- a/chalk-integration/Cargo.toml
+++ b/chalk-integration/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 string_cache = "0.8.0"
 salsa = "0.16.0"
-tracing = "0.1"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 chalk-derive = { version = "0.71.0-dev.0", path = "../chalk-derive" }
 chalk-ir = { version = "0.71.0-dev.0", path = "../chalk-ir" }

--- a/chalk-recursive/Cargo.toml
+++ b/chalk-recursive/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 rustc-hash = { version = "1.1.0" }
-tracing = "0.1"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 chalk-derive = { version = "0.71.0-dev.0", path = "../chalk-derive" }
 chalk-ir = { version = "0.71.0-dev.0", path = "../chalk-ir" }

--- a/chalk-solve/Cargo.toml
+++ b/chalk-solve/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 ena = "0.14.0"
 itertools = "0.10.0"
 petgraph = "0.5.1"
-tracing = "0.1"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.2", optional = true }
 tracing-tree = { version = "0.1.4", optional = true }
 rustc-hash = { version = "1.1.0" }


### PR DESCRIPTION
By default, tracing includes `attributes` feature, which enables proc
macros. This makes any crate using tracing to depend on `syn` being
fully compiled, which reduces opportunities for parallelism.

cc https://github.com/tokio-rs/tracing/issues/1526