### PR TITLE
Fix broken markdown and intr-doc links in documentation

### DIFF
--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -63,8 +63,8 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// `Ty<Self>`, which wraps this type.
     ///
     /// An `InternedType` must be something that can be created from a
-    /// `TyKind` (by the [`intern_ty`] method) and then later
-    /// converted back (by the [`ty_data`] method). The interned form
+    /// `TyKind` (by the [`intern_ty`][Self::intern_ty] method) and then later
+    /// converted back (by the [`ty_data`][Self::ty_data] method). The interned form
     /// must also introduce indirection, either via a `Box`, `&`, or
     /// other pointer type.
     type InternedType: Debug + Clone + Eq + Hash;
@@ -74,8 +74,8 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// `Lifetime<Self>`, which wraps this type.
     ///
     /// An `InternedLifetime` must be something that can be created
-    /// from a `LifetimeData` (by the [`intern_lifetime`] method) and
-    /// then later converted back (by the [`lifetime_data`] method).
+    /// from a `LifetimeData` (by the [`intern_lifetime`][Self::intern_lifetime] method) and
+    /// then later converted back (by the [`lifetime_data`][Self::lifetime_data] method).
     type InternedLifetime: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of const expressions. In normal user code,
@@ -83,8 +83,8 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// `Const<Self>`, which wraps this type.
     ///
     /// An `InternedConst` must be something that can be created
-    /// from a `ConstData` (by the [`intern_const`] method) and
-    /// then later converted back (by the [`const_data`] method).
+    /// from a `ConstData` (by the [`intern_const`][Self::intern_const] method) and
+    /// then later converted back (by the [`const_data`][Self::const_data] method).
     type InternedConst: Debug + Clone + Eq + Hash;
 
     /// "Interned" representation of an evaluated const value.

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -302,7 +302,7 @@ pub enum Mutability {
 /// `forall<T> { Goal(T) }` (syntactical representation)
 /// `forall { Goal(?0) }` (used a DeBruijn index)
 /// `Goal(!U1)` (the quantifier was moved to the environment and replaced with a universe index)
-/// See https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference.html#placeholders-and-universes for more.
+/// See <https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference.html#placeholders-and-universes> for more.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UniverseIndex {
     /// The counter for the universe index, starts with 0.
@@ -2114,7 +2114,7 @@ impl<T: HasInterner> Binders<T> {
     }
 
     /// Skips the binder and returns the "bound" value as well as the skipped free variables. This
-    /// is just as risky as [`skip_binders`].
+    /// is just as risky as [`skip_binders`][Self::skip_binders].
     pub fn into_value_and_skipped_binders(self) -> (T, VariableKinds<T::Interner>) {
         (self.value, self.binders)
     }

--- a/chalk-solve/src/display/utils.rs
+++ b/chalk-solve/src/display/utils.rs
@@ -24,7 +24,7 @@ macro_rules! write_joined_non_empty_list {
     }};
 }
 
-/// Processes a name given by an [`Interner`][chalk_ir::Interner] debug
+/// Processes a name given by an [`Interner`][chalk_ir::interner::Interner] debug
 /// method into something usable by the `display` module.
 ///
 /// This is specifically useful when implementing

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -18,10 +18,10 @@ impl<I: Interner> InferenceTable<I> {
     /// yet been assigned a value, then this function will return
     /// `None`, indicating that we cannot prove negation for this goal
     /// yet.  This follows the approach in Clark's original
-    /// negation-as-failure paper [1], where negative goals are only
+    /// [negation-as-failure paper][1], where negative goals are only
     /// permitted if they contain no free (existential) variables.
     ///
-    /// [1] https://www.doc.ic.ac.uk/~klc/NegAsFailure.pdf
+    /// [1]: https://www.doc.ic.ac.uk/~klc/NegAsFailure.pdf
     ///
     /// Restricting free existential variables is done because the
     /// semantics of such queries is not what you expect: it basically

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -893,16 +893,16 @@ impl WfWellKnownConstraints {
 
     /// Verify constraints a CoerceUnsized impl.
     /// Rules for CoerceUnsized impl to be considered well-formed:
-    /// a) pointer conversions: &[mut] T -> &[mut] U, &[mut] T -> *[mut] U,
-    ///    *[mut] T -> *[mut] U are considered valid if
-    ///    1) T: Unsize<U>
+    /// 1) pointer conversions: `&[mut] T -> &[mut] U`, `&[mut] T -> *[mut] U`,
+    ///    `*[mut] T -> *[mut] U` are considered valid if
+    ///    1) `T: Unsize<U>`
     ///    2) mutability is respected, i.e. immutable -> immutable, mutable -> immutable,
     ///       mutable -> mutable conversions are allowed, immutable -> mutable is not.
-    /// b) struct conversions of structures with the same definition, `S<P0...Pn>` -> `S<Q0...Qn>`.
+    /// 2) struct conversions of structures with the same definition, `S<P0...Pn>` -> `S<Q0...Qn>`.
     ///    To check if this impl is legal, we would walk down the fields of `S`
     ///    and consider their types with both substitutes. We are looking to find
-    ///    exactly one (non-phantom) field that has changed its type (from T to U), and
-    ///    expect T to be unsizeable to U, i.e. T: CoerceUnsized<U>.
+    ///    exactly one (non-phantom) field that has changed its type (from `T` to `U`), and
+    ///    expect `T` to be unsizeable to `U`, i.e. `T: CoerceUnsized<U>`.
     ///
     ///    As an example, consider a struct
     ///    ```rust


### PR DESCRIPTION
Was reading documentation and stumbled across some broken markdown. There are still lots of other broken intra-doc links in the repo, but this covers at least some of them and the more critical issues in `wf.rs`.