### PR TITLE
More clause fixes

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -107,8 +107,8 @@ lower_param_map!(
     ))
 );
 
-fn get_type_of_u32() -> chalk_ir::Ty<ChalkIr> {
-    chalk_ir::TyKind::Scalar(chalk_ir::Scalar::Uint(chalk_ir::UintTy::U32)).intern(&ChalkIr)
+fn get_type_of_usize() -> chalk_ir::Ty<ChalkIr> {
+    chalk_ir::TyKind::Scalar(chalk_ir::Scalar::Uint(chalk_ir::UintTy::Usize)).intern(&ChalkIr)
 }
 
 impl Lower for VariableKind {
@@ -128,7 +128,7 @@ impl Lower for VariableKind {
                 n,
             ),
             VariableKind::Lifetime(n) => (chalk_ir::VariableKind::Lifetime, n),
-            VariableKind::Const(ref n) => (chalk_ir::VariableKind::Const(get_type_of_u32()), n),
+            VariableKind::Const(ref n) => (chalk_ir::VariableKind::Const(get_type_of_usize()), n),
         };
 
         chalk_ir::WithKind::new(kind, n.str.clone())
@@ -830,7 +830,7 @@ impl LowerWithEnv for Const {
                     .map(|c| c.clone())
             }
             Const::Value(value) => Ok(chalk_ir::ConstData {
-                ty: get_type_of_u32(),
+                ty: get_type_of_usize(),
                 value: chalk_ir::ConstValue::Concrete(chalk_ir::ConcreteConst { interned: *value }),
             }
             .intern(interner)),

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -28,6 +28,10 @@ pub fn add_builtin_program_clauses<I: Interner>(
         let ty = self_ty.kind(db.interner()).clone();
 
         match well_known {
+            // There are no builtin impls provided for the following traits:
+            WellKnownTrait::Unpin | WellKnownTrait::Drop | WellKnownTrait::CoerceUnsized => (),
+            // Built-in traits are non-enumerable.
+            _ if self_ty.is_general_var(db.interner(), binders) => return Err(Floundered),
             WellKnownTrait::Sized => {
                 sized::add_sized_program_clauses(db, builder, trait_ref, ty, binders)?;
             }
@@ -48,8 +52,6 @@ pub fn add_builtin_program_clauses<I: Interner>(
             WellKnownTrait::Generator => {
                 generator::add_generator_program_clauses(db, builder, self_ty)?;
             }
-            // There are no builtin impls provided for the following traits:
-            WellKnownTrait::Unpin | WellKnownTrait::Drop | WellKnownTrait::CoerceUnsized => (),
         }
         Ok(())
     })

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -156,8 +156,6 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
             });
             Ok(())
         }
-        // Function traits are non-enumerable
-        TyKind::InferenceVar(..) | TyKind::BoundVar(_) | TyKind::Alias(..) => Err(Floundered),
         _ => Ok(()),
     }
 }

--- a/tests/lowering/mod.rs
+++ b/tests/lowering/mod.rs
@@ -806,8 +806,7 @@ fn algebraic_data_types() {
                 type Owned: Borrow<Self>;
             }
 
-            // FIXME(#435) should be `B: 'a + ToOwned`
-            enum Cow<'a, B> where B: ToOwned {
+            enum Cow<'a, B> where B: ToOwned, B: 'a {
                 Borrowed(&'a B),
                 Owned(<B as ToOwned>::Owned),
             }

--- a/tests/test/arrays.rs
+++ b/tests/test/arrays.rs
@@ -102,16 +102,37 @@ fn arrays_are_not_clone_if_element_not_clone() {
 }
 
 #[test]
-fn arrays_are_well_formed() {
+fn arrays_are_well_formed_if_elem_sized() {
     test! {
-        program { }
+        program {
+            #[lang(sized)]
+            trait Sized { }
+        }
+
+        goal {
+            forall<const N, T> {
+                if (T: Sized) {
+                    WellFormed([T; N])
+                }
+            }
+        } yields {
+            "Unique"
+        }
 
         goal {
             forall<const N, T> {
                 WellFormed([T; N])
             }
         } yields {
-            "Unique"
+            "No possible solution"
+        }
+
+        goal {
+            exists<const N, T> {
+                WellFormed([T; N])
+            }
+        } yields {
+            "Ambiguous; no inference guidance"
         }
     }
 }

--- a/tests/test/cycle.rs
+++ b/tests/test/cycle.rs
@@ -226,7 +226,6 @@ fn infinite_recursion() {
 fn cycle_with_ambiguity() {
     test! {
         program {
-            #[non_enumerable]
             #[lang(sized)]
             trait Sized { }
             trait From<T> {}

--- a/tests/test/existential_types.rs
+++ b/tests/test/existential_types.rs
@@ -417,3 +417,20 @@ fn dyn_associated_type_binding() {
         }
     }
 }
+
+#[test]
+fn dyn_well_formed() {
+    test! {
+        program {
+            trait MyTrait {}
+        }
+
+        goal {
+            exists<'s> {
+                WellFormed(dyn MyTrait + 's)
+            }
+        } yields {
+            "Unique"
+        }
+    }
+}

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -815,7 +815,7 @@ fn env_bound_vars() {
                 }
             }
         } yields {
-            "Unique"
+            "Ambiguous; definite substitution for<?U0> { [?0 := '^0.0] }"
         }
         goal {
             exists<'a> {

--- a/tests/test/refs.rs
+++ b/tests/test/refs.rs
@@ -3,12 +3,24 @@ use super::*;
 #[test]
 fn immut_refs_are_well_formed() {
     test! {
-        program { }
+        program {
+            struct A { }
+        }
 
         goal {
-            forall<'a, T> { WellFormed(&'a T) }
+            forall<'a, T> {
+                WellFormed(&'a T)
+            }
         } yields {
-            "Unique; substitution [], lifetime constraints []"
+            "Unique; substitution [], lifetime constraints [InEnvironment { environment: Env([]), goal: !1_1: '!1_0 }]"
+        }
+
+        goal {
+            exists<'a> {
+                WellFormed(&'a A)
+            }
+        } yields {
+            "Unique; for<?U0> { substitution [?0 := '^0.0], lifetime constraints [InEnvironment { environment: Env([]), goal: A: '^0.0 }] }"
         }
     }
 }
@@ -37,7 +49,7 @@ fn mut_refs_are_well_formed() {
         goal {
             forall<'a, T> { WellFormed(&'a mut T) }
         } yields {
-            "Unique; substitution [], lifetime constraints []"
+            "Unique; substitution [], lifetime constraints [InEnvironment { environment: Env([]), goal: !1_1: '!1_0 }]"
         }
     }
 }

