### PR TITLE
Add NormalizeFn domain goal that associates projections of functions on traits with the matching implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.13"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -30,22 +30,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-
-[[package]]
 name = "ascii-canvas"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8eb72df928aafb99fe5d37b383f2fe25bd2a765e3e5f7c365916b6f2463a29"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
 ]
@@ -63,15 +51,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bit-set"
@@ -84,71 +66,21 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
-]
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
-name = "byteorder"
-version = "1.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cc"
-version = "1.0.58"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -169,7 +101,7 @@ dependencies = [
  "chalk-solve",
  "diff",
  "docopt",
- "itertools 0.10.0",
+ "itertools",
  "pretty_assertions",
  "regex",
  "rustyline",
@@ -254,7 +186,7 @@ dependencies = [
  "chalk-integration",
  "chalk-ir",
  "ena",
- "itertools 0.10.0",
+ "itertools",
  "petgraph",
  "rustc-hash",
  "tracing",
@@ -264,56 +196,36 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits",
- "time",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
+ "winapi",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctor"
-version = "0.1.15"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
  "syn",
@@ -332,19 +244,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
-name = "digest"
-version = "0.8.1"
+name = "dirs-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "generic-array",
+ "cfg-if",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs"
-version = "1.0.5"
+name = "dirs-sys-next"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -353,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "docopt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
+checksum = "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f"
 dependencies = [
  "lazy_static",
  "regex",
@@ -365,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "ena"
@@ -377,12 +290,6 @@ checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
 dependencies = [
  "log",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fixedbitset"
@@ -401,57 +308,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.8.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
-dependencies = [
- "autocfg",
-]
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -459,64 +354,56 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
- "either",
+ "cfg-if",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lalrpop"
-version = "0.19.0"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f55673d283313791404be21209bb433f128f7e5c451986df107eb5fdbd68d2"
+checksum = "b15174f1c529af5bf1283c3bc0058266b483a67156f79589fab2a25e23cf8988"
 dependencies = [
  "ascii-canvas",
  "atty",
  "bit-set",
  "diff",
- "docopt",
  "ena",
- "itertools 0.9.0",
+ "itertools",
  "lalrpop-util",
  "petgraph",
+ "pico-args",
  "regex",
  "regex-syntax",
- "serde",
- "serde_derive",
- "sha2",
  "string_cache",
  "term",
+ "tiny-keccak",
  "unicode-xid",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.0"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e88f15a7d31dfa8fb607986819039127f0161058a3b248a146142d276cbd28"
+checksum = "d3e58cce361efcc90ba8a0a5f982c741ff86b603495bb15a998412e957dcd278"
 dependencies = [
  "regex",
 ]
@@ -529,26 +416,26 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "lock_api"
-version = "0.4.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -562,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -580,15 +467,15 @@ checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -596,24 +483,24 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "oorandom"
-version = "11.1.2"
+name = "once_cell"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
-name = "opaque-debug"
-version = "0.2.3"
+name = "oorandom"
+version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "output_vt100"
@@ -626,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -637,12 +524,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
@@ -670,6 +556,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,78 +587,66 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
  "redox_syscall",
- "rust-argon2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "byteorder",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
-
-[[package]]
-name = "rust-argon2"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils 0.7.2",
-]
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustc-hash"
@@ -769,13 +655,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "rustyline"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8227301bfc717136f0ecbd3d064ba8199e44497a0bdd46bb01ede4387cfd2cec"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "fs2",
  "libc",
  "log",
@@ -796,11 +688,11 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "salsa"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fadca2ab5de17acf66d744f4888049ca8f1bb9b8a1ab8afd9d032cc959c5dc"
+checksum = "4b84d9f96071f3f3be0dc818eae3327625d8ebc95b58da37d6850724f31d3403"
 dependencies = [
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils",
  "indexmap",
  "lock_api",
  "log",
@@ -831,18 +723,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.115"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -851,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
@@ -861,43 +753,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer",
- "digest",
- "fake-simd",
- "opaque-debug",
-]
-
-[[package]]
 name = "sharded-slab"
-version = "0.0.9"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "string_cache"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
+checksum = "8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
@@ -908,15 +788,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -937,59 +817,59 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "byteorder",
- "dirs",
+ "dirs-next",
+ "rustversion",
  "winapi",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
+name = "tiny-keccak"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
- "libc",
- "winapi",
+ "crunchy",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.19"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.10"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe233f4227389ab7df5b32649239da7ebe0b281824b4e84b342d04d3fd8c25e"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -998,18 +878,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.14"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -1018,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde",
  "tracing-core",
@@ -1028,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.11"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -1042,6 +922,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -1049,29 +930,23 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a3dc4774db3a6b2d66a4f8d8de670e874ec3ed55615860c994927419b32c5f"
+checksum = "1712b40907f8d9bc2bc66763ab61dec914b7123d7149e59feb0d4e2a95fc4967"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
- "chrono",
  "termcolor",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-
-[[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -1081,9 +956,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "utf8parse"
@@ -1093,9 +968,9 @@ checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -1,10 +1,3 @@
-//! Defines traits used to embed the chalk-engine in another crate.
-//!
-//! chalk and rustc both define types which implement the traits in this
-//! module. This allows each user of chalk-engine to define their own
-//! `DomainGoal` type, add arena lifetime parameters, and more. See
-//! [`Context`] trait for a list of types.
-
 use crate::CompleteAnswer;
 use chalk_ir::interner::Interner;
 use chalk_ir::Substitution;

--- a/chalk-engine/src/slg.rs
+++ b/chalk-engine/src/slg.rs
@@ -212,9 +212,16 @@ impl<I: Interner> MayInvalidate<'_, I> {
                 TyKind::OpaqueType(id_b, substitution_b),
             ) => self.aggregate_name_and_substs(id_a, substitution_a, id_b, substitution_b),
             (TyKind::Slice(ty_a), TyKind::Slice(ty_b)) => self.aggregate_tys(ty_a, ty_b),
-            (TyKind::FnDef(id_a, substitution_a), TyKind::FnDef(id_b, substitution_b)) => {
-                self.aggregate_name_and_substs(id_a, substitution_a, id_b, substitution_b)
-            }
+            (
+                TyKind::FnDef(FnDefTy {
+                    fn_def_id: id_a,
+                    substitution: substitution_a,
+                }),
+                TyKind::FnDef(FnDefTy {
+                    fn_def_id: id_b,
+                    substitution: substitution_b,
+                }),
+            ) => self.aggregate_name_and_substs(id_a, substitution_a, id_b, substitution_b),
             (TyKind::Ref(id_a, lifetime_a, ty_a), TyKind::Ref(id_b, lifetime_b, ty_b)) => {
                 id_a != id_b
                     || self.aggregate_lifetimes(lifetime_a, lifetime_b)

--- a/chalk-engine/src/slg/aggregate.rs
+++ b/chalk-engine/src/slg/aggregate.rs
@@ -305,9 +305,24 @@ impl<I: Interner> AntiUnifier<'_, '_, I> {
             (TyKind::Slice(ty_a), TyKind::Slice(ty_b)) => {
                 TyKind::Slice(self.aggregate_tys(ty_a, ty_b)).intern(interner)
             }
-            (TyKind::FnDef(id_a, substitution_a), TyKind::FnDef(id_b, substitution_b)) => self
+            (
+                TyKind::FnDef(FnDefTy {
+                    fn_def_id: id_a,
+                    substitution: substitution_a,
+                }),
+                TyKind::FnDef(FnDefTy {
+                    fn_def_id: id_b,
+                    substitution: substitution_b,
+                }),
+            ) => self
                 .aggregate_name_and_substs(id_a, substitution_a, id_b, substitution_b)
-                .map(|(&name, substitution)| TyKind::FnDef(name, substitution).intern(interner))
+                .map(|(&name, substitution)| {
+                    TyKind::FnDef(FnDefTy {
+                        fn_def_id: name,
+                        substitution,
+                    })
+                    .intern(interner)
+                })
                 .unwrap_or_else(|| self.new_ty_variable()),
             (TyKind::Ref(id_a, lifetime_a, ty_a), TyKind::Ref(id_b, lifetime_b, ty_b)) => {
                 if id_a == id_b {

--- a/chalk-engine/src/slg/resolvent.rs
+++ b/chalk-engine/src/slg/resolvent.rs
@@ -489,7 +489,16 @@ impl<'i, I: Interner> Zipper<'i, I> for AnswerSubstitutor<'i, I> {
                 )
             }
             (TyKind::Slice(ty_a), TyKind::Slice(ty_b)) => Zip::zip_with(self, variance, ty_a, ty_b),
-            (TyKind::FnDef(id_a, substitution_a), TyKind::FnDef(id_b, substitution_b)) => {
+            (
+                TyKind::FnDef(FnDefTy {
+                    fn_def_id: id_a,
+                    substitution: substitution_a,
+                }),
+                TyKind::FnDef(FnDefTy {
+                    fn_def_id: id_b,
+                    substitution: substitution_b,
+                }),
+            ) => {
                 if id_a != id_b {
                     return Err(NoSolution);
                 }

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -13,9 +13,9 @@ use chalk_ir::{
     UnificationDatabase, Variances,
 };
 use chalk_solve::rust_ir::{
-    AdtDatum, AdtRepr, AssociatedTyDatum, AssociatedTyValue, AssociatedTyValueId, ClosureKind,
-    FnDefDatum, FnDefInputsAndOutputDatum, GeneratorDatum, GeneratorWitnessDatum, ImplDatum,
-    OpaqueTyDatum, TraitDatum, WellKnownTrait,
+    AdtDatum, AdtRepr, AssociatedFnValue, AssociatedFnValueId, AssociatedTyDatum,
+    AssociatedTyValue, AssociatedTyValueId, ClosureKind, FnDefDatum, FnDefInputsAndOutputDatum,
+    GeneratorDatum, GeneratorWitnessDatum, ImplDatum, OpaqueTyDatum, TraitDatum, WellKnownTrait,
 };
 use chalk_solve::{RustIrDatabase, Solution, SubstitutionResult};
 use salsa::Database;
@@ -91,6 +91,13 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         self.program_ir().unwrap().associated_ty_data(ty)
     }
 
+    fn associated_fn_data(
+        &self,
+        f: chalk_ir::AssocFnDefId<ChalkIr>,
+    ) -> Arc<chalk_solve::rust_ir::AssociatedFnDatum<ChalkIr>> {
+        self.program_ir().unwrap().associated_fn_data(f)
+    }
+
     fn trait_datum(&self, id: TraitId<ChalkIr>) -> Arc<TraitDatum<ChalkIr>> {
         self.program_ir().unwrap().trait_datum(id)
     }
@@ -104,6 +111,13 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         id: AssociatedTyValueId<ChalkIr>,
     ) -> Arc<AssociatedTyValue<ChalkIr>> {
         self.program_ir().unwrap().associated_ty_values[&id].clone()
+    }
+
+    fn associated_fn_value(
+        &self,
+        id: AssociatedFnValueId<ChalkIr>,
+    ) -> Arc<AssociatedFnValue<ChalkIr>> {
+        self.program_ir().unwrap().associated_fn_values[&id].clone()
     }
 
     fn opaque_ty_data(&self, id: OpaqueTyId<ChalkIr>) -> Arc<OpaqueTyDatum<ChalkIr>> {

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -373,8 +373,9 @@ impl<'a> LowerWithEnv for LowerFnDefn<'a> {
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
         let LowerFnDefn(fn_defn, fn_def_id) = self;
-
-        let binders = env.in_binders(fn_defn.all_parameters(), |env| {
+        let params = fn_defn.all_parameters();
+        debug!(params = ?params);
+        let binders = env.in_binders(params, |env| {
             let where_clauses = fn_defn.where_clauses.lower(env)?;
 
             let inputs_and_output = env.in_binders(vec![], |env| {
@@ -394,6 +395,8 @@ impl<'a> LowerWithEnv for LowerFnDefn<'a> {
                 where_clauses,
             })
         })?;
+
+        debug!("LowerFnDefn id={:?} binders={:?}", &fn_def_id, &binders);
 
         Ok(rust_ir::FnDefDatum {
             id: *fn_def_id,

--- a/chalk-integration/src/lowering/env.rs
+++ b/chalk-integration/src/lowering/env.rs
@@ -57,7 +57,8 @@ pub struct Env<'k> {
 }
 
 /// Information about an associated type **declaration** (i.e., an
-/// `AssociatedTyDatum`). This information is gathered in the first
+/// [`rust_ir::AssociatedTyDatum`](chalk_solve::rust_ir::AssociatedTyDatum)).
+/// This information is gathered in the first
 /// phase of creating the Rust IR and is then later used to lookup the
 /// "id" of an associated type.
 ///

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -1,5 +1,6 @@
 use crate::interner::ChalkIr;
 use crate::{tls, Identifier, TypeKind};
+use chalk_ir::FnDefTy;
 use chalk_ir::{could_match::CouldMatch, UnificationDatabase};
 use chalk_ir::{debug::Angle, Variance};
 use chalk_ir::{
@@ -499,7 +500,14 @@ impl RustIrDatabase<ChalkIr> for Program {
                 (TyKind::Tuple(arity_a, _), TyKind::Tuple(arity_b, _)) => arity_a == arity_b,
                 (TyKind::OpaqueType(id_a, _), TyKind::OpaqueType(id_b, _)) => id_a == id_b,
                 (TyKind::Slice(_), TyKind::Slice(_)) => true,
-                (TyKind::FnDef(id_a, _), TyKind::FnDef(id_b, _)) => id_a == id_b,
+                (
+                    TyKind::FnDef(FnDefTy {
+                        fn_def_id: id_a, ..
+                    }),
+                    TyKind::FnDef(FnDefTy {
+                        fn_def_id: id_b, ..
+                    }),
+                ) => id_a == id_b,
                 (TyKind::Ref(id_a, _, _), TyKind::Ref(id_b, _, _)) => id_a == id_b,
                 (TyKind::Raw(id_a, _), TyKind::Raw(id_b, _)) => id_a == id_b,
                 (TyKind::Never, TyKind::Never) => true,

--- a/chalk-integration/src/tls.rs
+++ b/chalk-integration/src/tls.rs
@@ -1,4 +1,5 @@
 use crate::interner::ChalkIr;
+use chalk_ir::ImplId;
 use chalk_ir::{
     debug::SeparatorTraitRef, AdtId, AliasTy, AssocTypeId, CanonicalVarKinds, Constraints, FnDefId,
     GenericArg, Goal, Goals, Lifetime, OpaqueTy, OpaqueTyId, ProgramClause,
@@ -23,6 +24,12 @@ pub trait DebugContext {
     fn debug_trait_id(
         &self,
         id: TraitId<ChalkIr>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> Result<(), fmt::Error>;
+
+    fn debug_impl_id(
+        &self,
+        id: ImplId<ChalkIr>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error>;
 

--- a/chalk-ir/src/could_match.rs
+++ b/chalk-ir/src/could_match.rs
@@ -73,8 +73,14 @@ where
                         ty_a.could_match(interner, self.db, ty_b)
                     }
                     (
-                        TyKind::FnDef(fn_def_a, substitution_a),
-                        TyKind::FnDef(fn_def_b, substitution_b),
+                        TyKind::FnDef(FnDefTy {
+                            fn_def_id: fn_def_a,
+                            substitution: substitution_a,
+                        }),
+                        TyKind::FnDef(FnDefTy {
+                            fn_def_id: fn_def_b,
+                            substitution: substitution_b,
+                        }),
                     ) => {
                         fn_def_a == fn_def_b
                             && self

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -204,7 +204,10 @@ impl<I: Interner> Debug for TyKind<I> {
                 write!(fmt, "!{:?}<{:?}>", opaque_ty, substitution)
             }
             TyKind::Slice(substitution) => write!(fmt, "{{slice}}<{:?}>", substitution),
-            TyKind::FnDef(fn_def, substitution) => write!(fmt, "{:?}<{:?}>", fn_def, substitution),
+            TyKind::FnDef(FnDefTy {
+                fn_def_id,
+                substitution,
+            }) => write!(fmt, "{:?}<{:?}>", fn_def_id, substitution),
             TyKind::Ref(mutability, lifetime, ty) => match mutability {
                 Mutability::Mut => write!(fmt, "(&{:?} mut {:?})", lifetime, ty),
                 Mutability::Not => write!(fmt, "(&{:?} {:?})", lifetime, ty),
@@ -506,8 +509,16 @@ impl<'a, I: Interner> Debug for TyKindDebug<'a, I> {
                 substitution.with_angle(interner)
             ),
             TyKind::Slice(ty) => write!(fmt, "[{:?}]", ty),
-            TyKind::FnDef(fn_def, substitution) => {
-                write!(fmt, "{:?}{:?}", fn_def, substitution.with_angle(interner))
+            TyKind::FnDef(FnDefTy {
+                fn_def_id,
+                substitution,
+            }) => {
+                write!(
+                    fmt,
+                    "{:?}{:?}",
+                    fn_def_id,
+                    substitution.with_angle(interner)
+                )
             }
             TyKind::Ref(mutability, lifetime, ty) => match mutability {
                 Mutability::Mut => write!(fmt, "(&{:?} mut {:?})", lifetime, ty),

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -10,6 +10,12 @@ impl<I: Interner> Debug for TraitId<I> {
     }
 }
 
+impl<I: Interner> Debug for ImplId<I> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        I::debug_impl_id(*self, fmt).unwrap_or_else(|| write!(fmt, "ImplId({:?})", self.0))
+    }
+}
+
 impl<I: Interner> Debug for AdtId<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         I::debug_adt_id(*self, fmt).unwrap_or_else(|| write!(fmt, "AdtId({:?})", self.0))
@@ -20,6 +26,13 @@ impl<I: Interner> Debug for AssocTypeId<I> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
         I::debug_assoc_type_id(*self, fmt)
             .unwrap_or_else(|| write!(fmt, "AssocTypeId({:?})", self.0))
+    }
+}
+
+impl<I: Interner> Debug for AssocFnDefId<I> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        I::debug_assoc_fn_def_id(*self, fmt)
+            .unwrap_or_else(|| write!(fmt, "AssocFnDefId({:?})", self.0))
     }
 }
 
@@ -141,6 +154,13 @@ impl<I: Interner> Debug for ProjectionTy<I> {
         I::debug_projection_ty(self, fmt).unwrap_or_else(|| {
             unimplemented!("cannot format ProjectionTy without setting Program in tls")
         })
+    }
+}
+
+impl<I: Interner> Debug for FnDefTy<I> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
+        I::debug_fn_def_ty(self, fmt)
+            .unwrap_or_else(|| write!(fmt, "{:?} {:?}", self.fn_def_id, self.substitution))
     }
 }
 
@@ -819,6 +839,7 @@ impl<I: Interner> Debug for DomainGoal<I> {
             DomainGoal::WellFormed(n) => write!(fmt, "{:?}", n),
             DomainGoal::FromEnv(n) => write!(fmt, "{:?}", n),
             DomainGoal::Normalize(n) => write!(fmt, "{:?}", n),
+            DomainGoal::NormalizeFn(a, b) => write!(fmt, "NormalizeFn({:?}, {:?})", a, b),
             DomainGoal::IsLocal(n) => write!(fmt, "IsLocal({:?})", n),
             DomainGoal::IsUpstream(n) => write!(fmt, "IsUpstream({:?})", n),
             DomainGoal::IsFullyVisible(n) => write!(fmt, "IsFullyVisible({:?})", n),

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -426,10 +426,13 @@ where
                 TyKind::Slice(substitution.clone().fold_with(folder, outer_binder)?)
                     .intern(folder.interner())
             }
-            TyKind::FnDef(fn_def, substitution) => TyKind::FnDef(
-                fn_def.fold_with(folder, outer_binder)?,
-                substitution.clone().fold_with(folder, outer_binder)?,
-            )
+            TyKind::FnDef(FnDefTy {
+                fn_def_id,
+                substitution,
+            }) => TyKind::FnDef(FnDefTy {
+                fn_def_id: fn_def_id.fold_with(folder, outer_binder)?,
+                substitution: substitution.clone().fold_with(folder, outer_binder)?,
+            })
             .intern(folder.interner()),
             TyKind::Ref(mutability, lifetime, ty) => TyKind::Ref(
                 mutability.fold_with(folder, outer_binder)?,

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -251,6 +251,7 @@ id_fold!(TraitId);
 id_fold!(AssocTypeId);
 id_fold!(OpaqueTyId);
 id_fold!(FnDefId);
+id_fold!(AssocFnDefId);
 id_fold!(ClosureId);
 id_fold!(GeneratorId);
 id_fold!(ForeignDefId);

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -60,36 +60,40 @@ use std::sync::Arc;
 pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// "Interned" representation of types.  In normal user code,
     /// `Self::InternedType` is not referenced. Instead, we refer to
-    /// `Ty<Self>`, which wraps this type.
+    /// [`Ty<Self>`], which wraps this type.
     ///
     /// An `InternedType` must be something that can be created from a
-    /// `TyKind` (by the [`intern_ty`] method) and then later
-    /// converted back (by the [`ty_data`] method). The interned form
-    /// must also introduce indirection, either via a `Box`, `&`, or
-    /// other pointer type.
+    /// [`TyKind`] (by the [`intern_ty`](Interner::intern_ty) method) and
+    /// then later converted back (by the [`ty_data`](Interner::ty_data)
+    /// method). The interned form must also introduce indirection,
+    /// either via a `Box`, `&`, or other pointer type.
     type InternedType: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of lifetimes.  In normal user code,
     /// `Self::InternedLifetime` is not referenced. Instead, we refer to
-    /// `Lifetime<Self>`, which wraps this type.
+    /// [`Lifetime<Self>`], which wraps this type.
     ///
-    /// An `InternedLifetime` must be something that can be created
-    /// from a `LifetimeData` (by the [`intern_lifetime`] method) and
-    /// then later converted back (by the [`lifetime_data`] method).
+    /// An `InternedLifetime` must be something that can be created from
+    /// a [`LifetimeData`] (by the
+    /// [`intern_lifetime`](Interner::intern_lifetime) method) and then
+    /// later converted back (by the
+    /// [`lifetime_data`](Interner::lifetime_data) method).
     type InternedLifetime: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of const expressions. In normal user code,
     /// `Self::InternedConst` is not referenced. Instead, we refer to
-    /// `Const<Self>`, which wraps this type.
+    /// [`Const<Self>`], which wraps this type.
     ///
-    /// An `InternedConst` must be something that can be created
-    /// from a `ConstData` (by the [`intern_const`] method) and
-    /// then later converted back (by the [`const_data`] method).
+    /// An `InternedConst` must be something that can be created from a
+    /// [`ConstData`] (by the [`intern_const`](Interner::intern_const)
+    /// method) and then later converted back (by the
+    /// [`const_data`](Interner::const_data) method).
     type InternedConst: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of an evaluated const value.
     /// `Self::InternedConcreteConst` is not referenced. Instead,
-    /// we refer to `ConcreteConst<Self>`, which wraps this type.
+    /// we refer to [`ConcreteConst<Self>`](chalk_ir::ConcreteConst),
+    /// which wraps this type.
     ///
     /// `InternedConcreteConst` instances are not created by chalk,
     /// it can only make a query asking about equality of two
@@ -99,92 +103,111 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// "Interned" representation of a "generic parameter", which can
     /// be either a type or a lifetime.  In normal user code,
     /// `Self::InternedGenericArg` is not referenced. Instead, we refer to
-    /// `GenericArg<Self>`, which wraps this type.
+    /// [`GenericArg<Self>`], which wraps this type.
     ///
-    /// An `InternedType` is created by `intern_generic_arg` and can be
-    /// converted back to its underlying data via `generic_arg_data`.
+    /// An `InternedType` is created by
+    /// [`intern_generic_arg`](Self::intern_generic_arg) and can be
+    /// converted back to its underlying data via
+    /// [`generic_arg_data`](Self::generic_arg_data).
     type InternedGenericArg: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a "goal".  In normal user code,
     /// `Self::InternedGoal` is not referenced. Instead, we refer to
-    /// `Goal<Self>`, which wraps this type.
+    /// [`Goal<Self>`], which wraps this type.
     ///
-    /// An `InternedGoal` is created by `intern_goal` and can be
-    /// converted back to its underlying data via `goal_data`.
+    /// An `InternedGoal` is created by
+    /// [`intern_goal`](Self::intern_goal) and can be
+    /// converted back to its underlying [`GoalData`] via
+    /// [`goal_data`](Self::goal_data).
     type InternedGoal: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a list of goals.  In normal user code,
     /// `Self::InternedGoals` is not referenced. Instead, we refer to
-    /// `Goals<Self>`, which wraps this type.
+    /// [`Goals<Self>`], which wraps this type.
     ///
-    /// An `InternedGoals` is created by `intern_goals` and can be
-    /// converted back to its underlying data via `goals_data`.
+    /// An `InternedGoals` is created by
+    /// [`intern_goals`](Self::intern_goals) and can be converted back
+    /// to its underlying data via [`goals_data`](Self::goals_data).
     type InternedGoals: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a "substitution".  In normal user code,
     /// `Self::InternedSubstitution` is not referenced. Instead, we refer to
-    /// `Substitution<Self>`, which wraps this type.
+    /// [`Substitution<Self>`], which wraps this type.
     ///
-    /// An `InternedSubstitution` is created by `intern_substitution` and can be
-    /// converted back to its underlying data via `substitution_data`.
+    /// An `InternedSubstitution` is created by
+    /// [`intern_substitution`](Self::intern_substitution) and can be
+    /// converted back to its underlying data via
+    /// [`substitution_data`](Self::substitution_data).
     type InternedSubstitution: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a list of program clauses.  In normal user code,
     /// `Self::InternedProgramClauses` is not referenced. Instead, we refer to
-    /// `ProgramClauses<Self>`, which wraps this type.
+    /// [`ProgramClauses<Self>`], which wraps this type.
     ///
-    /// An `InternedProgramClauses` is created by `intern_program_clauses` and can be
-    /// converted back to its underlying data via `program_clauses_data`.
+    /// An `InternedProgramClauses` is created by
+    /// [`intern_program_clauses`](Self::intern_program_clauses) and can
+    /// be converted back to its underlying data via
+    /// [`program_clauses_data`](Self::program_clauses_data).
     type InternedProgramClauses: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a "program clause".  In normal user code,
     /// `Self::InternedProgramClause` is not referenced. Instead, we refer to
-    /// `ProgramClause<Self>`, which wraps this type.
+    /// [`ProgramClause<Self>`], which wraps this type.
     ///
-    /// An `InternedProgramClause` is created by `intern_program_clause` and can be
-    /// converted back to its underlying data via `program_clause_data`.
+    /// An `InternedProgramClause` is created by
+    /// [`intern_program_clause`](Self::intern_program_clause) and can
+    /// be converted back to its underlying data via
+    /// [`program_clause_data`](Self::program_clause_data).
     type InternedProgramClause: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a list of quantified where clauses.
     /// In normal user code, `Self::InternedQuantifiedWhereClauses` is not referenced.
-    /// Instead, we refer to `QuantifiedWhereClauses<Self>`, which wraps this type.
+    /// Instead, we refer to [`QuantifiedWhereClauses<Self>`], which wraps this type.
     ///
-    /// An `InternedQuantifiedWhereClauses` is created by `intern_quantified_where_clauses`
-    /// and can be converted back to its underlying data via `quantified_where_clauses_data`.
+    /// An `InternedQuantifiedWhereClauses` is created by
+    /// [`intern_quantified_where_clauses`](Self::intern_quantified_where_clauses)
+    /// and can be converted back to its underlying data via
+    /// [`quantified_where_clauses_data`](Self::quantified_where_clauses_data).
     type InternedQuantifiedWhereClauses: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a list of variable kinds.
     /// In normal user code, `Self::InternedVariableKinds` is not referenced.
-    /// Instead, we refer to `VariableKinds<Self>`, which wraps this type.
+    /// Instead, we refer to [`VariableKinds<Self>`], which wraps this type.
     ///
-    /// An `InternedVariableKinds` is created by `intern_generic_arg_kinds`
-    /// and can be converted back to its underlying data via `variable_kinds_data`.
+    /// An `InternedVariableKinds` is created by
+    /// [`intern_generic_arg_kinds`](Self::intern_generic_arg_kinds) and
+    /// can be converted back to its underlying data via
+    /// [`variable_kinds_data`](Self::variable_kinds_data).
     type InternedVariableKinds: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a list of variable kinds with universe index.
     /// In normal user code, `Self::InternedCanonicalVarKinds` is not referenced.
-    /// Instead, we refer to `CanonicalVarKinds<Self>`, which wraps this type.
+    /// Instead, we refer to [`CanonicalVarKinds<Self>`], which wraps this type.
     ///
     /// An `InternedCanonicalVarKinds` is created by
-    /// `intern_canonical_var_kinds` and can be converted back
-    /// to its underlying data via `canonical_var_kinds_data`.
+    /// [`intern_canonical_var_kinds`](Self::intern_canonical_var_kinds)
+    /// and can be converted back to its underlying data via
+    /// [`canonical_var_kinds_data`](Self::canonical_var_kinds_data).
     type InternedCanonicalVarKinds: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a list of region constraints.
     /// In normal user code, `Self::InternedConstraints` is not referenced.
-    /// Instead, we refer to `Constraints<Self>`, which wraps this type.
+    /// Instead, we refer to [`Constraints<Self>`], which wraps this type.
     ///
-    /// An `InternedConstraints` is created by `intern_constraints`
-    /// and can be converted back to its underlying data via `constraints_data`.
+    /// An `InternedConstraints` is created by
+    /// [`intern_constraints`](Self::intern_constraints) and can be
+    /// converted back to its underlying data via
+    /// [`constraints_data`](Self::constraints_data).
     type InternedConstraints: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of a list of `chalk_ir::Variance`.
     /// In normal user code, `Self::InternedVariances` is not referenced.
-    /// Instead, we refer to `Variances<Self>`, which wraps this type.
+    /// Instead, we refer to [`Variances<Self>`], which wraps this type.
     ///
     /// An `InternedVariances` is created by
-    /// `intern_variances` and can be converted back
-    /// to its underlying data via `variances_data`.
+    /// [`intern_variances`](Self::intern_variances) and can be
+    /// converted back to its underlying data via
+    /// [`variances_data`](Self::variances_data).
     type InternedVariances: Debug + Clone + Eq + Hash;
 
     /// The core "id" type used for trait-ids and the like.
@@ -206,7 +229,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a type-kind-id.
+    /// Prints the debug representation of a trait id.
     /// Returns `None` to fallback to the default debug output (e.g.,
     /// if no info about current program is available from TLS).
     #[allow(unused_variables)]
@@ -217,7 +240,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a type-kind-id.
+    /// Prints the debug representation of a associated type id.
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_assoc_type_id(
@@ -267,7 +290,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of an alias.
+    /// Prints the debug representation of a generator.
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_generator_id(
@@ -289,7 +312,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a ProjectionTy.
+    /// Prints the debug representation of a [`ProjectionTy`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_projection_ty(
@@ -299,7 +322,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of an OpaqueTy.
+    /// Prints the debug representation of an [`OpaqueTy`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_opaque_ty(
@@ -309,14 +332,14 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a type.
+    /// Prints the debug representation of a [`Ty`]pe.
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_ty(ty: &Ty<Self>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
         None
     }
 
-    /// Prints the debug representation of a lifetime.
+    /// Prints the debug representation of a [`Lifetime`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_lifetime(
@@ -326,7 +349,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a const.
+    /// Prints the debug representation of a [`Const`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_const(constant: &Const<Self>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
@@ -373,22 +396,23 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of an goal.
+    /// Prints the debug representation of a [`Goal`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_goal(goal: &Goal<Self>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
         None
     }
 
-    /// Prints the debug representation of a list of goals.
+    /// Prints the debug representation of a list of [`Goals`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_goals(goals: &Goals<Self>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
         None
     }
 
-    /// Prints the debug representation of a ProgramClauseImplication.
-    /// Returns `None` to fallback to the default debug output.
+    /// Prints the debug representation of a
+    /// [`ProgramClauseImplication`]. Returns `None` to fallback to the
+    /// default debug output.
     #[allow(unused_variables)]
     fn debug_program_clause_implication(
         pci: &ProgramClauseImplication<Self>,
@@ -397,7 +421,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a ProgramClause.
+    /// Prints the debug representation of a [`ProgramClause`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_program_clause(
@@ -407,7 +431,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a ProgramClauses.
+    /// Prints the debug representation of a [`ProgramClauses`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_program_clauses(
@@ -417,7 +441,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a Substitution.
+    /// Prints the debug representation of a [`Substitution`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_substitution(
@@ -427,7 +451,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a SeparatorTraitRef.
+    /// Prints the debug representation of a [`SeparatorTraitRef`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_separator_trait_ref(
@@ -437,7 +461,7 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Prints the debug representation of a QuantifiedWhereClauses.
+    /// Prints the debug representation of a [`QuantifiedWhereClauses`].
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_quantified_where_clauses(
@@ -467,30 +491,31 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
-    /// Create an "interned" type from `ty`. This is not normally
-    /// invoked directly; instead, you invoke `TyKind::intern` (which
+    /// Create an "interned" type from `kind`. This is not normally
+    /// invoked directly; instead, you invoke [`TyKind::intern`] (which
     /// will ultimately call this method).
     fn intern_ty(&self, kind: TyKind<Self>) -> Self::InternedType;
 
-    /// Lookup the `TyKind` from an interned type.
+    /// Lookup the [`TyKind`] from an interned type.
     fn ty_data<'a>(&self, ty: &'a Self::InternedType) -> &'a TyData<Self>;
 
     /// Create an "interned" lifetime from `lifetime`. This is not
     /// normally invoked directly; instead, you invoke
-    /// `LifetimeData::intern` (which will ultimately call this
+    /// [`LifetimeData::intern`] (which will ultimately call this
     /// method).
     fn intern_lifetime(&self, lifetime: LifetimeData<Self>) -> Self::InternedLifetime;
 
-    /// Lookup the `LifetimeData` that was interned to create a `InternedLifetime`.
+    /// Lookup the [`LifetimeData`] that was interned to create a
+    /// [`InternedLifetime`](Self::InternedLifetime).
     fn lifetime_data<'a>(&self, lifetime: &'a Self::InternedLifetime) -> &'a LifetimeData<Self>;
 
-    /// Create an "interned" const from `const`. This is not
-    /// normally invoked directly; instead, you invoke
-    /// `ConstData::intern` (which will ultimately call this
-    /// method).
+    /// Create an "interned" const from `constant`. This is not normally
+    /// invoked directly; instead, you invoke [`ConstData::intern`]
+    /// (which will ultimately call this method).
     fn intern_const(&self, constant: ConstData<Self>) -> Self::InternedConst;
 
-    /// Lookup the `ConstData` that was interned to create a `InternedConst`.
+    /// Lookup the [`ConstData`] that was interned to create a
+    /// [`InternedConst`](Self::InternedConst).
     fn const_data<'a>(&self, constant: &'a Self::InternedConst) -> &'a ConstData<Self>;
 
     /// Determine whether two concrete const values are equal.
@@ -503,11 +528,12 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
 
     /// Create an "interned" parameter from `data`. This is not
     /// normally invoked directly; instead, you invoke
-    /// `GenericArgData::intern` (which will ultimately call this
+    /// [`GenericArgData::intern`] (which will ultimately call this
     /// method).
     fn intern_generic_arg(&self, data: GenericArgData<Self>) -> Self::InternedGenericArg;
 
-    /// Lookup the `LifetimeData` that was interned to create a `InternedLifetime`.
+    /// Lookup the [`GenericArgData`] that was interned to create a
+    /// [`InternedGenericArg`](Self::InternedGenericArg).
     fn generic_arg_data<'a>(
         &self,
         lifetime: &'a Self::InternedGenericArg,

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -1,5 +1,6 @@
 //! Encapsulates the concrete representation of core types such as types and goals.
 use crate::AliasTy;
+use crate::AssocFnDefId;
 use crate::AssocTypeId;
 use crate::CanonicalVarKind;
 use crate::CanonicalVarKinds;
@@ -7,6 +8,7 @@ use crate::ClosureId;
 use crate::Constraint;
 use crate::Constraints;
 use crate::FnDefId;
+use crate::FnDefTy;
 use crate::ForeignDefId;
 use crate::GeneratorId;
 use crate::GenericArg;
@@ -14,6 +16,7 @@ use crate::GenericArgData;
 use crate::Goal;
 use crate::GoalData;
 use crate::Goals;
+use crate::ImplId;
 use crate::InEnvironment;
 use crate::Lifetime;
 use crate::LifetimeData;
@@ -240,11 +243,29 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
         None
     }
 
+    /// Prints the debug representation of an impl id.
+    /// Returns `None` to fallback to the default debug output (e.g.,
+    /// if no info about current program is available from TLS).
+    #[allow(unused_variables)]
+    fn debug_impl_id(impl_id: ImplId<Self>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
+        None
+    }
+
     /// Prints the debug representation of a associated type id.
     /// Returns `None` to fallback to the default debug output.
     #[allow(unused_variables)]
     fn debug_assoc_type_id(
         type_id: AssocTypeId<Self>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> Option<fmt::Result> {
+        None
+    }
+
+    /// Prints the debug representation of an associated-function-def-id.
+    /// Returns `None` to fallback to the default debug output.
+    #[allow(unused_variables)]
+    fn debug_assoc_fn_def_id(
+        fn_def_id: AssocFnDefId<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
         None
@@ -317,6 +338,16 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     #[allow(unused_variables)]
     fn debug_projection_ty(
         projection_ty: &ProjectionTy<Self>,
+        fmt: &mut fmt::Formatter<'_>,
+    ) -> Option<fmt::Result> {
+        None
+    }
+
+    /// Prints the debug representation of a [`FnDefTy`]
+    /// Returns `None` to fallback to the default debug output.
+    #[allow(unused_variables)]
+    fn debug_fn_def_ty(
+        fn_def_ty: &FnDefTy<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
         None

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -301,7 +301,7 @@ pub enum Mutability {
 /// `forall<T> { Goal(T) }` (syntactical representation)
 /// `forall { Goal(?0) }` (used a DeBruijn index)
 /// `Goal(!U1)` (the quantifier was moved to the environment and replaced with a universe index)
-/// See https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference.html#placeholders-and-universes for more.
+/// See <https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference.html#placeholders-and-universes> for more.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UniverseIndex {
     /// The counter for the universe index, starts with 0.
@@ -376,8 +376,8 @@ pub struct ImplId<I: Interner>(pub I::DefId);
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClauseId<I: Interner>(pub I::DefId);
 
-/// The id for the associated type member of a trait. The details of the type
-/// can be found by invoking the [`associated_ty_data`] method.
+/// The id for the associated type member of a trait. The details of the
+/// type can be found by invoking the [`associated_ty_data`] method.
 ///
 /// [`associated_ty_data`]: ../chalk_solve/trait.RustIrDatabase.html#tymethod.associated_ty_data
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -405,14 +405,14 @@ pub struct ForeignDefId<I: Interner>(pub I::DefId);
 
 impl_debugs!(ImplId, ClauseId);
 
-/// A Rust type. The actual type data is stored in `TyKind`.
+/// A Rust type. The actual type data is stored in [`TyKind`].
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasInterner)]
 pub struct Ty<I: Interner> {
     interned: I::InternedType,
 }
 
 impl<I: Interner> Ty<I> {
-    /// Creates a type from `TyKind`.
+    /// Creates a type from [`TyKind`].
     pub fn new(interner: &I, data: impl CastTo<TyKind<I>>) -> Self {
         let ty_kind = data.cast(&interner);
         Ty {
@@ -1424,14 +1424,14 @@ impl<I: Interner> VariableKind<I> {
     }
 }
 
-/// A generic argument, see `GenericArgData` for more information.
+/// A generic argument, see [`GenericArgData`] for more information.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasInterner)]
 pub struct GenericArg<I: Interner> {
     interned: I::InternedGenericArg,
 }
 
 impl<I: Interner> GenericArg<I> {
-    /// Constructs a generic argument using `GenericArgData`.
+    /// Constructs a generic argument using [`GenericArgData`].
     pub fn new(interner: &I, data: GenericArgData<I>) -> Self {
         let interned = I::intern_generic_arg(interner, data);
         GenericArg { interned }
@@ -2113,7 +2113,7 @@ impl<T: HasInterner> Binders<T> {
     }
 
     /// Skips the binder and returns the "bound" value as well as the skipped free variables. This
-    /// is just as risky as [`skip_binders`].
+    /// is just as risky as [`skip_binders`](Self::skip_binders).
     pub fn into_value_and_skipped_binders(self) -> (T, VariableKinds<T::Interner>) {
         (self.value, self.binders)
     }
@@ -2366,6 +2366,8 @@ impl<I: Interner> ProgramClauseData<I> {
 }
 
 /// A program clause is a logic expression used to describe a part of the program.
+///
+/// See [`ProgramClauseData`] for the interned data.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, HasInterner)]
 pub struct ProgramClause<I: Interner> {
     interned: I::InternedProgramClause,

--- a/chalk-ir/src/visit.rs
+++ b/chalk-ir/src/visit.rs
@@ -2,8 +2,8 @@
 use std::fmt::Debug;
 
 use crate::{
-    BoundVar, Const, ConstValue, DebruijnIndex, DomainGoal, Goal, InferenceVar, Interner, Lifetime,
-    LifetimeData, PlaceholderIndex, ProgramClause, Ty, TyKind, WhereClause,
+    BoundVar, Const, ConstValue, DebruijnIndex, DomainGoal, FnDefTy, Goal, InferenceVar, Interner,
+    Lifetime, LifetimeData, PlaceholderIndex, ProgramClause, Ty, TyKind, WhereClause,
 };
 
 mod binder_impls;
@@ -321,8 +321,11 @@ where
                 substitution.visit_with(visitor, outer_binder)
             }
             TyKind::Slice(substitution) => substitution.visit_with(visitor, outer_binder),
-            TyKind::FnDef(fn_def, substitution) => {
-                try_break!(fn_def.visit_with(visitor, outer_binder));
+            TyKind::FnDef(FnDefTy {
+                fn_def_id,
+                substitution,
+            }) => {
+                try_break!(fn_def_id.visit_with(visitor, outer_binder));
                 substitution.visit_with(visitor, outer_binder)
             }
             TyKind::Ref(mutability, lifetime, ty) => {

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -5,11 +5,11 @@
 //! The more interesting impls of `Visit` remain in the `visit` module.
 
 use crate::{
-    try_break, AdtId, AssocTypeId, ClausePriority, ClosureId, Constraints, ControlFlow,
-    DebruijnIndex, FloatTy, FnDefId, ForeignDefId, GeneratorId, GenericArg, Goals, ImplId, IntTy,
-    Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauses,
-    QuantifiedWhereClauses, QuantifierKind, Safety, Scalar, Substitution, SuperVisit, TraitId,
-    UintTy, UniverseIndex, Visit, Visitor,
+    try_break, AdtId, AssocFnDefId, AssocTypeId, ClausePriority, ClosureId, Constraints,
+    ControlFlow, DebruijnIndex, FloatTy, FnDefId, ForeignDefId, GeneratorId, GenericArg, Goals,
+    ImplId, IntTy, Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause,
+    ProgramClauses, QuantifiedWhereClauses, QuantifierKind, Safety, Scalar, Substitution,
+    SuperVisit, TraitId, UintTy, UniverseIndex, Visit, Visitor,
 };
 use std::{marker::PhantomData, sync::Arc};
 
@@ -232,6 +232,7 @@ id_visit!(TraitId);
 id_visit!(OpaqueTyId);
 id_visit!(AssocTypeId);
 id_visit!(FnDefId);
+id_visit!(AssocFnDefId);
 id_visit!(ClosureId);
 id_visit!(GeneratorId);
 id_visit!(ForeignDefId);

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -357,6 +357,7 @@ slice_zip!(I => Goals<I>);
 slice_zip!(I => ProgramClauses<I>);
 slice_zip!(I => Constraints<I>);
 slice_zip!(I => QuantifiedWhereClauses<I>);
+slice_zip!(I => Substitution<I>);
 
 impl<T: HasInterner<Interner = I> + Zip<I>, I: Interner> Zip<I> for InEnvironment<T> {
     fn zip_with<'i, Z: Zipper<'i, I>>(

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -333,6 +333,31 @@ eq_zip!(I => ClausePriority);
 eq_zip!(I => Mutability);
 eq_zip!(I => Scalar);
 
+macro_rules! slice_zip {
+    ($I:ident => $t:ty) => {
+        impl<$I: Interner> Zip<$I> for $t {
+            fn zip_with<'i, Z: Zipper<'i, $I>>(
+                zipper: &mut Z,
+                variance: Variance,
+                a: &Self,
+                b: &Self,
+            ) -> Fallible<()>
+            where
+                $I: 'i,
+            {
+                let interner = zipper.interner();
+                Zip::zip_with(zipper, variance, a.as_slice(interner), b.as_slice(interner))?;
+                Ok(())
+            }
+        }
+    };
+}
+
+slice_zip!(I => Goals<I>);
+slice_zip!(I => ProgramClauses<I>);
+slice_zip!(I => Constraints<I>);
+slice_zip!(I => QuantifiedWhereClauses<I>);
+
 impl<T: HasInterner<Interner = I> + Zip<I>, I: Interner> Zip<I> for InEnvironment<T> {
     fn zip_with<'i, Z: Zipper<'i, I>>(
         zipper: &mut Z,
@@ -367,70 +392,6 @@ impl<I: Interner> Zip<I> for Environment<I> {
             a.clauses.as_slice(interner),
             b.clauses.as_slice(interner),
         )?;
-        Ok(())
-    }
-}
-
-impl<I: Interner> Zip<I> for Goals<I> {
-    fn zip_with<'i, Z: Zipper<'i, I>>(
-        zipper: &mut Z,
-        variance: Variance,
-        a: &Self,
-        b: &Self,
-    ) -> Fallible<()>
-    where
-        I: 'i,
-    {
-        let interner = zipper.interner();
-        Zip::zip_with(zipper, variance, a.as_slice(interner), b.as_slice(interner))?;
-        Ok(())
-    }
-}
-
-impl<I: Interner> Zip<I> for ProgramClauses<I> {
-    fn zip_with<'i, Z: Zipper<'i, I>>(
-        zipper: &mut Z,
-        variance: Variance,
-        a: &Self,
-        b: &Self,
-    ) -> Fallible<()>
-    where
-        I: 'i,
-    {
-        let interner = zipper.interner();
-        Zip::zip_with(zipper, variance, a.as_slice(interner), b.as_slice(interner))?;
-        Ok(())
-    }
-}
-
-impl<I: Interner> Zip<I> for Constraints<I> {
-    fn zip_with<'i, Z: Zipper<'i, I>>(
-        zipper: &mut Z,
-        variance: Variance,
-        a: &Self,
-        b: &Self,
-    ) -> Fallible<()>
-    where
-        I: 'i,
-    {
-        let interner = zipper.interner();
-        Zip::zip_with(zipper, variance, a.as_slice(interner), b.as_slice(interner))?;
-        Ok(())
-    }
-}
-
-impl<I: Interner> Zip<I> for QuantifiedWhereClauses<I> {
-    fn zip_with<'i, Z: Zipper<'i, I>>(
-        zipper: &mut Z,
-        variance: Variance,
-        a: &Self,
-        b: &Self,
-    ) -> Fallible<()>
-    where
-        I: 'i,
-    {
-        let interner = zipper.interner();
-        Zip::zip_with(zipper, variance, a.as_slice(interner), b.as_slice(interner))?;
         Ok(())
     }
 }

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -251,24 +251,40 @@ ClosureArgs: Vec<Ty> = {
     "," <args:FnArgs> => args.to_tys(),
 }
 
+TraitItem: TraitItem = {
+    <assoc:AssocTyDefn> => TraitItem::Assoc(assoc),
+    <fndef:FnDefn> => TraitItem::FnDefn(fndef),
+};
+
 TraitDefn: TraitDefn = {
     <auto:AutoKeyword?> <marker:MarkerKeyword?> <upstream:UpstreamKeyword?> <fundamental:FundamentalKeyword?> <non_enumerable:NonEnumerableKeyword?> <coinductive:CoinductiveKeyword?> <object_safe:ObjectSafeKeyword?> <well_known:WellKnownTrait?> "trait" <n:Id><p:Angle<VariableKind>>
-        <w:QuantifiedWhereClauses> "{" <a:AssocTyDefn*> "}" => TraitDefn
-    {
-        name: n,
-        variable_kinds: p,
-        where_clauses: w,
-        assoc_ty_defns: a,
-        well_known,
-        flags: TraitFlags {
-            auto: auto.is_some(),
-            marker: marker.is_some(),
-            upstream: upstream.is_some(),
-            fundamental: fundamental.is_some(),
-            non_enumerable: non_enumerable.is_some(),
-            coinductive: coinductive.is_some(),
-            object_safe: object_safe.is_some(),
-        },
+        <w:QuantifiedWhereClauses> "{" <t:TraitItem*> "}" => {
+        let mut assoc = vec![];
+        let mut fn_defs = vec![];
+        for item in t {
+            match item {
+                TraitItem::Assoc(v) => assoc.push(v),
+                TraitItem::FnDefn(v) => fn_defs.push(v),
+            }
+        }
+
+        TraitDefn {
+            name: n,
+            variable_kinds: p,
+            where_clauses: w,
+            assoc_ty_defns: assoc,
+            fn_defs,
+            well_known,
+            flags: TraitFlags {
+                auto: auto.is_some(),
+                marker: marker.is_some(),
+                upstream: upstream.is_some(),
+                fundamental: fundamental.is_some(),
+                non_enumerable: non_enumerable.is_some(),
+                coinductive: coinductive.is_some(),
+                object_safe: object_safe.is_some(),
+            },
+        }
     }
 };
 
@@ -338,13 +354,30 @@ QuantifiedInlineBound: QuantifiedInlineBound = {
     },
 };
 
+ImplItem: ImplItem = {
+    <assoc:AssocTyValue> => ImplItem::Assoc(assoc),
+    <fndef:FnDefn> => ImplItem::FnDefn(fndef),
+};
+
+
 Impl: Impl = {
-    <external:UpstreamKeyword?> "impl" <p:Angle<VariableKind>> <mark:"!"?> <t:Id> <a:Angle<GenericArg>> "for" <s:Ty>
-        <w:QuantifiedWhereClauses> "{" <assoc:AssocTyValue*> "}" =>
+    <external:UpstreamKeyword?> "impl" <id:ImplId?> <p:Angle<VariableKind>>
+        <mark:"!"?> <t:Id> <a:Angle<GenericArg>> "for" <s:Ty>
+        <w:QuantifiedWhereClauses> "{" <items:ImplItem*> "}" =>
     {
         let mut args = vec![GenericArg::Ty(s)];
         args.extend(a);
+        let mut assoc = vec![];
+        let mut fn_defs = vec![];
+        for item in items {
+            match item {
+                ImplItem::Assoc(v) => assoc.push(v),
+                ImplItem::FnDefn(v) => fn_defs.push(v),
+            }
+        }
+
         Impl {
+            id,
             variable_kinds: p,
             polarity: Polarity::from_bool(mark.is_none()),
             trait_ref: TraitRef {
@@ -353,6 +386,7 @@ Impl: Impl = {
             },
             where_clauses: w,
             assoc_ty_values: assoc,
+            fn_defs,
             impl_type: external.map(|_| ImplType::External).unwrap_or(ImplType::Local),
         }
     },
@@ -425,7 +459,8 @@ TyWithoutId: Ty = {
         lifetime: l,
     },
     <n:Id> "<" <a:Comma<GenericArg>> ">" => Ty::Apply { name: n, args: a },
-    <p:ProjectionTy> => Ty::Projection { proj: p },
+    <p:Projection> => Ty::Projection { proj: p },
+    <f:ImplFnRef> => Ty::ImplFn { func: f },
     "(" <t:TupleOrParensInner> ")" => t,
     "*" <m: RawMutability> <t:Ty> => Ty::Raw{ mutability: m, ty: Box::new(t) },
     "&" <l: Lifetime> "mut" <t:Ty> => Ty::Ref{ mutability: Mutability::Mut, lifetime: l, ty: Box::new(t) },
@@ -463,7 +498,7 @@ FloatTy: FloatTy = {
 ScalarType: ScalarType = {
     <i:IntTy> => ScalarType::Int(i),
     <u:UintTy> => ScalarType::Uint(u),
-    <f:FloatTy> => ScalarType::Float(f), 
+    <f:FloatTy> => ScalarType::Float(f),
     "bool" => ScalarType::Bool,
     "char" => ScalarType::Char,
 };
@@ -507,8 +542,8 @@ GenericArg: GenericArg = {
     ConstWithoutId => GenericArg::Const(<>),
 };
 
-ProjectionTy: ProjectionTy = {
-    "<" <t:TraitRef<"as">> ">" "::" <n:Id> <a:Angle<GenericArg>> => ProjectionTy {
+Projection: Projection = {
+    "<" <t:TraitRef<"as">> ">" "::" <n:Id> <a:Angle<GenericArg>> => Projection {
         trait_ref: t, name: n, args: a
     },
 };
@@ -572,7 +607,7 @@ WhereClause: WhereClause = {
         let mut args = vec![GenericArg::Ty(s)];
         if let Some(a) = a { args.extend(a); }
         let trait_ref = TraitRef { trait_name: t, args: args };
-        let projection = ProjectionTy { trait_ref, name, args: a2 };
+        let projection = Projection { trait_ref, name, args: a2 };
         WhereClause::ProjectionEq { projection, ty }
     },
 
@@ -616,7 +651,10 @@ DomainGoal: DomainGoal = {
     "FromEnv" "(" <t:TraitRef<":">> ")" => DomainGoal::TraitRefFromEnv { trait_ref: t },
 
     // `<T as Foo>::U -> Bar` -- a normalization
-    "Normalize" "(" <s:ProjectionTy> "->" <t:Ty> ")" => DomainGoal::Normalize { projection: s, ty: t },
+    "Normalize" "(" <s:Projection> "->" <t:Ty> ")" => DomainGoal::Normalize { projection: s, ty: t },
+
+    // `<T as Foo>::some_func -> @SomeImpl::some_func` -- a normalization
+    "NormalizeFn" "(" <s:Projection> "->" <t:Ty> ")" => DomainGoal::NormalizeFn { projection: s, ty: t },
 
     "IsLocal" "(" <ty:Ty> ")" => DomainGoal::IsLocal { ty },
     "IsUpstream" "(" <ty:Ty> ")" => DomainGoal::IsUpstream { ty },
@@ -639,6 +677,15 @@ LeafGoal: LeafGoal = {
 
     "Subtype" "(" <a:Ty> "," <b:Ty> ")" => LeafGoal::SubtypeGenericArgs { a, b },
 };
+
+// @ImplName::f<A, B>
+ImplFnRef: ImplFnRef = {
+    <imp:ImplId> "::" <f:Id> <a:Angle<GenericArg>> => ImplFnRef {
+        impl_name: imp,
+        fn_name: f,
+        args: a,
+    },
+}
 
 TraitRef<S>: TraitRef = {
     <s:Ty> S <t:Id> <a:Angle<GenericArg>> => {
@@ -694,6 +741,13 @@ Id: Identifier = {
 
 LifetimeId: Identifier = {
     <l:@L> <s:r"'([A-Za-z]|_)([A-Za-z0-9]|_)*"> <r:@R> => Identifier {
+        str: Atom::from(s),
+        span: Span::new(l, r),
+    }
+};
+
+ImplId: Identifier = {
+    <l:@L> "@" <s:r"([A-Za-z]|_)([A-Za-z0-9]|_)*"> <r:@R> => Identifier {
         str: Atom::from(s),
         span: Span::new(l, r),
     }

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -39,7 +39,7 @@ fn constituent_types<I: Interner>(db: &dyn RustIrDatabase<I>, ty: &TyKind<I>) ->
         // And for `PhantomData<T>`, we pass `T`.
         TyKind::Adt(_, substitution)
         | TyKind::Tuple(_, substitution)
-        | TyKind::FnDef(_, substitution) => substitution
+        | TyKind::FnDef(FnDefTy { substitution, .. }) => substitution
             .iter(interner)
             .filter_map(|x| x.ty(interner))
             .cloned()
@@ -457,7 +457,7 @@ pub fn program_clauses_that_could_match<I: Interner>(
                     let _ = db.adt_datum(*adt_id);
                 }
 
-                TyKind::FnDef(fn_def_id, _) => {
+                TyKind::FnDef(FnDefTy { fn_def_id, .. }) => {
                     let _ = db.fn_def_datum(*fn_def_id);
                 }
 
@@ -881,7 +881,7 @@ fn match_ty<I: Interner>(
             .db
             .associated_ty_data(*type_id)
             .to_program_clauses(builder, environment),
-        TyKind::FnDef(fn_def_id, _) => builder
+        TyKind::FnDef(FnDefTy { fn_def_id, .. }) => builder
             .db
             .fn_def_datum(*fn_def_id)
             .to_program_clauses(builder, environment),

--- a/chalk-solve/src/clauses/builtin_traits/copy.rs
+++ b/chalk-solve/src/clauses/builtin_traits/copy.rs
@@ -45,7 +45,7 @@ pub fn add_copy_program_clauses<I: Interner>(
         TyKind::Array(ty, _) => {
             needs_impl_for_tys(db, builder, trait_ref, iter::once(ty.clone()));
         }
-        TyKind::FnDef(_, _) => {
+        TyKind::FnDef(_) => {
             builder.push_fact(trait_ref);
         }
         TyKind::Closure(closure_id, ref substitution) => {

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -3,8 +3,8 @@ use crate::rust_ir::{ClosureKind, FnDefInputsAndOutputDatum, WellKnownTrait};
 use crate::{Interner, RustIrDatabase, TraitRef};
 use chalk_ir::cast::Cast;
 use chalk_ir::{
-    AliasTy, Binders, Floundered, Normalize, ProjectionTy, Safety, Substitution, TraitId, Ty,
-    TyKind,
+    AliasTy, Binders, Floundered, FnDefTy, Normalize, ProjectionTy, Safety, Substitution, TraitId,
+    Ty, TyKind,
 };
 
 fn push_clauses<I: Interner>(
@@ -91,7 +91,10 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
     let trait_id = db.well_known_trait_id(well_known).unwrap();
 
     match self_ty.kind(interner) {
-        TyKind::FnDef(fn_def_id, substitution) => {
+        TyKind::FnDef(FnDefTy {
+            fn_def_id,
+            substitution,
+        }) => {
             let fn_def_datum = builder.db.fn_def_datum(*fn_def_id);
             if fn_def_datum.sig.safety == Safety::Safe && !fn_def_datum.sig.variadic {
                 let bound = fn_def_datum

--- a/chalk-solve/src/clauses/builtin_traits/sized.rs
+++ b/chalk-solve/src/clauses/builtin_traits/sized.rs
@@ -83,7 +83,7 @@ pub fn add_sized_program_clauses<I: Interner>(
         TyKind::Array(_, _)
         | TyKind::Never
         | TyKind::Closure(_, _)
-        | TyKind::FnDef(_, _)
+        | TyKind::FnDef(_)
         | TyKind::Scalar(_)
         | TyKind::Raw(_, _)
         | TyKind::Generator(_, _)

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -189,9 +189,12 @@ impl<I: Interner> ToProgramClauses<I> for AssociatedFnValue<I> {
                 .into_iter()
                 .map(|wc| wc.cloned().substitute(interner, impl_params));
 
+            let impl_where_clauses = impl_where_clauses.collect::<Vec<_>>();
+            tracing::debug!(impl_where_clauses = ?impl_where_clauses);
+
             // 2. any where-clauses from the `fn` declaration in the trait: the
             //    parameters must be substituted with those of the impl
-            let assoc_ty_where_clauses = associated_fn
+            let assoc_fn_where_clauses = associated_fn
                 .binders
                 .map_ref(|b| &b.where_clauses)
                 .into_iter()
@@ -217,7 +220,7 @@ impl<I: Interner> ToProgramClauses<I> for AssociatedFnValue<I> {
                     })
                     .intern(interner),
                 ),
-                impl_where_clauses.chain(assoc_ty_where_clauses),
+                impl_where_clauses.into_iter().chain(assoc_fn_where_clauses),
             );
         });
     }

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -470,7 +470,11 @@ impl<I: Interner> ToProgramClauses<I> for FnDefDatum<I> {
         let binders = self.binders.map_ref(|b| &b.where_clauses).cloned();
 
         builder.push_binders(binders, |builder, where_clauses| {
-            let ty = TyKind::FnDef(self.id, builder.substitution_in_scope()).intern(interner);
+            let ty = TyKind::FnDef(FnDefTy {
+                fn_def_id: self.id,
+                substitution: builder.substitution_in_scope(),
+            })
+            .intern(interner);
 
             well_formed_program_clauses(builder, ty.clone(), where_clauses.iter());
 

--- a/chalk-solve/src/display/stub.rs
+++ b/chalk-solve/src/display/stub.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::rust_ir::{GeneratorDatum, GeneratorWitnessDatum};
 use crate::{
     rust_ir::{
-        AdtDatumBound, AdtKind, AdtVariantDatum, AssociatedTyDatumBound, FnDefDatumBound,
+        AdtDatumBound, AdtKind, AdtVariantDatum, AssociatedItemDatumBound, FnDefDatumBound,
         OpaqueTyDatumBound, TraitDatumBound,
     },
     RustIrDatabase,
@@ -48,12 +48,20 @@ impl<I: Interner, DB: RustIrDatabase<I>> RustIrDatabase<I> for StubWrapper<'_, D
         let mut v = (*self.db.associated_ty_data(ty)).clone();
         v.binders = Binders::new(
             v.binders.binders.clone(),
-            AssociatedTyDatumBound {
+            AssociatedItemDatumBound {
                 where_clauses: Vec::new(),
                 bounds: Vec::new(),
             },
         );
         Arc::new(v)
+    }
+
+    fn associated_fn_data(
+        &self,
+        f: chalk_ir::AssocFnDefId<I>,
+    ) -> std::sync::Arc<crate::rust_ir::AssociatedFnDatum<I>> {
+        // there are no binders in here to stub out, those would be dealt with with FnDef
+        self.db.associated_fn_data(f)
     }
 
     fn trait_datum(
@@ -117,6 +125,13 @@ impl<I: Interner, DB: RustIrDatabase<I>> RustIrDatabase<I> for StubWrapper<'_, D
         _id: crate::rust_ir::AssociatedTyValueId<I>,
     ) -> std::sync::Arc<crate::rust_ir::AssociatedTyValue<I>> {
         unreachable!("associated type values should never be stubbed")
+    }
+
+    fn associated_fn_value(
+        &self,
+        _id: crate::rust_ir::AssociatedFnValueId<I>,
+    ) -> std::sync::Arc<crate::rust_ir::AssociatedFnValue<I>> {
+        unreachable!("associated function values should never be stubbed")
     }
 
     fn opaque_ty_data(

--- a/chalk-solve/src/display/utils.rs
+++ b/chalk-solve/src/display/utils.rs
@@ -24,7 +24,7 @@ macro_rules! write_joined_non_empty_list {
     }};
 }
 
-/// Processes a name given by an [`Interner`][chalk_ir::Interner] debug
+/// Processes a name given by an [`Interner`][chalk_ir::interner::Interner] debug
 /// method into something usable by the `display` module.
 ///
 /// This is specifically useful when implementing

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -21,7 +21,7 @@ impl<I: Interner> InferenceTable<I> {
     /// negation-as-failure paper [1], where negative goals are only
     /// permitted if they contain no free (existential) variables.
     ///
-    /// [1] https://www.doc.ic.ac.uk/~klc/NegAsFailure.pdf
+    /// [1]: https://www.doc.ic.ac.uk/~klc/NegAsFailure.pdf
     ///
     /// Restricting free existential variables is done because the
     /// semantics of such queries is not what you expect: it basically

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -73,7 +73,7 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// Returns the datum for the impl with the given id.
     fn impl_datum(&self, impl_id: ImplId<I>) -> Arc<ImplDatum<I>>;
 
-    /// Returns the `AssociatedTyValue` with the given id.
+    /// Returns the [`AssociatedTyValue`] with the given id.
     fn associated_ty_value(&self, id: AssociatedTyValueId<I>) -> Arc<AssociatedTyValue<I>>;
 
     /// Returns the `OpaqueTyDatum` with the given id.

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -49,6 +49,9 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// Returns the datum for the associated type with the given id.
     fn associated_ty_data(&self, ty: AssocTypeId<I>) -> Arc<AssociatedTyDatum<I>>;
 
+    /// Returns the datum for the associated fn with the given id.
+    fn associated_fn_data(&self, f: AssocFnDefId<I>) -> Arc<AssociatedFnDatum<I>>;
+
     /// Returns the datum for the definition with the given id.
     fn trait_datum(&self, trait_id: TraitId<I>) -> Arc<TraitDatum<I>>;
 
@@ -76,7 +79,10 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// Returns the [`AssociatedTyValue`] with the given id.
     fn associated_ty_value(&self, id: AssociatedTyValueId<I>) -> Arc<AssociatedTyValue<I>>;
 
-    /// Returns the `OpaqueTyDatum` with the given id.
+    /// Returns the [`AssociatedFnValue`] with the given id.
+    fn associated_fn_value(&self, id: AssociatedFnValueId<I>) -> Arc<AssociatedFnValue<I>>;
+
+    /// Returns the [`OpaqueTyDatum`] with the given id.
     fn opaque_ty_data(&self, id: OpaqueTyId<I>) -> Arc<OpaqueTyDatum<I>>;
 
     /// Returns the "hidden type" corresponding with the opaque type.

--- a/chalk-solve/src/logging_db.rs
+++ b/chalk-solve/src/logging_db.rs
@@ -128,6 +128,15 @@ where
         ty_datum
     }
 
+    fn associated_fn_data(
+        &self,
+        f: chalk_ir::AssocFnDefId<I>,
+    ) -> Arc<crate::rust_ir::AssociatedFnDatum<I>> {
+        let datum = self.ws.db().associated_fn_data(f);
+        self.record(datum.trait_id);
+        datum
+    }
+
     fn trait_datum(&self, trait_id: TraitId<I>) -> Arc<TraitDatum<I>> {
         self.record(trait_id);
         self.ws.db().trait_datum(trait_id)
@@ -171,6 +180,15 @@ where
         id: crate::rust_ir::AssociatedTyValueId<I>,
     ) -> Arc<crate::rust_ir::AssociatedTyValue<I>> {
         let value = self.ws.db().associated_ty_value(id);
+        self.record(value.impl_id);
+        value
+    }
+
+    fn associated_fn_value(
+        &self,
+        id: crate::rust_ir::AssociatedFnValueId<I>,
+    ) -> Arc<crate::rust_ir::AssociatedFnValue<I>> {
+        let value = self.ws.db().associated_fn_value(id);
         self.record(value.impl_id);
         value
     }
@@ -395,6 +413,13 @@ where
         self.db.associated_ty_data(ty)
     }
 
+    fn associated_fn_data(
+        &self,
+        f: chalk_ir::AssocFnDefId<I>,
+    ) -> Arc<crate::rust_ir::AssociatedFnDatum<I>> {
+        self.db.associated_fn_data(f)
+    }
+
     fn trait_datum(&self, trait_id: TraitId<I>) -> Arc<TraitDatum<I>> {
         self.db.trait_datum(trait_id)
     }
@@ -428,6 +453,13 @@ where
         id: crate::rust_ir::AssociatedTyValueId<I>,
     ) -> Arc<crate::rust_ir::AssociatedTyValue<I>> {
         self.db.associated_ty_value(id)
+    }
+
+    fn associated_fn_value(
+        &self,
+        id: crate::rust_ir::AssociatedFnValueId<I>,
+    ) -> Arc<crate::rust_ir::AssociatedFnValue<I>> {
+        self.db.associated_fn_value(id)
     }
 
     fn opaque_ty_data(&self, id: OpaqueTyId<I>) -> Arc<OpaqueTyDatum<I>> {

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -4,7 +4,7 @@ use chalk_ir::{
     interner::Interner,
     visit::{ControlFlow, Visitor},
     visit::{SuperVisit, Visit},
-    AliasTy, DebruijnIndex, TyKind, WhereClause,
+    AliasTy, DebruijnIndex, FnDefTy, TyKind, WhereClause,
 };
 use std::collections::BTreeSet;
 
@@ -134,7 +134,7 @@ where
     ) -> ControlFlow<()> {
         match ty.kind(self.db.interner()) {
             TyKind::Adt(adt, _) => self.record(*adt),
-            TyKind::FnDef(fn_def, _) => self.record(*fn_def),
+            TyKind::FnDef(FnDefTy { fn_def_id, .. }) => self.record(*fn_def_id),
             TyKind::OpaqueType(opaque, _) => self.record(*opaque),
             TyKind::Alias(alias) => self.visit_alias(&alias),
             TyKind::BoundVar(..) => (),

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -22,15 +22,21 @@ pub struct AssociatedTyValueId<I: Interner>(pub I::DefId);
 chalk_ir::id_visit!(AssociatedTyValueId);
 chalk_ir::id_fold!(AssociatedTyValueId);
 
+/// Data about a trait implementation.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Visit)]
 pub struct ImplDatum<I: Interner> {
+    /// Whether this is an `impl Trait` or `impl !Trait`
     pub polarity: Polarity,
+    /// Bindings of variables from the where clauses in the trait.
     pub binders: Binders<ImplDatumBound<I>>,
+    /// Whether this impl is local to this crate or from an external crate
     pub impl_type: ImplType,
+    /// IDs for associated types `type T = SomeTy`
     pub associated_ty_value_ids: Vec<AssociatedTyValueId<I>>,
 }
 
 impl<I: Interner> ImplDatum<I> {
+    /// True if this is an `impl Trait`, false if `impl !Trait`
     pub fn is_positive(&self) -> bool {
         self.polarity.is_positive()
     }
@@ -39,6 +45,7 @@ impl<I: Interner> ImplDatum<I> {
         self.binders.skip_binders().trait_ref.trait_id
     }
 
+    /// Gets the [`AdtId`] for the `Self` type of this impl.
     pub fn self_type_adt_id(&self, interner: &I) -> Option<AdtId<I>> {
         match self
             .binders
@@ -59,6 +66,7 @@ pub struct ImplDatumBound<I: Interner> {
     pub where_clauses: Vec<QuantifiedWhereClause<I>>,
 }
 
+/// Whether this impl is local to this crate or from an external crate
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ImplType {
     Local,
@@ -713,7 +721,9 @@ pub struct GeneratorWitnessExistential<I: Interner> {
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 pub enum Polarity {
+    /// `impl Trait for ..`
     Positive,
+    /// `impl !Trait for ..`
     Negative,
 }
 

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -596,14 +596,13 @@ pub struct AssociatedTyValue<I: Interner> {
     /// ```
     pub associated_ty_id: AssocTypeId<I>,
 
-    /// Additional binders declared on the associated type itself,
-    /// beyond those from the impl. This would be empty for normal
-    /// associated types, but non-empty for generic associated types.
+    /// All the binders declared on the impl and the associated type.
     ///
     /// ```ignore
     /// impl<T> Iterable for Vec<T> {
+    ///   // ^ refers to these generics here
     ///     type Iter<'a> = vec::Iter<'a, T>;
-    ///           // ^^^^ refers to these generics here
+    ///           // ^^^^ and here
     /// }
     /// ```
     pub value: Binders<AssociatedTyValueBound<I>>,

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -607,7 +607,7 @@ fn compute_assoc_ty_goal<I: Interner>(
                 //     * original in trait, `Self: 'a`
                 //     * after substituting impl parameters, `Box<!T>: '!a`
                 let assoc_ty_datum = db.associated_ty_data(projection.associated_ty_id);
-                let AssociatedTyDatumBound {
+                let AssociatedItemDatumBound {
                     bounds: defn_bounds,
                     where_clauses: defn_where_clauses,
                 } = assoc_ty_datum

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -895,8 +895,8 @@ impl WfWellKnownConstraints {
 
     /// Verify constraints a CoerceUnsized impl.
     /// Rules for CoerceUnsized impl to be considered well-formed:
-    /// a) pointer conversions: &[mut] T -> &[mut] U, &[mut] T -> *[mut] U,
-    ///    *[mut] T -> *[mut] U are considered valid if
+    /// a) pointer conversions: `&[mut] T` -> `&[mut] U`, `&[mut] T` -> `*[mut] U`,
+    ///    `*[mut] T` -> `*[mut] U` are considered valid if
     ///    1) T: Unsize<U>
     ///    2) mutability is respected, i.e. immutable -> immutable, mutable -> immutable,
     ///       mutable -> mutable conversions are allowed, immutable -> mutable is not.

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -135,9 +135,12 @@ impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
                 push_ty();
                 substitution.visit_with(self, outer_binder)
             }
-            TyKind::FnDef(fn_def, substitution) => {
+            TyKind::FnDef(FnDefTy {
+                fn_def_id,
+                substitution,
+            }) => {
                 push_ty();
-                fn_def.visit_with(self, outer_binder);
+                fn_def_id.visit_with(self, outer_binder);
                 substitution.visit_with(self, outer_binder)
             }
             TyKind::Ref(mutability, lifetime, ty) => {

--- a/tests/display/unique_names.rs
+++ b/tests/display/unique_names.rs
@@ -64,6 +64,12 @@ where
     ) -> std::sync::Arc<chalk_solve::rust_ir::AssociatedTyDatum<I>> {
         self.db.associated_ty_data(ty)
     }
+    fn associated_fn_data(
+        &self,
+        f: chalk_ir::AssocFnDefId<I>,
+    ) -> Arc<chalk_solve::rust_ir::AssociatedFnDatum<I>> {
+        self.db.associated_fn_data(f)
+    }
     fn trait_datum(
         &self,
         trait_id: chalk_ir::TraitId<I>,
@@ -96,6 +102,12 @@ where
         id: chalk_solve::rust_ir::AssociatedTyValueId<I>,
     ) -> std::sync::Arc<chalk_solve::rust_ir::AssociatedTyValue<I>> {
         self.db.associated_ty_value(id)
+    }
+    fn associated_fn_value(
+        &self,
+        id: chalk_solve::rust_ir::AssociatedFnValueId<I>,
+    ) -> std::sync::Arc<chalk_solve::rust_ir::AssociatedFnValue<I>> {
+        self.db.associated_fn_value(id)
     }
     fn generator_datum(
         &self,

--- a/tests/integration/panic.rs
+++ b/tests/integration/panic.rs
@@ -58,6 +58,10 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
         unimplemented!()
     }
 
+    fn associated_fn_data(&self, f: AssocFnDefId<ChalkIr>) -> Arc<AssociatedFnDatum<ChalkIr>> {
+        unimplemented!()
+    }
+
     // `trait Bar`, id `0`
     fn trait_datum(&self, id: TraitId<ChalkIr>) -> Arc<TraitDatum<ChalkIr>> {
         if let PanickingMethod::TraitDatum = self.panicking_method {
@@ -82,6 +86,7 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
                 coinductive: false,
             },
             associated_ty_ids: vec![],
+            fn_defs: vec![],
             well_known: None,
         })
     }
@@ -115,6 +120,7 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
             binders,
             impl_type: ImplType::Local,
             associated_ty_value_ids: vec![],
+            associated_fn_value_ids: vec![],
         })
     }
 
@@ -122,6 +128,13 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
         &self,
         id: AssociatedTyValueId<ChalkIr>,
     ) -> Arc<AssociatedTyValue<ChalkIr>> {
+        unimplemented!()
+    }
+
+    fn associated_fn_value(
+        &self,
+        id: AssociatedFnValueId<ChalkIr>,
+    ) -> Arc<AssociatedFnValue<ChalkIr>> {
         unimplemented!()
     }
 

--- a/tests/test/impls.rs
+++ b/tests/test/impls.rs
@@ -677,3 +677,121 @@ fn unify_types_in_impl() {
         }
     }
 }
+
+#[test]
+fn impl_function_basic() {
+    test! {
+        program {
+            trait Trait {
+                fn a();
+            }
+
+            struct A {}
+            struct B {}
+
+            impl@Impl Trait for A {
+                fn a();
+            }
+
+            impl@NotImpl Trait for B {
+                fn a();
+            }
+        }
+
+        goal {
+            exists <F> {
+                NormalizeFn(<A as Trait>::a -> F)
+            }
+        } yields {
+            "Unique; substitution [?0 := {impl @Impl}::a], lifetime constraints []"
+        }
+    }
+}
+
+#[test]
+fn impl_function_basic_generics() {
+    test! {
+        program {
+            trait Trait<T> {
+                fn a();
+            }
+
+            struct A<T> {}
+            struct B<T> {}
+            struct C {}
+
+            impl@Impl<T> Trait<T> for A<T> {
+                fn a();
+            }
+            impl@NotImpl<T> Trait<T> for B<T> {
+                fn a();
+            }
+        }
+
+        goal {
+            exists <F> {
+                NormalizeFn(<A<C> as Trait<C>>::a -> F)
+            }
+        } yields {
+            "Unique; substitution [?0 := {impl @Impl}::a<C>], lifetime constraints []"
+        }
+    }
+}
+
+#[test]
+fn impl_function_tautology() {
+    test! {
+        program {
+            trait Trait<T> {
+                fn a();
+            }
+
+            struct A<T> {}
+            struct B<T> {}
+            struct C {}
+
+            impl@Impl<T> Trait<T> for A<T> {
+                fn a();
+            }
+            impl@NotImpl<T> Trait<T> for B<T> {
+                fn a();
+            }
+        }
+
+        goal {
+            NormalizeFn(<A<C> as Trait<C>>::a -> @Impl::a<C>)
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+    }
+}
+
+#[test]
+fn impl_function_generic_arg() {
+    test! {
+        program {
+            trait Trait<T> {
+                fn a(v: T);
+            }
+
+            struct A<T> {}
+            struct B<T> {}
+            struct C {}
+
+            impl@Impl<T> Trait<T> for A<T> {
+                fn a(v: T);
+            }
+            impl@NotImpl<T> Trait<T> for B<T> {
+                fn a(v: T);
+            }
+        }
+
+        goal {
+            exists <F> {
+                NormalizeFn(<A<C> as Trait<C>>::a -> F)
+            }
+        } yields {
+            "Unique; substitution [?0 := {impl @Impl}::a<C>], lifetime constraints []"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #716
Related to https://github.com/rust-analyzer/rust-analyzer/issues/4558

This adds a NormalizeFn domain goal that's analogous to Normalize for types, which can be used to infer the related impl functions.

Along with this, I modify the chalk integration testing system's parser to add syntax naming impls: `impl SomeTrait@MyImpl<T> for SomeType<T>`. Impl functions can be referenced with `@MyImpl::some_func<P1, P2, .....>`. The parser also now supports functions in traits and impls.

The current state of this patch is ready for others to break it ;-) I don't have enough edge cases of traits in my head to think of all the ways to find more bugs in it.

Here is one of the tests from the PR, for context on what it does:

```rust
#[test]
fn impl_function_basic_generics() {
    test! {
        program {
            trait Trait<T> {
                fn a();
            }

            struct A<T> {}
            struct B<T> {}
            struct C {}

            impl@Impl<T> Trait<T> for A<T> {
                fn a();
            }
            impl@NotImpl<T> Trait<T> for B<T> {
                fn a();
            }
        }

        goal {
            exists <F> {
                NormalizeFn(<A<C> as Trait<C>>::a -> F)
            }
        } yields {
            "Unique; substitution [?0 := {impl @Impl}::a<C>], lifetime constraints []"
        }
    }
}
```

This may be generalizable to constants also? I didn't explore this yet. If it's desired to explore it for this PR, I will have to take a break for a while before getting to it.