### PR TITLE
Replace `ControlFlow` with version in std

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -181,14 +181,14 @@ fn derive_any_visit(
                 &self,
                 visitor: &mut dyn ::chalk_ir::visit::Visitor < 'i, #interner, BreakTy = B >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
-            ) -> ::chalk_ir::visit::ControlFlow<B>
+            ) -> std::ops::ControlFlow<B>
             where
                 #interner: 'i
             {
                 match *self {
                     #body
                 }
-                ::chalk_ir::visit::ControlFlow::CONTINUE
+                std::ops::ControlFlow::Continue(())
             }
         },
     )

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -58,11 +58,11 @@ use std::usize;
 
 use chalk_derive::{Fold, HasInterner, Visit};
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::ControlFlow;
 use chalk_ir::{
     AnswerSubst, Canonical, ConstrainedSubst, Constraint, DebruijnIndex, Goal, InEnvironment,
     Substitution,
 };
+use std::ops::ControlFlow;
 
 pub mod context;
 mod derived;

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -9,9 +9,10 @@ extern crate self as chalk_ir;
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
 use crate::fold::{Fold, Folder, Subst, SuperFold};
-use crate::visit::{ControlFlow, SuperVisit, Visit, VisitExt, Visitor};
+use crate::visit::{SuperVisit, Visit, VisitExt, Visitor};
 use chalk_derive::{Fold, HasInterner, SuperVisit, Visit, Zip};
 use std::marker::PhantomData;
+use std::ops::ControlFlow;
 
 pub use crate::debug::SeparatorTraitRef;
 #[macro_use(bitflags)]

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -26,7 +26,7 @@ where
     for e in it {
         try_break!(e.visit_with(visitor, outer_binder));
     }
-    ControlFlow::CONTINUE
+    ControlFlow::Continue(())
 }
 
 impl<T: Visit<I>, I: Interner> Visit<I> for &T {
@@ -104,7 +104,7 @@ macro_rules! tuple_visit {
                 $(
                     try_break!($n.visit_with(visitor, outer_binder));
                 )*
-                ControlFlow::CONTINUE
+                ControlFlow::Continue(())
             }
         }
     }
@@ -126,7 +126,7 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Option<T> {
     {
         match self {
             Some(e) => e.visit_with(visitor, outer_binder),
-            None => ControlFlow::CONTINUE,
+            None => ControlFlow::Continue(()),
         }
     }
 }
@@ -186,7 +186,7 @@ macro_rules! const_visit {
             where
                 I: 'i,
             {
-                ControlFlow::CONTINUE
+                ControlFlow::Continue(())
             }
         }
     };
@@ -220,7 +220,7 @@ macro_rules! id_visit {
             where
                 I: 'i,
             {
-                ControlFlow::CONTINUE
+                ControlFlow::Continue(())
             }
         }
     };
@@ -305,6 +305,6 @@ impl<I: Interner> Visit<I> for PhantomData<I> {
     where
         I: 'i,
     {
-        ControlFlow::CONTINUE
+        ControlFlow::Continue(())
     }
 }

--- a/chalk-ir/src/visit/visitors.rs
+++ b/chalk-ir/src/visit/visitors.rs
@@ -6,11 +6,11 @@ use crate::{BoundVar, ControlFlow, DebruijnIndex, Interner, Visit, Visitor};
 pub trait VisitExt<I: Interner>: Visit<I> {
     /// Check whether there are free (non-bound) variables.
     fn has_free_vars(&self, interner: &I) -> bool {
-        self.visit_with(
+        let flow = self.visit_with(
             &mut FindFreeVarsVisitor { interner },
             DebruijnIndex::INNERMOST,
-        )
-        .is_break()
+        );
+        matches!(flow, ControlFlow::Break(_))
     }
 }
 
@@ -36,6 +36,6 @@ impl<'i, I: Interner> Visitor<'i, I> for FindFreeVarsVisitor<'i, I> {
         _bound_var: BoundVar,
         _outer_binder: DebruijnIndex,
     ) -> ControlFlow<()> {
-        ControlFlow::BREAK
+        ControlFlow::Break(())
     }
 }

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -8,9 +8,10 @@ use crate::RustIrDatabase;
 use crate::Ty;
 use crate::{debug_span, TyKind};
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::{ControlFlow, Visit, Visitor};
+use chalk_ir::visit::{Visit, Visitor};
 use chalk_ir::{DebruijnIndex, Environment};
 use rustc_hash::FxHashSet;
+use std::ops::ControlFlow;
 use tracing::instrument;
 
 /// When proving a `FromEnv` goal, we elaborate all `FromEnv` goals