--- a/tests/test/slices.rs
+++ b/tests/test/slices.rs
@@ -17,15 +17,23 @@ fn slices_are_not_sized() {
 }
 
 #[test]
-fn slices_are_well_formed() {
+fn slices_are_well_formed_if_elem_sized() {
     test! {
         program {
+            #[lang(sized)]
+            trait Sized { }
+        }
+
+        goal {
+            forall<T> { if (T: Sized) { WellFormed([T]) } }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
         }
 
         goal {
             forall<T> { WellFormed([T]) }
         } yields {
-            "Unique; substitution [], lifetime constraints []"
+            "No possible solution"
         }
     }
 }

--- a/tests/test/tuples.rs
+++ b/tests/test/tuples.rs
@@ -230,3 +230,67 @@ fn tuples_are_clone() {
         }
     }
 }
+
+#[test]
+fn tuples_are_wf() {
+    test! {
+        program {
+            #[lang(sized)]
+            trait Sized { }
+        }
+
+        goal {
+            WellFormed(())
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            WellFormed((u8,))
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            WellFormed((u8, u8))
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            WellFormed(([u8],))
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            WellFormed((u8, [u8]))
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+
+        goal {
+            WellFormed(([u8], u8))
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            exists<T> { WellFormed((T, u8)) }
+        } yields {
+            "Ambiguous; no inference guidance"
+        }
+
+        goal {
+            forall<T> { WellFormed((T, u8)) }
+        } yields {
+            "No possible solution"
+        }
+
+        goal {
+            forall<T> { if (T: Sized) { WellFormed((T, u8)) } }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+    }
+}

--- a/tests/test/tuples.rs
+++ b/tests/test/tuples.rs
@@ -39,10 +39,6 @@ fn tuple_trait_impl() {
 fn tuples_are_copy() {
     test! {
         program {
-            // FIXME: If we don't declare Copy non-enumerable, `exists<T> { T:
-            // Copy }` gives wrong results, because it doesn't consider the
-            // built-in impls.
-            #[non_enumerable]
             #[lang(copy)]
             trait Copy { }
 
@@ -107,8 +103,6 @@ fn tuples_are_sized() {
         program {
             #[lang(sized)]
             trait Sized { }
-
-            trait Foo {}
         }
 
         goal {
@@ -179,7 +173,6 @@ fn tuples_are_sized() {
 fn tuples_are_clone() {
     test! {
         program {
-            #[non_enumerable] // see above
             #[lang(clone)]
             trait Clone { }
 

--- a/tests/test/wf_goals.rs
+++ b/tests/test/wf_goals.rs
@@ -107,3 +107,16 @@ fn drop_compatible() {
         }
     }
 }
+
+#[test]
+fn placeholder_wf() {
+    test! {
+        program { }
+
+        goal {
+            forall<T> { WellFormed(T) }
+        } yields {
+            "Unique; substitution [], lifetime constraints []"
+        }
+    }
+}

--- a/tests/test/wf_lowering.rs
+++ b/tests/test/wf_lowering.rs
@@ -1286,7 +1286,7 @@ fn coerce_unsized_struct() {
             #[lang(coerce_unsized)]
             trait CoerceUnsized<T> {}
 
-            struct Foo<'a, T> {
+            struct Foo<'a, T> where T: 'a {
                 t: &'a T
             }
 


### PR DESCRIPTION
- Makes all traits with built-in implementations effectively non-enumerable
- Handle clause generation for trait objects with escaping canonical vars
- Check more things for some of the clauses for `WellFormed`
- Make const generics have type `usize` in chalk-integration