@@ -71,7 +72,7 @@ impl<'me, 'builder, I: Interner> Visitor<'me, I> for EnvElaborator<'me, 'builder
                     .unwrap()
             }
         }
-        ControlFlow::CONTINUE
+        ControlFlow::Continue(())
     }
 
     fn visit_domain_goal(
@@ -95,12 +96,12 @@ impl<'me, 'builder, I: Interner> Visitor<'me, I> for EnvElaborator<'me, 'builder
                             .associated_ty_data(associated_ty_id)
                             .to_program_clauses(self.builder, self.environment);
                     }
-                    ControlFlow::CONTINUE
+                    ControlFlow::Continue(())
                 }
                 FromEnv::Ty(ty) => ty.visit_with(self, outer_binder),
             }
         } else {
-            ControlFlow::CONTINUE
+            ControlFlow::Continue(())
         }
     }
 }

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,8 +1,9 @@
 use crate::debug_span;
 use chalk_ir::fold::{Fold, Folder};
 use chalk_ir::interner::{HasInterner, Interner};
-use chalk_ir::visit::{ControlFlow, Visit, Visitor};
+use chalk_ir::visit::{Visit, Visitor};
 use chalk_ir::*;
+use std::ops::ControlFlow;
 
 use super::InferenceTable;
 
@@ -215,7 +216,7 @@ where
         _outer_binder: DebruijnIndex,
     ) -> ControlFlow<()> {
         self.universes.add(universe.ui);
-        ControlFlow::CONTINUE
+        ControlFlow::Continue(())
     }
 
     fn forbid_inference_vars(&self) -> bool {

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -2,11 +2,12 @@ use super::RecordedItemId;
 use crate::RustIrDatabase;
 use chalk_ir::{
     interner::Interner,
-    visit::{ControlFlow, Visitor},
+    visit::Visitor,
     visit::{SuperVisit, Visit},
     AliasTy, DebruijnIndex, TyKind, WhereClause,
 };
 use std::collections::BTreeSet;
+use std::ops::ControlFlow;
 
 /// Collects the identifiers needed to resolve all the names for a given
 /// set of identifers, excluding identifiers we already have.

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -7,13 +7,12 @@ use chalk_ir::cast::Cast;
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::interner::Interner;
 use chalk_ir::{
-    try_break,
-    visit::{ControlFlow, Visit},
-    AdtId, AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, FnDefId, GenericArg, ImplId,
-    OpaqueTyId, ProjectionTy, QuantifiedWhereClause, Substitution, ToGenericArg, TraitId, TraitRef,
-    Ty, TyKind, VariableKind, WhereClause, WithKind,
+    try_break, visit::Visit, AdtId, AliasEq, AliasTy, AssocTypeId, Binders, DebruijnIndex, FnDefId,
+    GenericArg, ImplId, OpaqueTyId, ProjectionTy, QuantifiedWhereClause, Substitution,
+    ToGenericArg, TraitId, TraitRef, Ty, TyKind, VariableKind, WhereClause, WithKind,
 };
 use std::iter;
+use std::ops::ControlFlow;
 
 /// Identifier for an "associated type value" found in some impl.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -2,9 +2,10 @@
 
 use crate::infer::InferenceTable;
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::{ControlFlow, SuperVisit, Visit, Visitor};
+use chalk_ir::visit::{SuperVisit, Visit, Visitor};
 use chalk_ir::*;
 use std::cmp::max;
+use std::ops::ControlFlow;
 
 /// "Truncation" (called "abstraction" in the papers referenced below)
 /// refers to the act of modifying a goal or answer that has become
@@ -60,7 +61,7 @@ impl<'infer, 'i, I: Interner> Visitor<'i, I> for TySizeVisitor<'infer, 'i, I> {
     fn visit_ty(&mut self, ty: &Ty<I>, outer_binder: DebruijnIndex) -> ControlFlow<()> {
         if let Some(normalized_ty) = self.infer.normalize_ty_shallow(self.interner, ty) {
             normalized_ty.visit_with(self, outer_binder);
-            return ControlFlow::CONTINUE;
+            return ControlFlow::Continue(());
         }
 
         self.size += 1;
@@ -75,7 +76,7 @@ impl<'infer, 'i, I: Interner> Visitor<'i, I> for TySizeVisitor<'infer, 'i, I> {
         if self.depth == 0 {
             self.size = 0;
         }
-        ControlFlow::CONTINUE
+        ControlFlow::Continue(())
     }
 
     fn interner(&self) -> &'i I {


### PR DESCRIPTION
- Since Rust 1.55, `ControlFlow` is now available in std
- Some functions are not available in std yet, and the functional
  equivalents have been used (e.g. `ControlFlow::Break(())` instead of
  `ControlFlow::BREAK`, etc.)

Closes #725
