### PR TITLE
Use owned copies of Interner rather than refs

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -177,14 +177,11 @@ fn derive_any_visit(
     s.bound_impl(
         quote!(::chalk_ir::visit:: #trait_name <#interner>),
         quote! {
-            fn #method_name <'i, B>(
+            fn #method_name <B>(
                 &self,
-                visitor: &mut dyn ::chalk_ir::visit::Visitor < 'i, #interner, BreakTy = B >,
+                visitor: &mut dyn ::chalk_ir::visit::Visitor < #interner, BreakTy = B >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
-            ) -> std::ops::ControlFlow<B>
-            where
-                #interner: 'i
-            {
+            ) -> std::ops::ControlFlow<B> {
                 match *self {
                     #body
                 }
@@ -241,15 +238,12 @@ fn derive_zip(mut s: synstructure::Structure) -> TokenStream {
         quote!(::chalk_ir::zip::Zip<#interner>),
         quote! {
 
-            fn zip_with<'i, Z: ::chalk_ir::zip::Zipper<'i, #interner>>(
+            fn zip_with<Z: ::chalk_ir::zip::Zipper<#interner>>(
                 zipper: &mut Z,
                 variance: ::chalk_ir::Variance,
                 a: &Self,
                 b: &Self,
-            ) -> ::chalk_ir::Fallible<()>
-            where
-                #interner: 'i,
-                {
+            ) -> ::chalk_ir::Fallible<()> {
                     match (a, b) { #body }
                 }
         },
@@ -299,14 +293,11 @@ fn derive_fold(mut s: synstructure::Structure) -> TokenStream {
         quote! {
             type Result = #result;
 
-            fn fold_with<'i, E>(
+            fn fold_with<E>(
                 self,
-                folder: &mut dyn ::chalk_ir::fold::Folder < 'i, #interner, Error = E >,
+                folder: &mut dyn ::chalk_ir::fold::Folder < #interner, Error = E >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
-            ) -> ::std::result::Result<Self::Result, E>
-            where
-                #interner: 'i,
-            {
+            ) -> ::std::result::Result<Self::Result, E> {
                 Ok(match self { #body })
             }
         },

--- a/chalk-engine/src/slg.rs
+++ b/chalk-engine/src/slg.rs
@@ -91,7 +91,7 @@ pub trait ResolventOps<I: Interner> {
     fn resolvent_clause(
         &mut self,
         ops: &dyn UnificationDatabase<I>,
-        interner: &I,
+        interner: I,
         environment: &Environment<I>,
         goal: &DomainGoal<I>,
         subst: &Substitution<I>,
@@ -100,7 +100,7 @@ pub trait ResolventOps<I: Interner> {
 
     fn apply_answer_subst(
         &mut self,
-        interner: &I,
+        interner: I,
         unification_database: &dyn UnificationDatabase<I>,
         ex_clause: &mut ExClause<I>,
         selected_goal: &InEnvironment<Goal<I>>,
@@ -110,11 +110,11 @@ pub trait ResolventOps<I: Interner> {
 }
 
 trait SubstitutionExt<I: Interner> {
-    fn may_invalidate(&self, interner: &I, subst: &Canonical<Substitution<I>>) -> bool;
+    fn may_invalidate(&self, interner: I, subst: &Canonical<Substitution<I>>) -> bool;
 }
 
 impl<I: Interner> SubstitutionExt<I> for Substitution<I> {
-    fn may_invalidate(&self, interner: &I, subst: &Canonical<Substitution<I>>) -> bool {
+    fn may_invalidate(&self, interner: I, subst: &Canonical<Substitution<I>>) -> bool {
         self.iter(interner)
             .zip(subst.value.iter(interner))
             .any(|(new, current)| MayInvalidate { interner }.aggregate_generic_args(new, current))
@@ -122,11 +122,11 @@ impl<I: Interner> SubstitutionExt<I> for Substitution<I> {
 }
 
 // This is a struct in case we need to add state at any point like in AntiUnifier
-struct MayInvalidate<'i, I> {
-    interner: &'i I,
+struct MayInvalidate<I> {
+    interner: I,
 }
 
-impl<I: Interner> MayInvalidate<'_, I> {
+impl<I: Interner> MayInvalidate<I> {
     fn aggregate_generic_args(&mut self, new: &GenericArg<I>, current: &GenericArg<I>) -> bool {
         let interner = self.interner;
         match (new.data(interner), current.data(interner)) {

--- a/chalk-engine/src/slg/aggregate.rs
+++ b/chalk-engine/src/slg/aggregate.rs
@@ -129,7 +129,7 @@ impl<I: Interner> AggregateOps<I> for SlgContextOps<'_, I> {
 /// u32` and the new answer is `?0 = i32`, then the guidance would
 /// become `?0 = ?X` (where `?X` is some fresh variable).
 fn merge_into_guidance<I: Interner>(
-    interner: &I,
+    interner: I,
     root_goal: &Canonical<InEnvironment<Goal<I>>>,
     guidance: Canonical<Substitution<I>>,
     answer: &Canonical<ConstrainedSubst<I>>,
@@ -184,7 +184,7 @@ fn merge_into_guidance<I: Interner>(
     infer.canonicalize(interner, aggr_subst).quantified
 }
 
-fn is_trivial<I: Interner>(interner: &I, subst: &Canonical<Substitution<I>>) -> bool {
+fn is_trivial<I: Interner>(interner: I, subst: &Canonical<Substitution<I>>) -> bool {
     // A subst is trivial if..
     subst
         .value
@@ -226,13 +226,13 @@ fn is_trivial<I: Interner>(interner: &I, subst: &Canonical<Substitution<I>>) -> 
 /// inference variables.
 ///
 /// [Anti-unification]: https://en.wikipedia.org/wiki/Anti-unification_(computer_science)
-struct AntiUnifier<'infer, 'intern, I: Interner> {
+struct AntiUnifier<'infer, I: Interner> {
     infer: &'infer mut InferenceTable<I>,
     universe: UniverseIndex,
-    interner: &'intern I,
+    interner: I,
 }
 
-impl<I: Interner> AntiUnifier<'_, '_, I> {
+impl<I: Interner> AntiUnifier<'_, I> {
     fn aggregate_tys(&mut self, ty0: &Ty<I>, ty1: &Ty<I>) -> Ty<I> {
         let interner = self.interner;
         match (ty0.kind(interner), ty1.kind(interner)) {
@@ -587,7 +587,7 @@ mod test {
         let mut anti_unifier = AntiUnifier {
             infer: &mut infer,
             universe: UniverseIndex::root(),
-            interner: &ChalkIr,
+            interner: ChalkIr,
         };
 
         let ty = anti_unifier.aggregate_tys(
@@ -601,7 +601,7 @@ mod test {
     #[test]
     fn vec_i32_vs_vec_i32() {
         use chalk_integration::interner::ChalkIr;
-        let interner = &ChalkIr;
+        let interner = ChalkIr;
         let mut infer: InferenceTable<ChalkIr> = InferenceTable::new();
         let mut anti_unifier = AntiUnifier {
             interner,
@@ -620,7 +620,7 @@ mod test {
     #[test]
     fn vec_x_vs_vec_y() {
         use chalk_integration::interner::ChalkIr;
-        let interner = &ChalkIr;
+        let interner = ChalkIr;
         let mut infer: InferenceTable<ChalkIr> = InferenceTable::new();
         let mut anti_unifier = AntiUnifier {
             interner,

--- a/chalk-engine/src/slg/resolvent.rs
+++ b/chalk-engine/src/slg/resolvent.rs
@@ -59,7 +59,7 @@ impl<I: Interner> ResolventOps<I> for InferenceTable<I> {
     fn resolvent_clause(
         &mut self,
         db: &dyn UnificationDatabase<I>,
-        interner: &I,
+        interner: I,
         environment: &Environment<I>,
         goal: &DomainGoal<I>,
         subst: &Substitution<I>,
@@ -214,7 +214,7 @@ impl<I: Interner> ResolventOps<I> for InferenceTable<I> {
     #[instrument(level = "debug", skip(self, interner))]
     fn apply_answer_subst(
         &mut self,
-        interner: &I,
+        interner: I,
         unification_database: &dyn UnificationDatabase<I>,
         ex_clause: &mut ExClause<I>,
         selected_goal: &InEnvironment<Goal<I>>,
@@ -276,13 +276,13 @@ struct AnswerSubstitutor<'t, I: Interner> {
     outer_binder: DebruijnIndex,
 
     ex_clause: &'t mut ExClause<I>,
-    interner: &'t I,
+    interner: I,
     unification_database: &'t dyn UnificationDatabase<I>,
 }
 
 impl<I: Interner> AnswerSubstitutor<'_, I> {
     fn substitute<T: Zip<I>>(
-        interner: &I,
+        interner: I,
         unification_database: &dyn UnificationDatabase<I>,
         table: &mut InferenceTable<I>,
         environment: &Environment<I>,
@@ -306,7 +306,7 @@ impl<I: Interner> AnswerSubstitutor<'_, I> {
 
     fn unify_free_answer_var(
         &mut self,
-        interner: &I,
+        interner: I,
         db: &dyn UnificationDatabase<I>,
         variance: Variance,
         answer_var: BoundVar,
@@ -379,7 +379,7 @@ impl<I: Interner> AnswerSubstitutor<'_, I> {
     }
 }
 
-impl<'i, I: Interner> Zipper<'i, I> for AnswerSubstitutor<'i, I> {
+impl<'i, I: Interner> Zipper<I> for AnswerSubstitutor<'i, I> {
     fn zip_tys(&mut self, variance: Variance, answer: &Ty<I>, pending: &Ty<I>) -> Fallible<()> {
         let interner = self.interner;
 
@@ -721,7 +721,7 @@ impl<'i, I: Interner> Zipper<'i, I> for AnswerSubstitutor<'i, I> {
         Ok(())
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -37,14 +37,11 @@ pub(crate) struct SelectedSubgoal {
 
 impl<I: Interner> Fold<I> for Strand<I> {
     type Result = Strand<I>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         Ok(Strand {
             ex_clause: self.ex_clause.fold_with(folder, outer_binder)?,
             last_pursued_time: self.last_pursued_time,

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -173,8 +173,8 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         chalk_solve::program_clauses_for_env(self, environment)
     }
 
-    fn interner(&self) -> &ChalkIr {
-        &ChalkIr
+    fn interner(&self) -> ChalkIr {
+        ChalkIr
     }
 
     fn is_object_safe(&self, trait_id: TraitId<ChalkIr>) -> bool {

--- a/chalk-integration/src/interner.rs
+++ b/chalk-integration/src/interner.rs
@@ -236,167 +236,167 @@ impl Interner for ChalkIr {
         tls::with_current_program(|prog| Some(prog?.debug_variances(variances, fmt)))
     }
 
-    fn intern_ty(&self, kind: TyKind<ChalkIr>) -> Arc<TyData<ChalkIr>> {
+    fn intern_ty(self, kind: TyKind<ChalkIr>) -> Arc<TyData<ChalkIr>> {
         let flags = kind.compute_flags(self);
         Arc::new(TyData { kind, flags })
     }
 
-    fn ty_data<'a>(&self, ty: &'a Arc<TyData<ChalkIr>>) -> &'a TyData<Self> {
+    fn ty_data<'a>(self, ty: &'a Arc<TyData<ChalkIr>>) -> &'a TyData<Self> {
         ty
     }
 
-    fn intern_lifetime(&self, lifetime: LifetimeData<ChalkIr>) -> LifetimeData<ChalkIr> {
+    fn intern_lifetime(self, lifetime: LifetimeData<ChalkIr>) -> LifetimeData<ChalkIr> {
         lifetime
     }
 
-    fn lifetime_data<'a>(&self, lifetime: &'a LifetimeData<ChalkIr>) -> &'a LifetimeData<ChalkIr> {
+    fn lifetime_data<'a>(self, lifetime: &'a LifetimeData<ChalkIr>) -> &'a LifetimeData<ChalkIr> {
         lifetime
     }
 
-    fn intern_const(&self, constant: ConstData<ChalkIr>) -> Arc<ConstData<ChalkIr>> {
+    fn intern_const(self, constant: ConstData<ChalkIr>) -> Arc<ConstData<ChalkIr>> {
         Arc::new(constant)
     }
 
-    fn const_data<'a>(&self, constant: &'a Arc<ConstData<ChalkIr>>) -> &'a ConstData<ChalkIr> {
+    fn const_data<'a>(self, constant: &'a Arc<ConstData<ChalkIr>>) -> &'a ConstData<ChalkIr> {
         constant
     }
 
-    fn const_eq(&self, _ty: &Arc<TyData<ChalkIr>>, c1: &u32, c2: &u32) -> bool {
+    fn const_eq(self, _ty: &Arc<TyData<ChalkIr>>, c1: &u32, c2: &u32) -> bool {
         c1 == c2
     }
 
-    fn intern_generic_arg(&self, generic_arg: GenericArgData<ChalkIr>) -> GenericArgData<ChalkIr> {
+    fn intern_generic_arg(self, generic_arg: GenericArgData<ChalkIr>) -> GenericArgData<ChalkIr> {
         generic_arg
     }
 
     fn generic_arg_data<'a>(
-        &self,
+        self,
         generic_arg: &'a GenericArgData<ChalkIr>,
     ) -> &'a GenericArgData<ChalkIr> {
         generic_arg
     }
 
-    fn intern_goal(&self, goal: GoalData<ChalkIr>) -> Arc<GoalData<ChalkIr>> {
+    fn intern_goal(self, goal: GoalData<ChalkIr>) -> Arc<GoalData<ChalkIr>> {
         Arc::new(goal)
     }
 
-    fn goal_data<'a>(&self, goal: &'a Arc<GoalData<ChalkIr>>) -> &'a GoalData<ChalkIr> {
+    fn goal_data<'a>(self, goal: &'a Arc<GoalData<ChalkIr>>) -> &'a GoalData<ChalkIr> {
         goal
     }
 
     fn intern_goals<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<Goal<ChalkIr>, E>>,
     ) -> Result<Vec<Goal<ChalkIr>>, E> {
         data.into_iter().collect()
     }
 
-    fn goals_data<'a>(&self, goals: &'a Vec<Goal<ChalkIr>>) -> &'a [Goal<ChalkIr>] {
+    fn goals_data<'a>(self, goals: &'a Vec<Goal<ChalkIr>>) -> &'a [Goal<ChalkIr>] {
         goals
     }
 
     fn intern_substitution<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<GenericArg<ChalkIr>, E>>,
     ) -> Result<Vec<GenericArg<ChalkIr>>, E> {
         data.into_iter().collect()
     }
 
     fn substitution_data<'a>(
-        &self,
+        self,
         substitution: &'a Vec<GenericArg<ChalkIr>>,
     ) -> &'a [GenericArg<ChalkIr>] {
         substitution
     }
 
-    fn intern_program_clause(&self, data: ProgramClauseData<Self>) -> ProgramClauseData<Self> {
+    fn intern_program_clause(self, data: ProgramClauseData<Self>) -> ProgramClauseData<Self> {
         data
     }
 
     fn program_clause_data<'a>(
-        &self,
+        self,
         clause: &'a ProgramClauseData<Self>,
     ) -> &'a ProgramClauseData<Self> {
         clause
     }
 
     fn intern_program_clauses<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<ProgramClause<Self>, E>>,
     ) -> Result<Vec<ProgramClause<Self>>, E> {
         data.into_iter().collect()
     }
 
     fn program_clauses_data<'a>(
-        &self,
+        self,
         clauses: &'a Vec<ProgramClause<Self>>,
     ) -> &'a [ProgramClause<Self>] {
         clauses
     }
 
     fn intern_quantified_where_clauses<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<QuantifiedWhereClause<Self>, E>>,
     ) -> Result<Self::InternedQuantifiedWhereClauses, E> {
         data.into_iter().collect()
     }
 
     fn quantified_where_clauses_data<'a>(
-        &self,
+        self,
         clauses: &'a Self::InternedQuantifiedWhereClauses,
     ) -> &'a [QuantifiedWhereClause<Self>] {
         clauses
     }
     fn intern_generic_arg_kinds<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<VariableKind<ChalkIr>, E>>,
     ) -> Result<Self::InternedVariableKinds, E> {
         data.into_iter().collect()
     }
 
     fn variable_kinds_data<'a>(
-        &self,
+        self,
         variable_kinds: &'a Self::InternedVariableKinds,
     ) -> &'a [VariableKind<ChalkIr>] {
         variable_kinds
     }
 
     fn intern_canonical_var_kinds<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<CanonicalVarKind<ChalkIr>, E>>,
     ) -> Result<Self::InternedCanonicalVarKinds, E> {
         data.into_iter().collect()
     }
 
     fn canonical_var_kinds_data<'a>(
-        &self,
+        self,
         canonical_var_kinds: &'a Self::InternedCanonicalVarKinds,
     ) -> &'a [CanonicalVarKind<ChalkIr>] {
         canonical_var_kinds
     }
 
     fn intern_constraints<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<InEnvironment<Constraint<Self>>, E>>,
     ) -> Result<Self::InternedConstraints, E> {
         data.into_iter().collect()
     }
 
     fn constraints_data<'a>(
-        &self,
+        self,
         constraints: &'a Self::InternedConstraints,
     ) -> &'a [InEnvironment<Constraint<Self>>] {
         constraints
     }
 
     fn intern_variances<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<Variance, E>>,
     ) -> Result<Self::InternedVariances, E> {
         data.into_iter().collect()
     }
 
-    fn variances_data<'a>(&self, variances: &'a Self::InternedVariances) -> &'a [Variance] {
+    fn variances_data<'a>(self, variances: &'a Self::InternedVariances) -> &'a [Variance] {
         variances
     }
 }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -108,7 +108,7 @@ lower_param_map!(
 );
 
 fn get_type_of_usize() -> chalk_ir::Ty<ChalkIr> {
-    chalk_ir::TyKind::Scalar(chalk_ir::Scalar::Uint(chalk_ir::UintTy::Usize)).intern(&ChalkIr)
+    chalk_ir::TyKind::Scalar(chalk_ir::Scalar::Uint(chalk_ir::UintTy::Usize)).intern(ChalkIr)
 }
 
 impl Lower for VariableKind {
@@ -1013,7 +1013,7 @@ impl LowerWithEnv for (&TraitDefn, chalk_ir::TraitId<ChalkIr>) {
 }
 
 pub fn lower_goal(goal: &Goal, program: &LoweredProgram) -> LowerResult<chalk_ir::Goal<ChalkIr>> {
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let associated_ty_lookups: BTreeMap<_, _> = program
         .associated_ty_data
         .iter()
@@ -1154,7 +1154,7 @@ impl Kinded for chalk_ir::VariableKind<ChalkIr> {
 
 impl Kinded for chalk_ir::GenericArg<ChalkIr> {
     fn kind(&self) -> Kind {
-        let interner = &ChalkIr;
+        let interner = ChalkIr;
         match self.data(interner) {
             chalk_ir::GenericArgData::Ty(_) => Kind::Ty,
             chalk_ir::GenericArgData::Lifetime(_) => Kind::Lifetime,

--- a/chalk-integration/src/lowering/env.rs
+++ b/chalk-integration/src/lowering/env.rs
@@ -87,8 +87,8 @@ pub enum TypeLookup<'k> {
 }
 
 impl Env<'_> {
-    pub fn interner(&self) -> &ChalkIr {
-        &ChalkIr
+    pub fn interner(&self) -> ChalkIr {
+        ChalkIr
     }
 
     pub fn lookup_generic_arg(

--- a/chalk-integration/src/lowering/program_lowerer.rs
+++ b/chalk-integration/src/lowering/program_lowerer.rs
@@ -243,16 +243,17 @@ impl ProgramLowerer {
                     let (kind, inputs_and_output) = defn.lower(&empty_env)?;
                     closure_closure_kind.insert(closure_def_id, kind);
                     closure_inputs_and_output.insert(closure_def_id, inputs_and_output);
-                    let upvars = empty_env.in_binders(defn.all_parameters(), |env| {
-                        let upvar_tys: LowerResult<Vec<chalk_ir::Ty<ChalkIr>>> =
-                            defn.upvars.iter().map(|ty| ty.lower(&env)).collect();
-                        let substitution = chalk_ir::Substitution::from_iter(
-                            &ChalkIr,
-                            upvar_tys?.into_iter().map(|ty| ty.cast(&ChalkIr)),
-                        );
-                        Ok(chalk_ir::TyKind::Tuple(defn.upvars.len(), substitution)
-                            .intern(&ChalkIr))
-                    })?;
+                    let upvars =
+                        empty_env.in_binders(defn.all_parameters(), |env| {
+                            let upvar_tys: LowerResult<Vec<chalk_ir::Ty<ChalkIr>>> =
+                                defn.upvars.iter().map(|ty| ty.lower(&env)).collect();
+                            let substitution = chalk_ir::Substitution::from_iter(
+                                ChalkIr,
+                                upvar_tys?.into_iter().map(|ty| ty.cast(ChalkIr)),
+                            );
+                            Ok(chalk_ir::TyKind::Tuple(defn.upvars.len(), substitution)
+                                .intern(ChalkIr))
+                        })?;
                     closure_upvars.insert(closure_def_id, upvars);
                 }
                 Item::TraitDefn(ref trait_defn) => {
@@ -516,7 +517,7 @@ macro_rules! lower_type_kind {
                     sort: TypeSort::$sort,
                     name: self.name.str.clone(),
                     binders: chalk_ir::Binders::new(
-                        VariableKinds::from_iter(&ChalkIr, $params(self).anonymize()),
+                        VariableKinds::from_iter(ChalkIr, $params(self).anonymize()),
                         crate::Unit,
                     ),
                 })

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -527,8 +527,8 @@ impl RustIrDatabase<ChalkIr> for Program {
         chalk_solve::program_clauses_for_env(self, environment)
     }
 
-    fn interner(&self) -> &ChalkIr {
-        &ChalkIr
+    fn interner(&self) -> ChalkIr {
+        ChalkIr
     }
 
     fn is_object_safe(&self, trait_id: TraitId<ChalkIr>) -> bool {

--- a/chalk-integration/src/test_macros.rs
+++ b/chalk-integration/src/test_macros.rs
@@ -9,18 +9,18 @@ macro_rules! ty {
 
             }),
             chalk_ir::Substitution::from_iter(
-                &chalk_integration::interner::ChalkIr,
+                chalk_integration::interner::ChalkIr,
                 vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             ),
         )
-        .intern(&chalk_integration::interner::ChalkIr)
+        .intern(chalk_integration::interner::ChalkIr)
     };
 
     (function $n:tt $($arg:tt)*) => {
         chalk_ir::TyKind::Function(chalk_ir::FnPointer {
             num_binders: $n,
             substitution: chalk_ir::FnSubst(chalk_ir::Substitution::from_iter(
-                &chalk_integration::interner::ChalkIr,
+                chalk_integration::interner::ChalkIr,
                 vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             )),
             sig: chalk_ir::FnSig {
@@ -28,39 +28,39 @@ macro_rules! ty {
                 abi: <chalk_integration::interner::ChalkIr as chalk_ir::interner::Interner>::FnAbi::Rust,
                 variadic: false,
             }
-        }).intern(&chalk_integration::interner::ChalkIr)
+        }).intern(chalk_integration::interner::ChalkIr)
     };
 
     (placeholder $n:expr) => {
         chalk_ir::TyKind::Placeholder(PlaceholderIndex {
             ui: UniverseIndex { counter: $n },
             idx: 0,
-        }).intern(&chalk_integration::interner::ChalkIr)
+        }).intern(chalk_integration::interner::ChalkIr)
     };
 
     (projection (item $n:tt) $($arg:tt)*) => {
             chalk_ir::AliasTy::Projection(chalk_ir::ProjectionTy  {
             associated_ty_id: AssocTypeId(chalk_integration::interner::RawId { index: $n }),
             substitution: chalk_ir::Substitution::from_iter(
-                &chalk_integration::interner::ChalkIr,
+                chalk_integration::interner::ChalkIr,
                 vec![$(arg!($arg)),*] as Vec<chalk_ir::GenericArg<_>>
             ),
-        }).intern(&chalk_integration::interner::ChalkIr)
+        }).intern(chalk_integration::interner::ChalkIr)
     };
 
     (infer $b:expr) => {
         chalk_ir::TyKind::InferenceVar(chalk_ir::InferenceVar::from($b), chalk_ir::TyVariableKind::General)
-            .intern(&chalk_integration::interner::ChalkIr)
+            .intern(chalk_integration::interner::ChalkIr)
     };
 
     (bound $d:tt $b:tt) => {
         chalk_ir::TyKind::BoundVar(chalk_ir::BoundVar::new(chalk_ir::DebruijnIndex::new($d), $b))
-            .intern(&chalk_integration::interner::ChalkIr)
+            .intern(chalk_integration::interner::ChalkIr)
     };
 
     (bound $b:expr) => {
         chalk_ir::TyKind::BoundVar(chalk_ir::BoundVar::new(chalk_ir::DebruijnIndex::INNERMOST, $b))
-            .intern(&chalk_integration::interner::ChalkIr)
+            .intern(chalk_integration::interner::ChalkIr)
     };
 
     (expr $b:expr) => {
@@ -76,14 +76,14 @@ macro_rules! ty {
 macro_rules! arg {
     ((lifetime $b:tt)) => {
         chalk_ir::GenericArg::new(
-            &chalk_integration::interner::ChalkIr,
+            chalk_integration::interner::ChalkIr,
             chalk_ir::GenericArgData::Lifetime(lifetime!($b)),
         )
     };
 
     ($arg:tt) => {
         chalk_ir::GenericArg::new(
-            &chalk_integration::interner::ChalkIr,
+            chalk_integration::interner::ChalkIr,
             chalk_ir::GenericArgData::Ty(ty!($arg)),
         )
     };
@@ -93,22 +93,22 @@ macro_rules! arg {
 macro_rules! lifetime {
     (infer $b:expr) => {
         chalk_ir::LifetimeData::InferenceVar(chalk_ir::InferenceVar::from($b))
-            .intern(&chalk_integration::interner::ChalkIr)
+            .intern(chalk_integration::interner::ChalkIr)
     };
 
     (bound $d:tt $b:tt) => {
         chalk_ir::LifetimeData::BoundVar(chalk_ir::BoundVar::new(chalk_ir::DebruijnIndex::new($d), $b))
-            .intern(&chalk_integration::interner::ChalkIr)
+            .intern(chalk_integration::interner::ChalkIr)
     };
 
     (bound $b:expr) => {
         chalk_ir::LifetimeData::BoundVar(chalk_ir::BoundVar::new(chalk_ir::DebruijnIndex::INNERMOST, $b))
-            .intern(&chalk_integration::interner::ChalkIr)
+            .intern(chalk_integration::interner::ChalkIr)
     };
 
     (placeholder $b:expr) => {
         chalk_ir::LifetimeData::Placeholder(PlaceholderIndex { ui: UniverseIndex { counter: $b }, idx: 0})
-            .intern(&chalk_integration::interner::ChalkIr)
+            .intern(chalk_integration::interner::ChalkIr)
     };
 
     (expr $b:expr) => {
@@ -123,6 +123,6 @@ macro_rules! lifetime {
 #[macro_export]
 macro_rules! empty_substitution {
     () => {
-        chalk_ir::Substitution::empty(&chalk_integration::interner::ChalkIr)
+        chalk_ir::Substitution::empty(chalk_integration::interner::ChalkIr)
     };
 }

--- a/chalk-ir/src/cast.rs
+++ b/chalk-ir/src/cast.rs
@@ -41,7 +41,7 @@ use std::marker::PhantomData;
 /// "cast to T".
 pub trait Cast: Sized {
     /// Cast a value to type `U` using `CastTo`.
-    fn cast<U>(self, interner: &U::Interner) -> U
+    fn cast<U>(self, interner: U::Interner) -> U
     where
         Self: CastTo<U>,
         U: HasInterner,
@@ -58,20 +58,20 @@ impl<T> Cast for T {}
 /// like that.
 pub trait CastTo<T: HasInterner>: Sized {
     /// Cast a value to type `T`.
-    fn cast_to(self, interner: &T::Interner) -> T;
+    fn cast_to(self, interner: T::Interner) -> T;
 }
 
 macro_rules! reflexive_impl {
     (for($($t:tt)*) $u:ty) => {
         impl<$($t)*> CastTo<$u> for $u {
-            fn cast_to(self, _interner: &<$u as HasInterner>::Interner) -> $u {
+            fn cast_to(self, _interner: <$u as HasInterner>::Interner) -> $u {
                 self
             }
         }
     };
     ($u:ty) => {
         impl CastTo<$u> for $u {
-            fn cast_to(self, interner: &<$u as HasInterner>::Interner) -> $u {
+            fn cast_to(self, interner: <$u as HasInterner>::Interner) -> $u {
                 self
             }
         }
@@ -94,25 +94,25 @@ reflexive_impl!(for(I: Interner) CanonicalVarKinds<I>);
 reflexive_impl!(for(I: Interner) Constraint<I>);
 
 impl<I: Interner> CastTo<WhereClause<I>> for TraitRef<I> {
-    fn cast_to(self, _interner: &I) -> WhereClause<I> {
+    fn cast_to(self, _interner: I) -> WhereClause<I> {
         WhereClause::Implemented(self)
     }
 }
 
 impl<I: Interner> CastTo<WhereClause<I>> for AliasEq<I> {
-    fn cast_to(self, _interner: &I) -> WhereClause<I> {
+    fn cast_to(self, _interner: I) -> WhereClause<I> {
         WhereClause::AliasEq(self)
     }
 }
 
 impl<I: Interner> CastTo<WhereClause<I>> for LifetimeOutlives<I> {
-    fn cast_to(self, _interner: &I) -> WhereClause<I> {
+    fn cast_to(self, _interner: I) -> WhereClause<I> {
         WhereClause::LifetimeOutlives(self)
     }
 }
 
 impl<I: Interner> CastTo<WhereClause<I>> for TypeOutlives<I> {
-    fn cast_to(self, _interner: &I) -> WhereClause<I> {
+    fn cast_to(self, _interner: I) -> WhereClause<I> {
         WhereClause::TypeOutlives(self)
     }
 }
@@ -122,7 +122,7 @@ where
     T: CastTo<WhereClause<I>>,
     I: Interner,
 {
-    fn cast_to(self, interner: &I) -> DomainGoal<I> {
+    fn cast_to(self, interner: I) -> DomainGoal<I> {
         DomainGoal::Holds(self.cast(interner))
     }
 }
@@ -131,43 +131,43 @@ impl<T, I: Interner> CastTo<Goal<I>> for T
 where
     T: CastTo<DomainGoal<I>>,
 {
-    fn cast_to(self, interner: &I) -> Goal<I> {
+    fn cast_to(self, interner: I) -> Goal<I> {
         GoalData::DomainGoal(self.cast(interner)).intern(interner)
     }
 }
 
 impl<I: Interner> CastTo<DomainGoal<I>> for Normalize<I> {
-    fn cast_to(self, _interner: &I) -> DomainGoal<I> {
+    fn cast_to(self, _interner: I) -> DomainGoal<I> {
         DomainGoal::Normalize(self)
     }
 }
 
 impl<I: Interner> CastTo<DomainGoal<I>> for WellFormed<I> {
-    fn cast_to(self, _interner: &I) -> DomainGoal<I> {
+    fn cast_to(self, _interner: I) -> DomainGoal<I> {
         DomainGoal::WellFormed(self)
     }
 }
 
 impl<I: Interner> CastTo<DomainGoal<I>> for FromEnv<I> {
-    fn cast_to(self, _interner: &I) -> DomainGoal<I> {
+    fn cast_to(self, _interner: I) -> DomainGoal<I> {
         DomainGoal::FromEnv(self)
     }
 }
 
 impl<I: Interner> CastTo<Goal<I>> for EqGoal<I> {
-    fn cast_to(self, interner: &I) -> Goal<I> {
+    fn cast_to(self, interner: I) -> Goal<I> {
         GoalData::EqGoal(self).intern(interner)
     }
 }
 
 impl<I: Interner> CastTo<Goal<I>> for SubtypeGoal<I> {
-    fn cast_to(self, interner: &I) -> Goal<I> {
+    fn cast_to(self, interner: I) -> Goal<I> {
         GoalData::SubtypeGoal(self).intern(interner)
     }
 }
 
 impl<I: Interner, T: HasInterner<Interner = I> + CastTo<Goal<I>>> CastTo<Goal<I>> for Binders<T> {
-    fn cast_to(self, interner: &I) -> Goal<I> {
+    fn cast_to(self, interner: I) -> Goal<I> {
         GoalData::Quantified(
             QuantifierKind::ForAll,
             self.map(|bound| bound.cast(interner)),
@@ -177,31 +177,31 @@ impl<I: Interner, T: HasInterner<Interner = I> + CastTo<Goal<I>>> CastTo<Goal<I>
 }
 
 impl<I: Interner> CastTo<TyKind<I>> for AliasTy<I> {
-    fn cast_to(self, _interner: &I) -> TyKind<I> {
+    fn cast_to(self, _interner: I) -> TyKind<I> {
         TyKind::Alias(self)
     }
 }
 
 impl<I: Interner> CastTo<GenericArg<I>> for Ty<I> {
-    fn cast_to(self, interner: &I) -> GenericArg<I> {
+    fn cast_to(self, interner: I) -> GenericArg<I> {
         GenericArg::new(interner, GenericArgData::Ty(self))
     }
 }
 
 impl<I: Interner> CastTo<GenericArg<I>> for Lifetime<I> {
-    fn cast_to(self, interner: &I) -> GenericArg<I> {
+    fn cast_to(self, interner: I) -> GenericArg<I> {
         GenericArg::new(interner, GenericArgData::Lifetime(self))
     }
 }
 
 impl<I: Interner> CastTo<GenericArg<I>> for Const<I> {
-    fn cast_to(self, interner: &I) -> GenericArg<I> {
+    fn cast_to(self, interner: I) -> GenericArg<I> {
         GenericArg::new(interner, GenericArgData::Const(self))
     }
 }
 
 impl<I: Interner> CastTo<GenericArg<I>> for GenericArg<I> {
-    fn cast_to(self, _interner: &I) -> GenericArg<I> {
+    fn cast_to(self, _interner: I) -> GenericArg<I> {
         self
     }
 }
@@ -211,7 +211,7 @@ where
     T: CastTo<DomainGoal<I>>,
     I: Interner,
 {
-    fn cast_to(self, interner: &I) -> ProgramClause<I> {
+    fn cast_to(self, interner: I) -> ProgramClause<I> {
         let implication = ProgramClauseImplication {
             consequence: self.cast(interner),
             conditions: Goals::empty(interner),
@@ -229,7 +229,7 @@ where
     I: Interner,
     T: HasInterner<Interner = I> + CastTo<DomainGoal<I>>,
 {
-    fn cast_to(self, interner: &I) -> ProgramClause<I> {
+    fn cast_to(self, interner: I) -> ProgramClause<I> {
         ProgramClauseData(self.map(|bound| ProgramClauseImplication {
             consequence: bound.cast(interner),
             conditions: Goals::empty(interner),
@@ -245,7 +245,7 @@ where
     T: CastTo<U>,
     U: HasInterner,
 {
-    fn cast_to(self, interner: &U::Interner) -> Option<U> {
+    fn cast_to(self, interner: U::Interner) -> Option<U> {
         self.map(|v| v.cast(interner))
     }
 }
@@ -256,7 +256,7 @@ where
     U: HasInterner<Interner = I>,
     I: Interner,
 {
-    fn cast_to(self, interner: &U::Interner) -> InEnvironment<U> {
+    fn cast_to(self, interner: U::Interner) -> InEnvironment<U> {
         self.map(|v| v.cast(interner))
     }
 }
@@ -266,7 +266,7 @@ where
     T: CastTo<U>,
     U: HasInterner,
 {
-    fn cast_to(self, interner: &U::Interner) -> Result<U, E> {
+    fn cast_to(self, interner: U::Interner) -> Result<U, E> {
         self.map(|v| v.cast(interner))
     }
 }
@@ -290,7 +290,7 @@ where
     T: CastTo<U> + HasInterner,
     U: HasInterner<Interner = T::Interner>,
 {
-    fn cast_to(self, interner: &T::Interner) -> Canonical<U> {
+    fn cast_to(self, interner: T::Interner) -> Canonical<U> {
         // Subtle point: It should be ok to re-use the binders here,
         // because `cast()` never introduces new inference variables,
         // nor changes the "substance" of the type we are working
@@ -307,7 +307,7 @@ where
     T: CastTo<U> + HasInterner,
     U: HasInterner,
 {
-    fn cast_to(self, interner: &U::Interner) -> Vec<U> {
+    fn cast_to(self, interner: U::Interner) -> Vec<U> {
         self.into_iter().casted(interner).collect()
     }
 }
@@ -316,19 +316,19 @@ impl<T> CastTo<T> for &T
 where
     T: Clone + HasInterner,
 {
-    fn cast_to(self, _interner: &T::Interner) -> T {
+    fn cast_to(self, _interner: T::Interner) -> T {
         self.clone()
     }
 }
 
 /// An iterator that casts each element to some other type.
-pub struct Casted<'i, IT, U: HasInterner> {
-    interner: &'i U::Interner,
+pub struct Casted<IT, U: HasInterner> {
+    interner: U::Interner,
     iterator: IT,
     _cast: PhantomData<U>,
 }
 
-impl<IT: Iterator, U> Iterator for Casted<'_, IT, U>
+impl<IT: Iterator, U> Iterator for Casted<IT, U>
 where
     IT::Item: CastTo<U>,
     U: HasInterner,
@@ -348,7 +348,7 @@ where
 /// to some other type.
 pub trait Caster: Iterator + Sized {
     /// Cast each element in this iterator.
-    fn casted<U>(self, interner: &U::Interner) -> Casted<'_, Self, U>
+    fn casted<U>(self, interner: U::Interner) -> Casted<Self, U>
     where
         Self::Item: CastTo<U>,
         U: HasInterner,

--- a/chalk-ir/src/could_match.rs
+++ b/chalk-ir/src/could_match.rs
@@ -9,7 +9,7 @@ pub trait CouldMatch<T: ?Sized + HasInterner> {
     /// Checks whether `self` and `other` could possibly match.
     fn could_match(
         &self,
-        interner: &T::Interner,
+        interner: T::Interner,
         db: &dyn UnificationDatabase<T::Interner>,
         other: &T,
     ) -> bool;
@@ -21,7 +21,7 @@ where
     T: Zip<I> + ?Sized + HasInterner<Interner = I>,
     I: Interner,
 {
-    fn could_match(&self, interner: &I, db: &dyn UnificationDatabase<I>, other: &T) -> bool {
+    fn could_match(&self, interner: I, db: &dyn UnificationDatabase<I>, other: &T) -> bool {
         return Zip::zip_with(
             &mut MatchZipper { interner, db },
             Variance::Invariant,
@@ -31,11 +31,11 @@ where
         .is_ok();
 
         struct MatchZipper<'i, I> {
-            interner: &'i I,
+            interner: I,
             db: &'i dyn UnificationDatabase<I>,
         }
 
-        impl<'i, I: Interner> Zipper<'i, I> for MatchZipper<'i, I> {
+        impl<'i, I: Interner> Zipper<I> for MatchZipper<'i, I> {
             fn zip_tys(&mut self, variance: Variance, a: &Ty<I>, b: &Ty<I>) -> Fallible<()> {
                 let interner = self.interner;
                 let matches = |a: &Substitution<I>, b: &Substitution<I>| {
@@ -179,7 +179,7 @@ where
                 Zip::zip_with(self, variance, &a.value, &b.value)
             }
 
-            fn interner(&self) -> &'i I {
+            fn interner(&self) -> I {
                 self.interner
             }
 
@@ -193,7 +193,7 @@ where
 impl<I: Interner> CouldMatch<DomainGoal<I>> for ProgramClauseData<I> {
     fn could_match(
         &self,
-        interner: &I,
+        interner: I,
         db: &dyn UnificationDatabase<I>,
         other: &DomainGoal<I>,
     ) -> bool {
@@ -204,7 +204,7 @@ impl<I: Interner> CouldMatch<DomainGoal<I>> for ProgramClauseData<I> {
 impl<I: Interner> CouldMatch<DomainGoal<I>> for ProgramClause<I> {
     fn could_match(
         &self,
-        interner: &I,
+        interner: I,
         db: &dyn UnificationDatabase<I>,
         other: &DomainGoal<I>,
     ) -> bool {

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -306,7 +306,7 @@ impl<I: Interner> VariableKinds<I> {
     }
 
     /// Helper method for debugging variable kinds.
-    pub fn inner_debug<'a>(&'a self, interner: &'a I) -> VariableKindsInnerDebug<'a, I> {
+    pub fn inner_debug<'a>(&'a self, interner: I) -> VariableKindsInnerDebug<'a, I> {
         VariableKindsInnerDebug {
             variable_kinds: self,
             interner,
@@ -326,7 +326,7 @@ impl<'a, I: Interner> Debug for VariableKindsDebug<'a, I> {
 /// Helper struct for showing debug output for `VariableKinds`.
 pub struct VariableKindsInnerDebug<'a, I: Interner> {
     variable_kinds: &'a VariableKinds<I>,
-    interner: &'a I,
+    interner: I,
 }
 
 impl<'a, I: Interner> Debug for VariableKindsInnerDebug<'a, I> {
@@ -387,7 +387,7 @@ impl<I: Interner> Debug for GoalData<I> {
 /// Helper struct for showing debug output for `Goals`.
 pub struct GoalsDebug<'a, I: Interner> {
     goals: &'a Goals<I>,
-    interner: &'a I,
+    interner: I,
 }
 
 impl<'a, I: Interner> Debug for GoalsDebug<'a, I> {
@@ -406,7 +406,7 @@ impl<'a, I: Interner> Debug for GoalsDebug<'a, I> {
 
 impl<I: Interner> Goals<I> {
     /// Show debug output for `Goals`.
-    pub fn debug<'a>(&'a self, interner: &'a I) -> GoalsDebug<'a, I> {
+    pub fn debug<'a>(&'a self, interner: I) -> GoalsDebug<'a, I> {
         GoalsDebug {
             goals: self,
             interner,
@@ -437,7 +437,7 @@ impl<I: Interner> GenericArgData<I> {
 /// Helper struct for showing debug output for program clause implications.
 pub struct ProgramClauseImplicationDebug<'a, I: Interner> {
     pci: &'a ProgramClauseImplication<I>,
-    interner: &'a I,
+    interner: I,
 }
 
 impl<'a, I: Interner> Debug for ProgramClauseImplicationDebug<'a, I> {
@@ -445,7 +445,7 @@ impl<'a, I: Interner> Debug for ProgramClauseImplicationDebug<'a, I> {
         let ProgramClauseImplicationDebug { pci, interner } = self;
         write!(fmt, "{:?}", pci.consequence)?;
 
-        let conditions = pci.conditions.as_slice(interner);
+        let conditions = pci.conditions.as_slice(*interner);
 
         let conds = conditions.len();
         if conds == 0 {
@@ -462,7 +462,7 @@ impl<'a, I: Interner> Debug for ProgramClauseImplicationDebug<'a, I> {
 
 impl<I: Interner> ProgramClauseImplication<I> {
     /// Show debug output for the program clause implication.
-    pub fn debug<'a>(&'a self, interner: &'a I) -> ProgramClauseImplicationDebug<'a, I> {
+    pub fn debug<'a>(&'a self, interner: I) -> ProgramClauseImplicationDebug<'a, I> {
         ProgramClauseImplicationDebug {
             pci: self,
             interner,
@@ -473,7 +473,7 @@ impl<I: Interner> ProgramClauseImplication<I> {
 /// Helper struct for showing debug output for application types.
 pub struct TyKindDebug<'a, I: Interner> {
     ty: &'a TyKind<I>,
-    interner: &'a I,
+    interner: I,
 }
 
 impl<'a, I: Interner> Debug for TyKindDebug<'a, I> {
@@ -542,7 +542,7 @@ impl<'a, I: Interner> Debug for TyKindDebug<'a, I> {
 
 impl<I: Interner> TyKind<I> {
     /// Show debug output for the application type.
-    pub fn debug<'a>(&'a self, interner: &'a I) -> TyKindDebug<'a, I> {
+    pub fn debug<'a>(&'a self, interner: I) -> TyKindDebug<'a, I> {
         TyKindDebug { ty: self, interner }
     }
 }
@@ -550,7 +550,7 @@ impl<I: Interner> TyKind<I> {
 /// Helper struct for showing debug output for substitutions.
 pub struct SubstitutionDebug<'a, I: Interner> {
     substitution: &'a Substitution<I>,
-    interner: &'a I,
+    interner: I,
 }
 
 impl<'a, I: Interner> Debug for SubstitutionDebug<'a, I> {
@@ -563,7 +563,7 @@ impl<'a, I: Interner> Debug for SubstitutionDebug<'a, I> {
 
         write!(fmt, "[")?;
 
-        for (index, value) in substitution.iter(interner).enumerate() {
+        for (index, value) in substitution.iter(*interner).enumerate() {
             if first {
                 first = false;
             } else {
@@ -581,7 +581,7 @@ impl<'a, I: Interner> Debug for SubstitutionDebug<'a, I> {
 
 impl<I: Interner> Substitution<I> {
     /// Show debug output for the substitution.
-    pub fn debug<'a>(&'a self, interner: &'a I) -> SubstitutionDebug<'a, I> {
+    pub fn debug<'a>(&'a self, interner: I) -> SubstitutionDebug<'a, I> {
         SubstitutionDebug {
             substitution: self,
             interner,
@@ -632,7 +632,7 @@ pub struct SeparatorTraitRef<'me, I: Interner> {
 /// Helper struct for showing debug output for the `SeperatorTraitRef`.
 pub struct SeparatorTraitRefDebug<'a, 'me, I: Interner> {
     separator_trait_ref: &'a SeparatorTraitRef<'me, I>,
-    interner: &'a I,
+    interner: I,
 }
 
 impl<'a, 'me, I: Interner> Debug for SeparatorTraitRefDebug<'a, 'me, I> {
@@ -644,7 +644,7 @@ impl<'a, 'me, I: Interner> Debug for SeparatorTraitRefDebug<'a, 'me, I> {
         let parameters = separator_trait_ref
             .trait_ref
             .substitution
-            .as_slice(interner);
+            .as_slice(*interner);
         write!(
             fmt,
             "{:?}{}{:?}{:?}",
@@ -658,7 +658,7 @@ impl<'a, 'me, I: Interner> Debug for SeparatorTraitRefDebug<'a, 'me, I> {
 
 impl<'me, I: Interner> SeparatorTraitRef<'me, I> {
     /// Show debug output for the `SeperatorTraitRef`.
-    pub fn debug<'a>(&'a self, interner: &'a I) -> SeparatorTraitRefDebug<'a, 'me, I> {
+    pub fn debug<'a>(&'a self, interner: I) -> SeparatorTraitRefDebug<'a, 'me, I> {
         SeparatorTraitRefDebug {
             separator_trait_ref: self,
             interner,
@@ -681,7 +681,7 @@ impl<I: Interner> Debug for TypeOutlives<I> {
 /// Helper struct for showing debug output for projection types.
 pub struct ProjectionTyDebug<'a, I: Interner> {
     projection_ty: &'a ProjectionTy<I>,
-    interner: &'a I,
+    interner: I,
 }
 
 impl<'a, I: Interner> Debug for ProjectionTyDebug<'a, I> {
@@ -694,14 +694,14 @@ impl<'a, I: Interner> Debug for ProjectionTyDebug<'a, I> {
             fmt,
             "({:?}){:?}",
             projection_ty.associated_ty_id,
-            projection_ty.substitution.with_angle(interner)
+            projection_ty.substitution.with_angle(*interner)
         )
     }
 }
 
 impl<I: Interner> ProjectionTy<I> {
     /// Show debug output for the projection type.
-    pub fn debug<'a>(&'a self, interner: &'a I) -> ProjectionTyDebug<'a, I> {
+    pub fn debug<'a>(&'a self, interner: I) -> ProjectionTyDebug<'a, I> {
         ProjectionTyDebug {
             projection_ty: self,
             interner,
@@ -712,7 +712,7 @@ impl<I: Interner> ProjectionTy<I> {
 /// Helper struct for showing debug output for opaque types.
 pub struct OpaqueTyDebug<'a, I: Interner> {
     opaque_ty: &'a OpaqueTy<I>,
-    interner: &'a I,
+    interner: I,
 }
 
 impl<'a, I: Interner> Debug for OpaqueTyDebug<'a, I> {
@@ -725,14 +725,14 @@ impl<'a, I: Interner> Debug for OpaqueTyDebug<'a, I> {
             fmt,
             "{:?}{:?}",
             opaque_ty.opaque_ty_id,
-            opaque_ty.substitution.with_angle(interner)
+            opaque_ty.substitution.with_angle(*interner)
         )
     }
 }
 
 impl<I: Interner> OpaqueTy<I> {
     /// Show debug output for the opaque type.
-    pub fn debug<'a>(&'a self, interner: &'a I) -> OpaqueTyDebug<'a, I> {
+    pub fn debug<'a>(&'a self, interner: I) -> OpaqueTyDebug<'a, I> {
         OpaqueTyDebug {
             opaque_ty: self,
             interner,
@@ -866,7 +866,7 @@ impl<I: Interner> Debug for CanonicalVarKinds<I> {
 
 impl<T: HasInterner + Display> Canonical<T> {
     /// Display the canonicalized item.
-    pub fn display<'a>(&'a self, interner: &'a T::Interner) -> CanonicalDisplay<'a, T> {
+    pub fn display<'a>(&'a self, interner: T::Interner) -> CanonicalDisplay<'a, T> {
         CanonicalDisplay {
             canonical: self,
             interner,
@@ -877,7 +877,7 @@ impl<T: HasInterner + Display> Canonical<T> {
 /// Helper struct for displaying canonicalized items.
 pub struct CanonicalDisplay<'a, T: HasInterner> {
     canonical: &'a Canonical<T>,
-    interner: &'a T::Interner,
+    interner: T::Interner,
 }
 
 impl<'a, T: HasInterner + Display> Display for CanonicalDisplay<'a, T> {
@@ -973,7 +973,7 @@ impl<I: Interner> Display for ConstrainedSubst<I> {
 impl<I: Interner> Substitution<I> {
     /// Displays the substitution in the form `< P0, .. Pn >`, or (if
     /// the substitution is empty) as an empty string.
-    pub fn with_angle(&self, interner: &I) -> Angle<'_, GenericArg<I>> {
+    pub fn with_angle(&self, interner: I) -> Angle<'_, GenericArg<I>> {
         Angle(self.as_slice(interner))
     }
 }

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -7,14 +7,11 @@ use crate::*;
 
 impl<I: Interner> Fold<I> for FnPointer<I> {
     type Result = FnPointer<I>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         let FnPointer {
             num_binders,
             substitution,
@@ -39,14 +36,11 @@ where
     I: Interner,
 {
     type Result = Binders<T::Result>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         let Binders {
             binders: self_binders,
             value: self_value,
@@ -66,14 +60,11 @@ where
     <T as Fold<I>>::Result: HasInterner<Interner = I>,
 {
     type Result = Canonical<T::Result>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         let Canonical {
             binders: self_binders,
             value: self_value,

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -10,28 +10,22 @@ use std::marker::PhantomData;
 
 impl<T: Fold<I>, I: Interner> Fold<I> for Vec<T> {
     type Result = Vec<T::Result>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         in_place::fallible_map_vec(self, |e| e.fold_with(folder, outer_binder))
     }
 }
 
 impl<T: Fold<I>, I: Interner> Fold<I> for Box<T> {
     type Result = Box<T::Result>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         in_place::fallible_map_box(self, |e| e.fold_with(folder, outer_binder))
     }
 }
@@ -40,9 +34,7 @@ macro_rules! tuple_fold {
     ($($n:ident),*) => {
         impl<$($n: Fold<I>,)* I: Interner> Fold<I> for ($($n,)*) {
             type Result = ($($n::Result,)*);
-            fn fold_with<'i, Error>(self, folder: &mut dyn Folder<'i, I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self::Result, Error>
-            where
-                I: 'i,
+            fn fold_with<Error>(self, folder: &mut dyn Folder<I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self::Result, Error>
             {
                 #[allow(non_snake_case)]
                 let ($($n),*) = self;
@@ -59,14 +51,11 @@ tuple_fold!(A, B, C, D, E);
 
 impl<T: Fold<I>, I: Interner> Fold<I> for Option<T> {
     type Result = Option<T::Result>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         match self {
             None => Ok(None),
             Some(e) => Ok(Some(e.fold_with(folder, outer_binder)?)),
@@ -76,14 +65,11 @@ impl<T: Fold<I>, I: Interner> Fold<I> for Option<T> {
 
 impl<I: Interner> Fold<I> for GenericArg<I> {
     type Result = GenericArg<I>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         let interner = folder.interner();
 
         let data = self
@@ -96,14 +82,11 @@ impl<I: Interner> Fold<I> for GenericArg<I> {
 
 impl<I: Interner> Fold<I> for Substitution<I> {
     type Result = Substitution<I>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         let interner = folder.interner();
 
         let folded = self
@@ -116,14 +99,11 @@ impl<I: Interner> Fold<I> for Substitution<I> {
 
 impl<I: Interner> Fold<I> for Goals<I> {
     type Result = Goals<I>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         let interner = folder.interner();
         let folded = self
             .iter(interner)
@@ -135,14 +115,11 @@ impl<I: Interner> Fold<I> for Goals<I> {
 
 impl<I: Interner> Fold<I> for ProgramClauses<I> {
     type Result = ProgramClauses<I>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         let interner = folder.interner();
         let folded = self
             .iter(interner)
@@ -154,14 +131,11 @@ impl<I: Interner> Fold<I> for ProgramClauses<I> {
 
 impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
     type Result = QuantifiedWhereClauses<I>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         let interner = folder.interner();
         let folded = self
             .iter(interner)
@@ -173,14 +147,11 @@ impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
 
 impl<I: Interner> Fold<I> for Constraints<I> {
     type Result = Constraints<I>;
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> Result<Self::Result, E> {
         let interner = folder.interner();
         let folded = self
             .iter(interner)
@@ -196,14 +167,11 @@ macro_rules! copy_fold {
     ($t:ty) => {
         impl<I: Interner> $crate::fold::Fold<I> for $t {
             type Result = Self;
-            fn fold_with<'i, E>(
+            fn fold_with<E>(
                 self,
-                _folder: &mut dyn ($crate::fold::Folder<'i, I, Error = E>),
+                _folder: &mut dyn ($crate::fold::Folder<I, Error = E>),
                 _outer_binder: DebruijnIndex,
-            ) -> ::std::result::Result<Self::Result, E>
-            where
-                I: 'i,
-            {
+            ) -> ::std::result::Result<Self::Result, E> {
                 Ok(self)
             }
         }
@@ -231,14 +199,11 @@ macro_rules! id_fold {
     ($t:ident) => {
         impl<I: Interner> $crate::fold::Fold<I> for $t<I> {
             type Result = $t<I>;
-            fn fold_with<'i, E>(
+            fn fold_with<E>(
                 self,
-                _folder: &mut dyn ($crate::fold::Folder<'i, I, Error = E>),
+                _folder: &mut dyn ($crate::fold::Folder<I, Error = E>),
                 _outer_binder: DebruijnIndex,
-            ) -> ::std::result::Result<Self::Result, E>
-            where
-                I: 'i,
-            {
+            ) -> ::std::result::Result<Self::Result, E> {
                 Ok(self)
             }
         }
@@ -256,27 +221,21 @@ id_fold!(GeneratorId);
 id_fold!(ForeignDefId);
 
 impl<I: Interner> SuperFold<I> for ProgramClauseData<I> {
-    fn super_fold_with<'i, E>(
+    fn super_fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> ::std::result::Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> ::std::result::Result<Self::Result, E> {
         Ok(ProgramClauseData(self.0.fold_with(folder, outer_binder)?))
     }
 }
 
 impl<I: Interner> SuperFold<I> for ProgramClause<I> {
-    fn super_fold_with<'i, E>(
+    fn super_fold_with<E>(
         self,
-        folder: &mut dyn Folder<'i, I, Error = E>,
+        folder: &mut dyn Folder<I, Error = E>,
         outer_binder: DebruijnIndex,
-    ) -> ::std::result::Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> ::std::result::Result<Self::Result, E> {
         let clause = self.data(folder.interner()).clone();
         Ok(clause
             .super_fold_with(folder, outer_binder)?
@@ -287,14 +246,11 @@ impl<I: Interner> SuperFold<I> for ProgramClause<I> {
 impl<I: Interner> Fold<I> for PhantomData<I> {
     type Result = PhantomData<I>;
 
-    fn fold_with<'i, E>(
+    fn fold_with<E>(
         self,
-        _folder: &mut dyn Folder<'i, I, Error = E>,
+        _folder: &mut dyn Folder<I, Error = E>,
         _outer_binder: DebruijnIndex,
-    ) -> ::std::result::Result<Self::Result, E>
-    where
-        I: 'i,
-    {
+    ) -> ::std::result::Result<Self::Result, E> {
         Ok(PhantomData)
     }
 }

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -2,17 +2,17 @@ use super::*;
 use crate::fold::shift::Shift;
 
 /// Substitution used during folding
-pub struct Subst<'s, 'i, I: Interner> {
+pub struct Subst<'s, I: Interner> {
     /// Values to substitute. A reference to a free variable with
     /// index `i` will be mapped to `parameters[i]` -- if `i >
     /// parameters.len()`, then we will leave the variable untouched.
     parameters: &'s [GenericArg<I>],
-    interner: &'i I,
+    interner: I,
 }
 
-impl<I: Interner> Subst<'_, '_, I> {
+impl<I: Interner> Subst<'_, I> {
     /// Applies the substitution by folding
-    pub fn apply<T: Fold<I>>(interner: &I, parameters: &[GenericArg<I>], value: T) -> T::Result {
+    pub fn apply<T: Fold<I>>(interner: I, parameters: &[GenericArg<I>], value: T) -> T::Result {
         value
             .fold_with(
                 &mut Subst {
@@ -25,10 +25,10 @@ impl<I: Interner> Subst<'_, '_, I> {
     }
 }
 
-impl<'i, I: Interner> Folder<'i, I> for Subst<'_, 'i, I> {
+impl<I: Interner> Folder<I> for Subst<'_, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
         self
     }
 
@@ -117,7 +117,7 @@ impl<'i, I: Interner> Folder<'i, I> for Subst<'_, 'i, I> {
         }
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 }

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -57,7 +57,7 @@ use std::sync::Arc;
 /// (e.g., `SourceI` and `TargetI`) -- even if those type parameters
 /// wind up being mapped to the same underlying type families in the
 /// end.
-pub trait Interner: Debug + Copy + Eq + Ord + Hash {
+pub trait Interner: Debug + Copy + Eq + Ord + Hash + Sized {
     /// "Interned" representation of types.  In normal user code,
     /// `Self::InternedType` is not referenced. Instead, we refer to
     /// `Ty<Self>`, which wraps this type.
@@ -470,32 +470,32 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// Create an "interned" type from `ty`. This is not normally
     /// invoked directly; instead, you invoke `TyKind::intern` (which
     /// will ultimately call this method).
-    fn intern_ty(&self, kind: TyKind<Self>) -> Self::InternedType;
+    fn intern_ty(self, kind: TyKind<Self>) -> Self::InternedType;
 
     /// Lookup the `TyKind` from an interned type.
-    fn ty_data<'a>(&self, ty: &'a Self::InternedType) -> &'a TyData<Self>;
+    fn ty_data<'a>(self, ty: &'a Self::InternedType) -> &'a TyData<Self>;
 
     /// Create an "interned" lifetime from `lifetime`. This is not
     /// normally invoked directly; instead, you invoke
     /// `LifetimeData::intern` (which will ultimately call this
     /// method).
-    fn intern_lifetime(&self, lifetime: LifetimeData<Self>) -> Self::InternedLifetime;
+    fn intern_lifetime(self, lifetime: LifetimeData<Self>) -> Self::InternedLifetime;
 
     /// Lookup the `LifetimeData` that was interned to create a `InternedLifetime`.
-    fn lifetime_data<'a>(&self, lifetime: &'a Self::InternedLifetime) -> &'a LifetimeData<Self>;
+    fn lifetime_data<'a>(self, lifetime: &'a Self::InternedLifetime) -> &'a LifetimeData<Self>;
 
     /// Create an "interned" const from `const`. This is not
     /// normally invoked directly; instead, you invoke
     /// `ConstData::intern` (which will ultimately call this
     /// method).
-    fn intern_const(&self, constant: ConstData<Self>) -> Self::InternedConst;
+    fn intern_const(self, constant: ConstData<Self>) -> Self::InternedConst;
 
     /// Lookup the `ConstData` that was interned to create a `InternedConst`.
-    fn const_data<'a>(&self, constant: &'a Self::InternedConst) -> &'a ConstData<Self>;
+    fn const_data<'a>(self, constant: &'a Self::InternedConst) -> &'a ConstData<Self>;
 
     /// Determine whether two concrete const values are equal.
     fn const_eq(
-        &self,
+        self,
         ty: &Self::InternedType,
         c1: &Self::InternedConcreteConst,
         c2: &Self::InternedConcreteConst,
@@ -505,11 +505,11 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// normally invoked directly; instead, you invoke
     /// `GenericArgData::intern` (which will ultimately call this
     /// method).
-    fn intern_generic_arg(&self, data: GenericArgData<Self>) -> Self::InternedGenericArg;
+    fn intern_generic_arg(self, data: GenericArgData<Self>) -> Self::InternedGenericArg;
 
     /// Lookup the `LifetimeData` that was interned to create a `InternedLifetime`.
     fn generic_arg_data<'a>(
-        &self,
+        self,
         lifetime: &'a Self::InternedGenericArg,
     ) -> &'a GenericArgData<Self>;
 
@@ -517,35 +517,35 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// normally invoked directly; instead, you invoke
     /// `GoalData::intern` (which will ultimately call this
     /// method).
-    fn intern_goal(&self, data: GoalData<Self>) -> Self::InternedGoal;
+    fn intern_goal(self, data: GoalData<Self>) -> Self::InternedGoal;
 
     /// Lookup the `GoalData` that was interned to create a `InternedGoal`.
-    fn goal_data<'a>(&self, goal: &'a Self::InternedGoal) -> &'a GoalData<Self>;
+    fn goal_data<'a>(self, goal: &'a Self::InternedGoal) -> &'a GoalData<Self>;
 
     /// Create an "interned" goals from `data`. This is not
     /// normally invoked directly; instead, you invoke
     /// `GoalsData::intern` (which will ultimately call this
     /// method).
     fn intern_goals<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<Goal<Self>, E>>,
     ) -> Result<Self::InternedGoals, E>;
 
     /// Lookup the `GoalsData` that was interned to create a `InternedGoals`.
-    fn goals_data<'a>(&self, goals: &'a Self::InternedGoals) -> &'a [Goal<Self>];
+    fn goals_data<'a>(self, goals: &'a Self::InternedGoals) -> &'a [Goal<Self>];
 
     /// Create an "interned" substitution from `data`. This is not
     /// normally invoked directly; instead, you invoke
     /// `SubstitutionData::intern` (which will ultimately call this
     /// method).
     fn intern_substitution<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<GenericArg<Self>, E>>,
     ) -> Result<Self::InternedSubstitution, E>;
 
     /// Lookup the `SubstitutionData` that was interned to create a `InternedSubstitution`.
     fn substitution_data<'a>(
-        &self,
+        self,
         substitution: &'a Self::InternedSubstitution,
     ) -> &'a [GenericArg<Self>];
 
@@ -553,11 +553,11 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// normally invoked directly; instead, you invoke
     /// `ProgramClauseData::intern` (which will ultimately call this
     /// method).
-    fn intern_program_clause(&self, data: ProgramClauseData<Self>) -> Self::InternedProgramClause;
+    fn intern_program_clause(self, data: ProgramClauseData<Self>) -> Self::InternedProgramClause;
 
     /// Lookup the `ProgramClauseData` that was interned to create a `ProgramClause`.
     fn program_clause_data<'a>(
-        &self,
+        self,
         clause: &'a Self::InternedProgramClause,
     ) -> &'a ProgramClauseData<Self>;
 
@@ -566,13 +566,13 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// `ProgramClauses::from_iter` (which will ultimately call this
     /// method).
     fn intern_program_clauses<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<ProgramClause<Self>, E>>,
     ) -> Result<Self::InternedProgramClauses, E>;
 
     /// Lookup the `ProgramClauseData` that was interned to create a `ProgramClause`.
     fn program_clauses_data<'a>(
-        &self,
+        self,
         clauses: &'a Self::InternedProgramClauses,
     ) -> &'a [ProgramClause<Self>];
 
@@ -581,14 +581,14 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// `QuantifiedWhereClauses::from_iter` (which will ultimately call this
     /// method).
     fn intern_quantified_where_clauses<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<QuantifiedWhereClause<Self>, E>>,
     ) -> Result<Self::InternedQuantifiedWhereClauses, E>;
 
     /// Lookup the slice of `QuantifiedWhereClause` that was interned to
     /// create a `QuantifiedWhereClauses`.
     fn quantified_where_clauses_data<'a>(
-        &self,
+        self,
         clauses: &'a Self::InternedQuantifiedWhereClauses,
     ) -> &'a [QuantifiedWhereClause<Self>];
 
@@ -597,14 +597,14 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// `VariableKinds::from_iter` (which will ultimately call this
     /// method).
     fn intern_generic_arg_kinds<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<VariableKind<Self>, E>>,
     ) -> Result<Self::InternedVariableKinds, E>;
 
     /// Lookup the slice of `VariableKinds` that was interned to
     /// create a `VariableKinds`.
     fn variable_kinds_data<'a>(
-        &self,
+        self,
         variable_kinds: &'a Self::InternedVariableKinds,
     ) -> &'a [VariableKind<Self>];
 
@@ -613,14 +613,14 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// `CanonicalVarKinds::from_iter` (which will ultimately call this
     /// method).
     fn intern_canonical_var_kinds<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<CanonicalVarKind<Self>, E>>,
     ) -> Result<Self::InternedCanonicalVarKinds, E>;
 
     /// Lookup the slice of `CanonicalVariableKind` that was interned to
     /// create a `CanonicalVariableKinds`.
     fn canonical_var_kinds_data<'a>(
-        &self,
+        self,
         canonical_var_kinds: &'a Self::InternedCanonicalVarKinds,
     ) -> &'a [CanonicalVarKind<Self>];
 
@@ -629,14 +629,14 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// `Constraints::from_iter` (which will ultimately call this
     /// method).
     fn intern_constraints<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<InEnvironment<Constraint<Self>>, E>>,
     ) -> Result<Self::InternedConstraints, E>;
 
     /// Lookup the slice of `Constraint` that was interned to
     /// create a `Constraints`.
     fn constraints_data<'a>(
-        &self,
+        self,
         constraints: &'a Self::InternedConstraints,
     ) -> &'a [InEnvironment<Constraint<Self>>];
 
@@ -645,13 +645,13 @@ pub trait Interner: Debug + Copy + Eq + Ord + Hash {
     /// `Variances::from` (which will ultimately call this
     /// method).
     fn intern_variances<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<Variance, E>>,
     ) -> Result<Self::InternedVariances, E>;
 
     /// Lookup the slice of `Variance` that was interned to
     /// create a `Variances`.
-    fn variances_data<'a>(&self, variances: &'a Self::InternedVariances) -> &'a [Variance];
+    fn variances_data<'a>(self, variances: &'a Self::InternedVariances) -> &'a [Variance];
 }
 
 /// Implemented by types that have an associated interner (which

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -159,14 +159,14 @@ impl<I: Interner> Copy for Environment<I> where I::InternedProgramClauses: Copy 
 
 impl<I: Interner> Environment<I> {
     /// Creates a new environment.
-    pub fn new(interner: &I) -> Self {
+    pub fn new(interner: I) -> Self {
         Environment {
             clauses: ProgramClauses::empty(interner),
         }
     }
 
     /// Adds (an iterator of) clauses to the environment.
-    pub fn add_clauses<II>(&self, interner: &I, clauses: II) -> Self
+    pub fn add_clauses<II>(&self, interner: I, clauses: II) -> Self
     where
         II: IntoIterator<Item = ProgramClause<I>>,
     {
@@ -178,7 +178,7 @@ impl<I: Interner> Environment<I> {
 
     /// True if any of the clauses in the environment have a consequence of `Compatible`.
     /// Panics if the conditions or constraints of that clause are not empty.
-    pub fn has_compatible_clause(&self, interner: &I) -> bool {
+    pub fn has_compatible_clause(&self, interner: I) -> bool {
         self.clauses.as_slice(interner).iter().any(|c| {
             let ProgramClauseData(implication) = c.data(interner);
             match implication.skip_binders().consequence {
@@ -414,8 +414,8 @@ pub struct Ty<I: Interner> {
 
 impl<I: Interner> Ty<I> {
     /// Creates a type from `TyKind`.
-    pub fn new(interner: &I, data: impl CastTo<TyKind<I>>) -> Self {
-        let ty_kind = data.cast(&interner);
+    pub fn new(interner: I, data: impl CastTo<TyKind<I>>) -> Self {
+        let ty_kind = data.cast(interner);
         Ty {
             interned: I::intern_ty(interner, ty_kind),
         }
@@ -427,12 +427,12 @@ impl<I: Interner> Ty<I> {
     }
 
     /// Gets the underlying type data.
-    pub fn data(&self, interner: &I) -> &TyData<I> {
+    pub fn data(&self, interner: I) -> &TyData<I> {
         I::ty_data(interner, &self.interned)
     }
 
     /// Gets the underlying type kind.
-    pub fn kind(&self, interner: &I) -> &TyKind<I> {
+    pub fn kind(&self, interner: I) -> &TyKind<I> {
         &I::ty_data(interner, &self.interned).kind
     }
 
@@ -447,12 +447,12 @@ impl<I: Interner> Ty<I> {
     }
 
     /// Creates a domain goal `FromEnv(T)` where `T` is this type.
-    pub fn into_from_env_goal(self, interner: &I) -> DomainGoal<I> {
+    pub fn into_from_env_goal(self, interner: I) -> DomainGoal<I> {
         self.from_env().cast(interner)
     }
 
     /// If this is a `TyKind::BoundVar(d)`, returns `Some(d)` else `None`.
-    pub fn bound_var(&self, interner: &I) -> Option<BoundVar> {
+    pub fn bound_var(&self, interner: I) -> Option<BoundVar> {
         if let TyKind::BoundVar(bv) = self.kind(interner) {
             Some(*bv)
         } else {
@@ -461,7 +461,7 @@ impl<I: Interner> Ty<I> {
     }
 
     /// If this is a `TyKind::InferenceVar(d)`, returns `Some(d)` else `None`.
-    pub fn inference_var(&self, interner: &I) -> Option<InferenceVar> {
+    pub fn inference_var(&self, interner: I) -> Option<InferenceVar> {
         if let TyKind::InferenceVar(depth, _) = self.kind(interner) {
             Some(*depth)
         } else {
@@ -470,7 +470,7 @@ impl<I: Interner> Ty<I> {
     }
 
     /// Returns true if this is a `BoundVar` or an `InferenceVar` of `TyVariableKind::General`.
-    pub fn is_general_var(&self, interner: &I, binders: &CanonicalVarKinds<I>) -> bool {
+    pub fn is_general_var(&self, interner: I, binders: &CanonicalVarKinds<I>) -> bool {
         match self.kind(interner) {
             TyKind::BoundVar(bv)
                 if bv.debruijn == DebruijnIndex::INNERMOST
@@ -485,7 +485,7 @@ impl<I: Interner> Ty<I> {
     }
 
     /// Returns true if this is an `Alias`.
-    pub fn is_alias(&self, interner: &I) -> bool {
+    pub fn is_alias(&self, interner: I) -> bool {
         match self.kind(interner) {
             TyKind::Alias(..) => true,
             _ => false,
@@ -493,7 +493,7 @@ impl<I: Interner> Ty<I> {
     }
 
     /// Returns true if this is an `IntTy` or `UintTy`.
-    pub fn is_integer(&self, interner: &I) -> bool {
+    pub fn is_integer(&self, interner: I) -> bool {
         match self.kind(interner) {
             TyKind::Scalar(Scalar::Int(_)) | TyKind::Scalar(Scalar::Uint(_)) => true,
             _ => false,
@@ -501,7 +501,7 @@ impl<I: Interner> Ty<I> {
     }
 
     /// Returns true if this is a `FloatTy`.
-    pub fn is_float(&self, interner: &I) -> bool {
+    pub fn is_float(&self, interner: I) -> bool {
         match self.kind(interner) {
             TyKind::Scalar(Scalar::Float(_)) => true,
             _ => false,
@@ -509,7 +509,7 @@ impl<I: Interner> Ty<I> {
     }
 
     /// Returns `Some(adt_id)` if this is an ADT, `None` otherwise
-    pub fn adt_id(&self, interner: &I) -> Option<AdtId<I>> {
+    pub fn adt_id(&self, interner: I) -> Option<AdtId<I>> {
         match self.kind(interner) {
             TyKind::Adt(adt_id, _) => Some(*adt_id),
             _ => None,
@@ -519,7 +519,7 @@ impl<I: Interner> Ty<I> {
     /// True if this type contains "bound" types/lifetimes, and hence
     /// needs to be shifted across binders. This is a very inefficient
     /// check, intended only for debug assertions, because I am lazy.
-    pub fn needs_shift(&self, interner: &I) -> bool {
+    pub fn needs_shift(&self, interner: I) -> bool {
         self.has_free_vars(interner)
     }
 }
@@ -683,12 +683,12 @@ where
 
 impl<I: Interner> TyKind<I> {
     /// Casts the type data to a type.
-    pub fn intern(self, interner: &I) -> Ty<I> {
+    pub fn intern(self, interner: I) -> Ty<I> {
         Ty::new(interner, self)
     }
 
     /// Compute type flags for a TyKind
-    pub fn compute_flags(&self, interner: &I) -> TypeFlags {
+    pub fn compute_flags(&self, interner: I) -> TypeFlags {
         match self {
             TyKind::Adt(_, substitution)
             | TyKind::AssociatedType(_, substitution)
@@ -746,7 +746,7 @@ impl<I: Interner> TyKind<I> {
                 }
                 lifetime_flags | dyn_flags
             }
-            TyKind::Alias(alias_ty) => alias_ty.compute_flags(&interner),
+            TyKind::Alias(alias_ty) => alias_ty.compute_flags(interner),
             TyKind::BoundVar(_) => TypeFlags::empty(),
             TyKind::InferenceVar(_, _) => TypeFlags::HAS_TY_INFER,
             TyKind::Function(fn_pointer) => fn_pointer.substitution.0.compute_flags(interner),
@@ -793,17 +793,17 @@ impl BoundVar {
     }
 
     /// Casts the bound variable to a type.
-    pub fn to_ty<I: Interner>(self, interner: &I) -> Ty<I> {
+    pub fn to_ty<I: Interner>(self, interner: I) -> Ty<I> {
         TyKind::<I>::BoundVar(self).intern(interner)
     }
 
     /// Wrap the bound variable in a lifetime.
-    pub fn to_lifetime<I: Interner>(self, interner: &I) -> Lifetime<I> {
+    pub fn to_lifetime<I: Interner>(self, interner: I) -> Lifetime<I> {
         LifetimeData::<I>::BoundVar(self).intern(interner)
     }
 
     /// Wraps the bound variable in a constant.
-    pub fn to_const<I: Interner>(self, interner: &I, ty: Ty<I>) -> Const<I> {
+    pub fn to_const<I: Interner>(self, interner: I, ty: Ty<I>) -> Const<I> {
         ConstData {
             ty,
             value: ConstValue::<I>::BoundVar(self),
@@ -1062,17 +1062,17 @@ impl InferenceVar {
     }
 
     /// Wraps the inference variable in a type.
-    pub fn to_ty<I: Interner>(self, interner: &I, kind: TyVariableKind) -> Ty<I> {
+    pub fn to_ty<I: Interner>(self, interner: I, kind: TyVariableKind) -> Ty<I> {
         TyKind::<I>::InferenceVar(self, kind).intern(interner)
     }
 
     /// Wraps the inference variable in a lifetime.
-    pub fn to_lifetime<I: Interner>(self, interner: &I) -> Lifetime<I> {
+    pub fn to_lifetime<I: Interner>(self, interner: I) -> Lifetime<I> {
         LifetimeData::<I>::InferenceVar(self).intern(interner)
     }
 
     /// Wraps the inference variable in a constant.
-    pub fn to_const<I: Interner>(self, interner: &I, ty: Ty<I>) -> Const<I> {
+    pub fn to_const<I: Interner>(self, interner: I, ty: Ty<I>) -> Const<I> {
         ConstData {
             ty,
             value: ConstValue::<I>::InferenceVar(self),
@@ -1109,7 +1109,7 @@ impl<I: Interner> Copy for FnPointer<I> where I::InternedSubstitution: Copy {}
 
 impl<I: Interner> FnPointer<I> {
     /// Represent the current `Fn` as if it was wrapped in `Binders`
-    pub fn into_binders(self, interner: &I) -> Binders<FnSubst<I>> {
+    pub fn into_binders(self, interner: I) -> Binders<FnSubst<I>> {
         Binders::new(
             VariableKinds::from_iter(
                 interner,
@@ -1120,7 +1120,7 @@ impl<I: Interner> FnPointer<I> {
     }
 
     /// Represent the current `Fn` as if it was wrapped in `Binders`
-    pub fn as_binders(&self, interner: &I) -> Binders<&FnSubst<I>> {
+    pub fn as_binders(&self, interner: I) -> Binders<&FnSubst<I>> {
         Binders::new(
             VariableKinds::from_iter(
                 interner,
@@ -1139,7 +1139,7 @@ pub struct Const<I: Interner> {
 
 impl<I: Interner> Const<I> {
     /// Create a `Const` using something that can be cast to const data.
-    pub fn new(interner: &I, data: impl CastTo<ConstData<I>>) -> Self {
+    pub fn new(interner: I, data: impl CastTo<ConstData<I>>) -> Self {
         Const {
             interned: I::intern_const(interner, data.cast(interner)),
         }
@@ -1151,12 +1151,12 @@ impl<I: Interner> Const<I> {
     }
 
     /// Gets the constant data from the interner.
-    pub fn data(&self, interner: &I) -> &ConstData<I> {
+    pub fn data(&self, interner: I) -> &ConstData<I> {
         I::const_data(interner, &self.interned)
     }
 
     /// If this is a `ConstData::BoundVar(d)`, returns `Some(d)` else `None`.
-    pub fn bound_var(&self, interner: &I) -> Option<BoundVar> {
+    pub fn bound_var(&self, interner: I) -> Option<BoundVar> {
         if let ConstValue::BoundVar(bv) = &self.data(interner).value {
             Some(*bv)
         } else {
@@ -1165,7 +1165,7 @@ impl<I: Interner> Const<I> {
     }
 
     /// If this is a `ConstData::InferenceVar(d)`, returns `Some(d)` else `None`.
-    pub fn inference_var(&self, interner: &I) -> Option<InferenceVar> {
+    pub fn inference_var(&self, interner: I) -> Option<InferenceVar> {
         if let ConstValue::InferenceVar(iv) = &self.data(interner).value {
             Some(*iv)
         } else {
@@ -1175,7 +1175,7 @@ impl<I: Interner> Const<I> {
 
     /// True if this const is a "bound" const, and hence
     /// needs to be shifted across binders. Meant for debug assertions.
-    pub fn needs_shift(&self, interner: &I) -> bool {
+    pub fn needs_shift(&self, interner: I) -> bool {
         match &self.data(interner).value {
             ConstValue::BoundVar(_) => true,
             ConstValue::InferenceVar(_) => false,
@@ -1211,7 +1211,7 @@ impl<I: Interner> Copy for ConstValue<I> where I::InternedConcreteConst: Copy {}
 
 impl<I: Interner> ConstData<I> {
     /// Wraps the constant data in a `Const`.
-    pub fn intern(self, interner: &I) -> Const<I> {
+    pub fn intern(self, interner: I) -> Const<I> {
         Const::new(interner, self)
     }
 }
@@ -1226,7 +1226,7 @@ pub struct ConcreteConst<I: Interner> {
 
 impl<I: Interner> ConcreteConst<I> {
     /// Checks whether two concrete constants are equal.
-    pub fn const_eq(&self, ty: &Ty<I>, other: &ConcreteConst<I>, interner: &I) -> bool {
+    pub fn const_eq(&self, ty: &Ty<I>, other: &ConcreteConst<I>, interner: I) -> bool {
         interner.const_eq(&ty.interned, &self.interned, &other.interned)
     }
 }
@@ -1240,7 +1240,7 @@ pub struct Lifetime<I: Interner> {
 impl<I: Interner> Lifetime<I> {
     /// Create a lifetime from lifetime data
     /// (or something that can be cast to lifetime data).
-    pub fn new(interner: &I, data: impl CastTo<LifetimeData<I>>) -> Self {
+    pub fn new(interner: I, data: impl CastTo<LifetimeData<I>>) -> Self {
         Lifetime {
             interned: I::intern_lifetime(interner, data.cast(interner)),
         }
@@ -1252,12 +1252,12 @@ impl<I: Interner> Lifetime<I> {
     }
 
     /// Gets the lifetime data.
-    pub fn data(&self, interner: &I) -> &LifetimeData<I> {
+    pub fn data(&self, interner: I) -> &LifetimeData<I> {
         I::lifetime_data(interner, &self.interned)
     }
 
     /// If this is a `Lifetime::BoundVar(d)`, returns `Some(d)` else `None`.
-    pub fn bound_var(&self, interner: &I) -> Option<BoundVar> {
+    pub fn bound_var(&self, interner: I) -> Option<BoundVar> {
         if let LifetimeData::BoundVar(bv) = self.data(interner) {
             Some(*bv)
         } else {
@@ -1266,7 +1266,7 @@ impl<I: Interner> Lifetime<I> {
     }
 
     /// If this is a `Lifetime::InferenceVar(d)`, returns `Some(d)` else `None`.
-    pub fn inference_var(&self, interner: &I) -> Option<InferenceVar> {
+    pub fn inference_var(&self, interner: I) -> Option<InferenceVar> {
         if let LifetimeData::InferenceVar(depth) = self.data(interner) {
             Some(*depth)
         } else {
@@ -1276,7 +1276,7 @@ impl<I: Interner> Lifetime<I> {
 
     /// True if this lifetime is a "bound" lifetime, and hence
     /// needs to be shifted across binders. Meant for debug assertions.
-    pub fn needs_shift(&self, interner: &I) -> bool {
+    pub fn needs_shift(&self, interner: I) -> bool {
         match self.data(interner) {
             LifetimeData::BoundVar(_) => true,
             LifetimeData::InferenceVar(_) => false,
@@ -1289,8 +1289,8 @@ impl<I: Interner> Lifetime<I> {
     }
 
     ///compute type flags for Lifetime
-    fn compute_flags(&self, interner: &I) -> TypeFlags {
-        match self.data(&interner) {
+    fn compute_flags(&self, interner: I) -> TypeFlags {
+        match self.data(interner) {
             LifetimeData::InferenceVar(_) => {
                 TypeFlags::HAS_RE_INFER
                     | TypeFlags::HAS_FREE_LOCAL_REGIONS
@@ -1334,7 +1334,7 @@ pub enum LifetimeData<I: Interner> {
 
 impl<I: Interner> LifetimeData<I> {
     /// Wrap the lifetime data in a lifetime.
-    pub fn intern(self, interner: &I) -> Lifetime<I> {
+    pub fn intern(self, interner: I) -> Lifetime<I> {
         Lifetime::new(interner, self)
     }
 }
@@ -1352,17 +1352,17 @@ pub struct PlaceholderIndex {
 
 impl PlaceholderIndex {
     /// Wrap the placeholder instance in a lifetime.
-    pub fn to_lifetime<I: Interner>(self, interner: &I) -> Lifetime<I> {
+    pub fn to_lifetime<I: Interner>(self, interner: I) -> Lifetime<I> {
         LifetimeData::<I>::Placeholder(self).intern(interner)
     }
 
     /// Create an interned type.
-    pub fn to_ty<I: Interner>(self, interner: &I) -> Ty<I> {
+    pub fn to_ty<I: Interner>(self, interner: I) -> Ty<I> {
         TyKind::Placeholder(self).intern(interner)
     }
 
     /// Wrap the placeholder index in a constant.
-    pub fn to_const<I: Interner>(self, interner: &I, ty: Ty<I>) -> Const<I> {
+    pub fn to_const<I: Interner>(self, interner: I, ty: Ty<I>) -> Const<I> {
         ConstData {
             ty,
             value: ConstValue::Placeholder(self),
@@ -1404,7 +1404,7 @@ impl<I: Interner> interner::HasInterner for VariableKind<I> {
 impl<I: Interner> Copy for VariableKind<I> where I::InternedType: Copy {}
 
 impl<I: Interner> VariableKind<I> {
-    fn to_bound_variable(&self, interner: &I, bound_var: BoundVar) -> GenericArg<I> {
+    fn to_bound_variable(&self, interner: I, bound_var: BoundVar) -> GenericArg<I> {
         match self {
             VariableKind::Ty(_) => {
                 GenericArgData::Ty(TyKind::BoundVar(bound_var).intern(interner)).intern(interner)
@@ -1433,7 +1433,7 @@ pub struct GenericArg<I: Interner> {
 
 impl<I: Interner> GenericArg<I> {
     /// Constructs a generic argument using `GenericArgData`.
-    pub fn new(interner: &I, data: GenericArgData<I>) -> Self {
+    pub fn new(interner: I, data: GenericArgData<I>) -> Self {
         let interned = I::intern_generic_arg(interner, data);
         GenericArg { interned }
     }
@@ -1444,27 +1444,27 @@ impl<I: Interner> GenericArg<I> {
     }
 
     /// Gets the underlying data.
-    pub fn data(&self, interner: &I) -> &GenericArgData<I> {
+    pub fn data(&self, interner: I) -> &GenericArgData<I> {
         I::generic_arg_data(interner, &self.interned)
     }
 
     /// Asserts that this is a type argument.
-    pub fn assert_ty_ref(&self, interner: &I) -> &Ty<I> {
+    pub fn assert_ty_ref(&self, interner: I) -> &Ty<I> {
         self.ty(interner).unwrap()
     }
 
     /// Asserts that this is a lifetime argument.
-    pub fn assert_lifetime_ref(&self, interner: &I) -> &Lifetime<I> {
+    pub fn assert_lifetime_ref(&self, interner: I) -> &Lifetime<I> {
         self.lifetime(interner).unwrap()
     }
 
     /// Asserts that this is a constant argument.
-    pub fn assert_const_ref(&self, interner: &I) -> &Const<I> {
+    pub fn assert_const_ref(&self, interner: I) -> &Const<I> {
         self.constant(interner).unwrap()
     }
 
     /// Checks whether the generic argument is a type.
-    pub fn is_ty(&self, interner: &I) -> bool {
+    pub fn is_ty(&self, interner: I) -> bool {
         match self.data(interner) {
             GenericArgData::Ty(_) => true,
             GenericArgData::Lifetime(_) => false,
@@ -1473,7 +1473,7 @@ impl<I: Interner> GenericArg<I> {
     }
 
     /// Returns the type if it is one, `None` otherwise.
-    pub fn ty(&self, interner: &I) -> Option<&Ty<I>> {
+    pub fn ty(&self, interner: I) -> Option<&Ty<I>> {
         match self.data(interner) {
             GenericArgData::Ty(t) => Some(t),
             _ => None,
@@ -1481,7 +1481,7 @@ impl<I: Interner> GenericArg<I> {
     }
 
     /// Returns the lifetime if it is one, `None` otherwise.
-    pub fn lifetime(&self, interner: &I) -> Option<&Lifetime<I>> {
+    pub fn lifetime(&self, interner: I) -> Option<&Lifetime<I>> {
         match self.data(interner) {
             GenericArgData::Lifetime(t) => Some(t),
             _ => None,
@@ -1489,7 +1489,7 @@ impl<I: Interner> GenericArg<I> {
     }
 
     /// Returns the constant if it is one, `None` otherwise.
-    pub fn constant(&self, interner: &I) -> Option<&Const<I>> {
+    pub fn constant(&self, interner: I) -> Option<&Const<I>> {
         match self.data(interner) {
             GenericArgData::Const(c) => Some(c),
             _ => None,
@@ -1497,12 +1497,12 @@ impl<I: Interner> GenericArg<I> {
     }
 
     /// Compute type flags for GenericArg<I>
-    fn compute_flags(&self, interner: &I) -> TypeFlags {
-        match self.data(&interner) {
+    fn compute_flags(&self, interner: I) -> TypeFlags {
+        match self.data(interner) {
             GenericArgData::Ty(ty) => ty.data(interner).flags,
             GenericArgData::Lifetime(lifetime) => lifetime.compute_flags(interner),
             GenericArgData::Const(constant) => {
-                let data = constant.data(&interner);
+                let data = constant.data(interner);
                 let flags = data.ty.data(interner).flags;
                 match data.value {
                     ConstValue::BoundVar(_) => flags,
@@ -1542,7 +1542,7 @@ where
 
 impl<I: Interner> GenericArgData<I> {
     /// Create an interned type.
-    pub fn intern(self, interner: &I) -> GenericArg<I> {
+    pub fn intern(self, interner: I) -> GenericArg<I> {
         GenericArg::new(interner, self)
     }
 }
@@ -1619,12 +1619,12 @@ impl<I: Interner> Copy for AliasTy<I> where I::InternedSubstitution: Copy {}
 
 impl<I: Interner> AliasTy<I> {
     /// Create an interned type for this alias.
-    pub fn intern(self, interner: &I) -> Ty<I> {
+    pub fn intern(self, interner: I) -> Ty<I> {
         Ty::new(interner, self)
     }
 
     /// Compute type flags for aliases
-    fn compute_flags(&self, interner: &I) -> TypeFlags {
+    fn compute_flags(&self, interner: I) -> TypeFlags {
         match self {
             AliasTy::Projection(projection_ty) => {
                 TypeFlags::HAS_TY_PROJECTION | projection_ty.substitution.compute_flags(interner)
@@ -1649,7 +1649,7 @@ impl<I: Interner> Copy for ProjectionTy<I> where I::InternedSubstitution: Copy {
 
 impl<I: Interner> ProjectionTy<I> {
     /// Gets the type parameters of the `Self` type in this alias type.
-    pub fn self_type_parameter(&self, interner: &I) -> Ty<I> {
+    pub fn self_type_parameter(&self, interner: I) -> Ty<I> {
         self.substitution
             .iter(interner)
             .find_map(move |p| p.ty(interner))
@@ -1687,7 +1687,7 @@ impl<I: Interner> Copy for TraitRef<I> where I::InternedSubstitution: Copy {}
 
 impl<I: Interner> TraitRef<I> {
     /// Gets all type parameters in this trait ref, including `Self`.
-    pub fn type_parameters<'a>(&'a self, interner: &'a I) -> impl Iterator<Item = Ty<I>> + 'a {
+    pub fn type_parameters<'a>(&'a self, interner: I) -> impl Iterator<Item = Ty<I>> + 'a {
         self.substitution
             .iter(interner)
             .filter_map(move |p| p.ty(interner))
@@ -1695,7 +1695,7 @@ impl<I: Interner> TraitRef<I> {
     }
 
     /// Gets the type parameters of the `Self` type in this trait ref.
-    pub fn self_type_parameter(&self, interner: &I) -> Ty<I> {
+    pub fn self_type_parameter(&self, interner: I) -> Ty<I> {
         self.type_parameters(interner).next().unwrap()
     }
 
@@ -1925,7 +1925,7 @@ impl<I: Interner> WhereClause<I> {
     /// * `Implemented(T: Trait)` maps to `WellFormed(T: Trait)`
     /// * `ProjectionEq(<T as Trait>::Item = Foo)` maps to `WellFormed(<T as Trait>::Item = Foo)`
     /// * any other clause maps to itself
-    pub fn into_well_formed_goal(self, interner: &I) -> DomainGoal<I> {
+    pub fn into_well_formed_goal(self, interner: I) -> DomainGoal<I> {
         match self {
             WhereClause::Implemented(trait_ref) => WellFormed::Trait(trait_ref).cast(interner),
             wc => wc.cast(interner),
@@ -1933,7 +1933,7 @@ impl<I: Interner> WhereClause<I> {
     }
 
     /// Same as `into_well_formed_goal` but with the `FromEnv` predicate instead of `WellFormed`.
-    pub fn into_from_env_goal(self, interner: &I) -> DomainGoal<I> {
+    pub fn into_from_env_goal(self, interner: I) -> DomainGoal<I> {
         match self {
             WhereClause::Implemented(trait_ref) => FromEnv::Trait(trait_ref).cast(interner),
             wc => wc.cast(interner),
@@ -1956,7 +1956,7 @@ impl<I: Interner> QuantifiedWhereClause<I> {
     /// quantified where clause. For example, `forall<T> {
     /// Implemented(T: Trait)}` would map to `forall<T> {
     /// WellFormed(T: Trait) }`.
-    pub fn into_well_formed_goal(self, interner: &I) -> Binders<DomainGoal<I>> {
+    pub fn into_well_formed_goal(self, interner: I) -> Binders<DomainGoal<I>> {
         self.map(|wc| wc.into_well_formed_goal(interner))
     }
 
@@ -1964,7 +1964,7 @@ impl<I: Interner> QuantifiedWhereClause<I> {
     /// binders. For example, `forall<T> {
     /// Implemented(T: Trait)}` would map to `forall<T> {
     /// FromEnv(T: Trait) }`.
-    pub fn into_from_env_goal(self, interner: &I) -> Binders<DomainGoal<I>> {
+    pub fn into_from_env_goal(self, interner: I) -> Binders<DomainGoal<I>> {
         self.map(|wc| wc.into_from_env_goal(interner))
     }
 
@@ -1977,7 +1977,7 @@ impl<I: Interner> QuantifiedWhereClause<I> {
 impl<I: Interner> DomainGoal<I> {
     /// Convert `Implemented(...)` into `FromEnv(...)`, but leave other
     /// goals unchanged.
-    pub fn into_from_env_goal(self, interner: &I) -> DomainGoal<I> {
+    pub fn into_from_env_goal(self, interner: I) -> DomainGoal<I> {
         match self {
             DomainGoal::Holds(wc) => wc.into_from_env_goal(interner),
             goal => goal,
@@ -1985,7 +1985,7 @@ impl<I: Interner> DomainGoal<I> {
     }
 
     /// Lists generic arguments that are inputs to this domain goal.
-    pub fn inputs(&self, interner: &I) -> Vec<GenericArg<I>> {
+    pub fn inputs(&self, interner: I) -> Vec<GenericArg<I>> {
         match self {
             DomainGoal::Holds(WhereClause::AliasEq(alias_eq)) => {
                 vec![GenericArgData::Ty(alias_eq.alias.clone().intern(interner)).intern(interner)]
@@ -2093,7 +2093,7 @@ impl<T: HasInterner> Binders<T> {
     /// Wraps the given value in a binder without variables, i.e. `for<>
     /// (value)`. Since our deBruijn indices count binders, not variables, this
     /// is sometimes useful.
-    pub fn empty(interner: &T::Interner, value: T) -> Self {
+    pub fn empty(interner: T::Interner, value: T) -> Self {
         let binders = VariableKinds::empty(interner);
         Self { binders, value }
     }
@@ -2168,7 +2168,7 @@ impl<T: HasInterner> Binders<T> {
     /// Creates a `Substitution` containing bound vars such that applying this
     /// substitution will not change the value, i.e. `^0.0, ^0.1, ^0.2` and so
     /// on.
-    pub fn identity_substitution(&self, interner: &T::Interner) -> Substitution<T::Interner> {
+    pub fn identity_substitution(&self, interner: T::Interner) -> Substitution<T::Interner> {
         Substitution::from_iter(
             interner,
             self.binders
@@ -2185,7 +2185,7 @@ impl<T: HasInterner> Binders<T> {
     ///
     /// XXX FIXME -- this is potentially a pretty footgun-y function.
     pub fn with_fresh_type_var(
-        interner: &T::Interner,
+        interner: T::Interner,
         op: impl FnOnce(Ty<T::Interner>) -> T,
     ) -> Binders<T> {
         // The new variable is at the front and everything afterwards is shifted up by 1
@@ -2196,7 +2196,7 @@ impl<T: HasInterner> Binders<T> {
     }
 
     /// Returns the number of binders.
-    pub fn len(&self, interner: &T::Interner) -> usize {
+    pub fn len(&self, interner: T::Interner) -> usize {
         self.binders.len(interner)
     }
 }
@@ -2208,7 +2208,7 @@ where
     I: Interner,
 {
     /// This turns two levels of binders (`for<A> for<B>`) into one level (`for<A, B>`).
-    pub fn fuse_binders(self, interner: &T::Interner) -> Binders<T::Result> {
+    pub fn fuse_binders(self, interner: T::Interner) -> Binders<T::Result> {
         let num_binders = self.len(interner);
         // generate a substitution to shift the indexes of the inner binder:
         let subst = Substitution::from_iter(
@@ -2248,7 +2248,7 @@ where
     /// B] T`.
     pub fn substitute(
         self,
-        interner: &I,
+        interner: I,
         parameters: &(impl AsParameters<I> + ?Sized),
     ) -> T::Result {
         let parameters = parameters.as_parameters(interner);
@@ -2338,7 +2338,7 @@ pub struct ProgramClauseData<I: Interner>(pub Binders<ProgramClauseImplication<I
 
 impl<I: Interner> ProgramClauseImplication<I> {
     /// Change the implication into an application holding a `FromEnv` goal.
-    pub fn into_from_env_clause(self, interner: &I) -> ProgramClauseImplication<I> {
+    pub fn into_from_env_clause(self, interner: I) -> ProgramClauseImplication<I> {
         if self.conditions.is_empty(interner) {
             ProgramClauseImplication {
                 consequence: self.consequence.into_from_env_goal(interner),
@@ -2354,12 +2354,12 @@ impl<I: Interner> ProgramClauseImplication<I> {
 
 impl<I: Interner> ProgramClauseData<I> {
     /// Change the program clause data into a `FromEnv` program clause.
-    pub fn into_from_env_clause(self, interner: &I) -> ProgramClauseData<I> {
+    pub fn into_from_env_clause(self, interner: I) -> ProgramClauseData<I> {
         ProgramClauseData(self.0.map(|i| i.into_from_env_clause(interner)))
     }
 
     /// Intern the program clause data.
-    pub fn intern(self, interner: &I) -> ProgramClause<I> {
+    pub fn intern(self, interner: I) -> ProgramClause<I> {
         ProgramClause {
             interned: interner.intern_program_clause(self),
         }
@@ -2374,13 +2374,13 @@ pub struct ProgramClause<I: Interner> {
 
 impl<I: Interner> ProgramClause<I> {
     /// Create a new program clause using `ProgramClauseData`.
-    pub fn new(interner: &I, clause: ProgramClauseData<I>) -> Self {
+    pub fn new(interner: I, clause: ProgramClauseData<I>) -> Self {
         let interned = interner.intern_program_clause(clause);
         Self { interned }
     }
 
     /// Change the clause into a `FromEnv` clause.
-    pub fn into_from_env_clause(self, interner: &I) -> ProgramClause<I> {
+    pub fn into_from_env_clause(self, interner: I) -> ProgramClause<I> {
         let program_clause_data = self.data(interner);
         let new_clause = program_clause_data.clone().into_from_env_clause(interner);
         Self::new(interner, new_clause)
@@ -2392,7 +2392,7 @@ impl<I: Interner> ProgramClause<I> {
     }
 
     /// Get the program clause data.
-    pub fn data(&self, interner: &I) -> &ProgramClauseData<I> {
+    pub fn data(&self, interner: I) -> &ProgramClauseData<I> {
         interner.program_clause_data(&self.interned)
     }
 }
@@ -2435,7 +2435,7 @@ impl<T: HasInterner> UCanonical<T> {
     /// substitution (e.g. an identity substitution).
     pub fn is_trivial_substitution(
         &self,
-        interner: &T::Interner,
+        interner: T::Interner,
         canonical_subst: &Canonical<AnswerSubst<T::Interner>>,
     ) -> bool {
         let subst = &canonical_subst.value.subst;
@@ -2447,7 +2447,7 @@ impl<T: HasInterner> UCanonical<T> {
     }
 
     /// Creates an identity substitution.
-    pub fn trivial_substitution(&self, interner: &T::Interner) -> Substitution<T::Interner> {
+    pub fn trivial_substitution(&self, interner: T::Interner) -> Substitution<T::Interner> {
         let binders = &self.canonical.binders;
         Substitution::from_iter(
             interner,
@@ -2488,7 +2488,7 @@ pub struct Goal<I: Interner> {
 
 impl<I: Interner> Goal<I> {
     /// Create a new goal using `GoalData`.
-    pub fn new(interner: &I, interned: GoalData<I>) -> Self {
+    pub fn new(interner: I, interned: GoalData<I>) -> Self {
         let interned = I::intern_goal(interner, interned);
         Self { interned }
     }
@@ -2499,27 +2499,22 @@ impl<I: Interner> Goal<I> {
     }
 
     /// Gets the interned goal data.
-    pub fn data(&self, interner: &I) -> &GoalData<I> {
+    pub fn data(&self, interner: I) -> &GoalData<I> {
         interner.goal_data(&self.interned)
     }
 
     /// Create a goal using a `forall` or `exists` quantifier.
-    pub fn quantify(
-        self,
-        interner: &I,
-        kind: QuantifierKind,
-        binders: VariableKinds<I>,
-    ) -> Goal<I> {
+    pub fn quantify(self, interner: I, kind: QuantifierKind, binders: VariableKinds<I>) -> Goal<I> {
         GoalData::Quantified(kind, Binders::new(binders, self)).intern(interner)
     }
 
     /// Takes a goal `G` and turns it into `not { G }`.
-    pub fn negate(self, interner: &I) -> Self {
+    pub fn negate(self, interner: I) -> Self {
         GoalData::Not(self).intern(interner)
     }
 
     /// Takes a goal `G` and turns it into `compatible { G }`.
-    pub fn compatible(self, interner: &I) -> Self {
+    pub fn compatible(self, interner: I) -> Self {
         // compatible { G } desugars into: forall<T> { if (Compatible, DownstreamType(T)) { G } }
         // This activates the compatible modality rules and introduces an anonymous downstream type
         GoalData::Quantified(
@@ -2539,13 +2534,13 @@ impl<I: Interner> Goal<I> {
     }
 
     /// Create an implication goal that holds if the predicates are true.
-    pub fn implied_by(self, interner: &I, predicates: ProgramClauses<I>) -> Goal<I> {
+    pub fn implied_by(self, interner: I, predicates: ProgramClauses<I>) -> Goal<I> {
         GoalData::Implies(predicates, self).intern(interner)
     }
 
     /// True if this goal is "trivially true" -- i.e., no work is
     /// required to prove it.
-    pub fn is_trivially_true(&self, interner: &I) -> bool {
+    pub fn is_trivially_true(&self, interner: I) -> bool {
         match self.data(interner) {
             GoalData::All(goals) => goals.is_empty(interner),
             _ => false,
@@ -2558,7 +2553,7 @@ where
     I: Interner,
 {
     /// Creates a single goal that only holds if a list of goals holds.
-    pub fn all<II>(interner: &I, iter: II) -> Self
+    pub fn all<II>(interner: I, iter: II) -> Self
     where
         II: IntoIterator<Item = Goal<I>>,
     {
@@ -2633,7 +2628,7 @@ where
 
 impl<I: Interner> GoalData<I> {
     /// Create an interned goal.
-    pub fn intern(self, interner: &I) -> Goal<I> {
+    pub fn intern(self, interner: I) -> Goal<I> {
         Goal::new(interner, self)
     }
 }
@@ -2696,7 +2691,7 @@ impl<I: Interner> Substitution<I> {
     ///
     /// Basically, each value is mapped to a type or lifetime with its
     /// same index.
-    pub fn is_identity_subst(&self, interner: &I) -> bool {
+    pub fn is_identity_subst(&self, interner: I) -> bool {
         self.iter(interner).zip(0..).all(|(generic_arg, index)| {
             let index_db = BoundVar::new(DebruijnIndex::INNERMOST, index);
             match generic_arg.data(interner) {
@@ -2717,7 +2712,7 @@ impl<I: Interner> Substitution<I> {
     }
 
     /// Apply the substitution to a value.
-    pub fn apply<T>(&self, value: T, interner: &I) -> T::Result
+    pub fn apply<T>(&self, value: T, interner: I) -> T::Result
     where
         T: Fold<I>,
     {
@@ -2725,16 +2720,16 @@ impl<I: Interner> Substitution<I> {
     }
 
     /// Gets an iterator of all type parameters.
-    pub fn type_parameters<'a>(&'a self, interner: &'a I) -> impl Iterator<Item = Ty<I>> + 'a {
+    pub fn type_parameters<'a>(&'a self, interner: I) -> impl Iterator<Item = Ty<I>> + 'a {
         self.iter(interner)
             .filter_map(move |p| p.ty(interner))
             .cloned()
     }
 
     /// Compute type flags for Substitution<I>
-    fn compute_flags(&self, interner: &I) -> TypeFlags {
+    fn compute_flags(&self, interner: I) -> TypeFlags {
         let mut flags = TypeFlags::empty();
-        for generic_arg in self.iter(&interner) {
+        for generic_arg in self.iter(interner) {
             flags |= generic_arg.compute_flags(interner);
         }
         flags
@@ -2742,7 +2737,7 @@ impl<I: Interner> Substitution<I> {
 }
 
 struct SubstFolder<'i, I: Interner, A: AsParameters<I>> {
-    interner: &'i I,
+    interner: I,
     subst: &'i A,
 }
 
@@ -2757,30 +2752,30 @@ impl<I: Interner, A: AsParameters<I>> SubstFolder<'_, I, A> {
 /// Convert a value to a list of parameters.
 pub trait AsParameters<I: Interner> {
     /// Convert the current value to parameters.
-    fn as_parameters(&self, interner: &I) -> &[GenericArg<I>];
+    fn as_parameters(&self, interner: I) -> &[GenericArg<I>];
 }
 
 impl<I: Interner> AsParameters<I> for Substitution<I> {
     #[allow(unreachable_code, unused_variables)]
-    fn as_parameters(&self, interner: &I) -> &[GenericArg<I>] {
+    fn as_parameters(&self, interner: I) -> &[GenericArg<I>] {
         self.as_slice(interner)
     }
 }
 
 impl<I: Interner> AsParameters<I> for [GenericArg<I>] {
-    fn as_parameters(&self, _interner: &I) -> &[GenericArg<I>] {
+    fn as_parameters(&self, _interner: I) -> &[GenericArg<I>] {
         self
     }
 }
 
 impl<I: Interner> AsParameters<I> for [GenericArg<I>; 1] {
-    fn as_parameters(&self, _interner: &I) -> &[GenericArg<I>] {
+    fn as_parameters(&self, _interner: I) -> &[GenericArg<I>] {
         self
     }
 }
 
 impl<I: Interner> AsParameters<I> for Vec<GenericArg<I>> {
-    fn as_parameters(&self, _interner: &I) -> &[GenericArg<I>] {
+    fn as_parameters(&self, _interner: I) -> &[GenericArg<I>] {
         self
     }
 }
@@ -2789,7 +2784,7 @@ impl<T, I: Interner> AsParameters<I> for &T
 where
     T: ?Sized + AsParameters<I>,
 {
-    fn as_parameters(&self, interner: &I) -> &[GenericArg<I>] {
+    fn as_parameters(&self, interner: I) -> &[GenericArg<I>] {
         T::as_parameters(self, interner)
     }
 }
@@ -2798,11 +2793,11 @@ where
 /// that it can applied as a substituion to a value
 pub trait Substitute<I: Interner>: AsParameters<I> {
     /// Apply the substitution to a value.
-    fn apply<T: Fold<I>>(&self, value: T, interner: &I) -> T::Result;
+    fn apply<T: Fold<I>>(&self, value: T, interner: I) -> T::Result;
 }
 
 impl<I: Interner, A: AsParameters<I>> Substitute<I> for A {
-    fn apply<T>(&self, value: T, interner: &I) -> T::Result
+    fn apply<T>(&self, value: T, interner: I) -> T::Result
     where
         T: Fold<I>,
     {
@@ -2825,26 +2820,26 @@ impl<I: Interner, A: AsParameters<I>> Substitute<I> for A {
 /// variable of appropriate kind at the corresponding index.
 pub trait ToGenericArg<I: Interner> {
     /// Converts the binders in scope to references to those binders.
-    fn to_generic_arg(&self, interner: &I) -> GenericArg<I> {
+    fn to_generic_arg(&self, interner: I) -> GenericArg<I> {
         self.to_generic_arg_at_depth(interner, DebruijnIndex::INNERMOST)
     }
 
     /// Converts the binders at the specified depth to references to those binders.
-    fn to_generic_arg_at_depth(&self, interner: &I, debruijn: DebruijnIndex) -> GenericArg<I>;
+    fn to_generic_arg_at_depth(&self, interner: I, debruijn: DebruijnIndex) -> GenericArg<I>;
 }
 
 impl<'a, I: Interner> ToGenericArg<I> for (usize, &'a VariableKind<I>) {
-    fn to_generic_arg_at_depth(&self, interner: &I, debruijn: DebruijnIndex) -> GenericArg<I> {
+    fn to_generic_arg_at_depth(&self, interner: I, debruijn: DebruijnIndex) -> GenericArg<I> {
         let &(index, binder) = self;
         let bound_var = BoundVar::new(debruijn, index);
         binder.to_bound_variable(interner, bound_var)
     }
 }
 
-impl<'i, I: Interner, A: AsParameters<I>> Folder<'i, I> for &SubstFolder<'i, I, A> {
+impl<'i, I: Interner, A: AsParameters<I>> Folder<I> for &SubstFolder<'i, I, A> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
         self
     }
 
@@ -2882,7 +2877,7 @@ impl<'i, I: Interner, A: AsParameters<I>> Folder<'i, I> for &SubstFolder<'i, I, 
         Ok(c.clone().shifted_in_from(self.interner(), outer_binder))
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 }
@@ -2902,32 +2897,32 @@ macro_rules! interned_slice_common {
             }
 
             /// Returns a slice containing the elements.
-            pub fn as_slice(&self, interner: &I) -> &[$elem] {
+            pub fn as_slice(&self, interner: I) -> &[$elem] {
                 Interner::$data(interner, &self.interned)
             }
 
             /// Index into the sequence.
-            pub fn at(&self, interner: &I, index: usize) -> &$elem {
+            pub fn at(&self, interner: I, index: usize) -> &$elem {
                 &self.as_slice(interner)[index]
             }
 
             /// Create an empty sequence.
-            pub fn empty(interner: &I) -> Self {
+            pub fn empty(interner: I) -> Self {
                 Self::from_iter(interner, None::<$elem>)
             }
 
             /// Check whether this is an empty sequence.
-            pub fn is_empty(&self, interner: &I) -> bool {
+            pub fn is_empty(&self, interner: I) -> bool {
                 self.as_slice(interner).is_empty()
             }
 
             /// Get an iterator over the elements of the sequence.
-            pub fn iter(&self, interner: &I) -> std::slice::Iter<'_, $elem> {
+            pub fn iter(&self, interner: I) -> std::slice::Iter<'_, $elem> {
                 self.as_slice(interner).iter()
             }
 
             /// Get the length of the sequence.
-            pub fn len(&self, interner: &I) -> usize {
+            pub fn len(&self, interner: I) -> usize {
                 self.as_slice(interner).len()
             }
         }
@@ -2941,7 +2936,7 @@ macro_rules! interned_slice {
         impl<I: Interner> $seq<I> {
             /// Tries to create a sequence using an iterator of element-like things.
             pub fn from_fallible<E>(
-                interner: &I,
+                interner: I,
                 elements: impl IntoIterator<Item = Result<impl CastTo<$elem>, E>>,
             ) -> Result<Self, E> {
                 Ok(Self {
@@ -2951,7 +2946,7 @@ macro_rules! interned_slice {
 
             /// Create a sequence from elements
             pub fn from_iter(
-                interner: &I,
+                interner: I,
                 elements: impl IntoIterator<Item = impl CastTo<$elem>>,
             ) -> Self {
                 Self::from_fallible(
@@ -2964,7 +2959,7 @@ macro_rules! interned_slice {
             }
 
             /// Create a sequence from a single element.
-            pub fn from1(interner: &I, element: impl CastTo<$elem>) -> Self {
+            pub fn from1(interner: I, element: impl CastTo<$elem>) -> Self {
                 Self::from_iter(interner, Some(element))
             }
         }
@@ -3018,7 +3013,7 @@ interned_slice_common!(
 impl<I: Interner> Variances<I> {
     /// Tries to create a list of canonical variable kinds using an iterator.
     pub fn from_fallible<E>(
-        interner: &I,
+        interner: I,
         variances: impl IntoIterator<Item = Result<Variance, E>>,
     ) -> Result<Self, E> {
         Ok(Variances {
@@ -3027,7 +3022,7 @@ impl<I: Interner> Variances<I> {
     }
 
     /// Creates a list of canonical variable kinds using an iterator.
-    pub fn from_iter(interner: &I, variances: impl IntoIterator<Item = Variance>) -> Self {
+    pub fn from_iter(interner: I, variances: impl IntoIterator<Item = Variance>) -> Self {
         Self::from_fallible(
             interner,
             variances
@@ -3038,7 +3033,7 @@ impl<I: Interner> Variances<I> {
     }
 
     /// Creates a list of canonical variable kinds from a single canonical variable kind.
-    pub fn from1(interner: &I, variance: Variance) -> Self {
+    pub fn from1(interner: I, variance: Variance) -> Self {
         Self::from_iter(interner, Some(variance))
     }
 }

--- a/chalk-ir/src/visit/binder_impls.rs
+++ b/chalk-ir/src/visit/binder_impls.rs
@@ -7,14 +7,11 @@ use crate::interner::HasInterner;
 use crate::{Binders, Canonical, ControlFlow, DebruijnIndex, FnPointer, Interner, Visit, Visitor};
 
 impl<I: Interner> Visit<I> for FnPointer<I> {
-    fn visit_with<'i, B>(
+    fn visit_with<B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
+        visitor: &mut dyn Visitor<I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<B>
-    where
-        I: 'i,
-    {
+    ) -> ControlFlow<B> {
         self.substitution
             .visit_with(visitor, outer_binder.shifted_in())
     }
@@ -24,14 +21,11 @@ impl<T, I: Interner> Visit<I> for Binders<T>
 where
     T: HasInterner + Visit<I>,
 {
-    fn visit_with<'i, B>(
+    fn visit_with<B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
+        visitor: &mut dyn Visitor<I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<B>
-    where
-        I: 'i,
-    {
+    ) -> ControlFlow<B> {
         self.value.visit_with(visitor, outer_binder.shifted_in())
     }
 }
@@ -41,14 +35,11 @@ where
     I: Interner,
     T: HasInterner<Interner = I> + Visit<I>,
 {
-    fn visit_with<'i, B>(
+    fn visit_with<B>(
         &self,
-        visitor: &mut dyn Visitor<'i, I, BreakTy = B>,
+        visitor: &mut dyn Visitor<I, BreakTy = B>,
         outer_binder: DebruijnIndex,
-    ) -> ControlFlow<B>
-    where
-        I: 'i,
-    {
+    ) -> ControlFlow<B> {
         self.value.visit_with(visitor, outer_binder.shifted_in())
     }
 }

--- a/chalk-ir/src/visit/visitors.rs
+++ b/chalk-ir/src/visit/visitors.rs
@@ -5,7 +5,7 @@ use crate::{BoundVar, ControlFlow, DebruijnIndex, Interner, Visit, Visitor};
 /// Visitor extensions.
 pub trait VisitExt<I: Interner>: Visit<I> {
     /// Check whether there are free (non-bound) variables.
-    fn has_free_vars(&self, interner: &I) -> bool {
+    fn has_free_vars(&self, interner: I) -> bool {
         let flow = self.visit_with(
             &mut FindFreeVarsVisitor { interner },
             DebruijnIndex::INNERMOST,
@@ -16,18 +16,18 @@ pub trait VisitExt<I: Interner>: Visit<I> {
 
 impl<T, I: Interner> VisitExt<I> for T where T: Visit<I> {}
 
-struct FindFreeVarsVisitor<'i, I: Interner> {
-    interner: &'i I,
+struct FindFreeVarsVisitor<I: Interner> {
+    interner: I,
 }
 
-impl<'i, I: Interner> Visitor<'i, I> for FindFreeVarsVisitor<'i, I> {
+impl<I: Interner> Visitor<I> for FindFreeVarsVisitor<I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
         self
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 

--- a/chalk-recursive/src/combine.rs
+++ b/chalk-recursive/src/combine.rs
@@ -5,7 +5,7 @@ use chalk_ir::interner::Interner;
 use chalk_ir::{ClausePriority, DomainGoal, GenericArg};
 
 pub(super) fn with_priorities<I: Interner>(
-    interner: &I,
+    interner: I,
     domain_goal: &DomainGoal<I>,
     a: Solution<I>,
     prio_a: ClausePriority,
@@ -38,7 +38,7 @@ pub(super) fn with_priorities<I: Interner>(
 }
 
 fn calculate_inputs<I: Interner>(
-    interner: &I,
+    interner: I,
     domain_goal: &DomainGoal<I>,
     solution: &Solution<I>,
 ) -> Vec<GenericArg<I>> {

--- a/chalk-recursive/src/fulfill.rs
+++ b/chalk-recursive/src/fulfill.rs
@@ -64,7 +64,7 @@ enum NegativeSolution {
 
 fn canonicalize<I: Interner, T>(
     infer: &mut InferenceTable<I>,
-    interner: &I,
+    interner: I,
     value: T,
 ) -> (Canonical<T::Result>, Vec<GenericArg<I>>)
 where
@@ -82,7 +82,7 @@ where
 
 fn u_canonicalize<I: Interner, T>(
     _infer: &mut InferenceTable<I>,
-    interner: &I,
+    interner: I,
     value0: &Canonical<T>,
 ) -> (UCanonical<T::Result>, UniverseMap)
 where
@@ -95,7 +95,7 @@ where
 
 fn unify<I: Interner, T>(
     infer: &mut InferenceTable<I>,
-    interner: &I,
+    interner: I,
     db: &dyn UnificationDatabase<I>,
     environment: &Environment<I>,
     variance: Variance,
@@ -604,7 +604,7 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>> Fulfill<'s, I, Solver> {
         }
     }
 
-    fn interner(&self) -> &I {
+    fn interner(&self) -> I {
         self.solver.interner()
     }
 }

--- a/chalk-recursive/src/recursive.rs
+++ b/chalk-recursive/src/recursive.rs
@@ -112,8 +112,8 @@ impl<'me, I: Interner> SolveDatabase<I> for Solver<'me, I> {
         self.context.solve_goal(&goal, minimums, self.program)
     }
 
-    fn interner(&self) -> &I {
-        &self.program.interner()
+    fn interner(&self) -> I {
+        self.program.interner()
     }
 
     fn db(&self) -> &dyn RustIrDatabase<I> {

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -24,7 +24,7 @@ pub(super) trait SolveDatabase<I: Interner>: Sized {
 
     fn max_size(&self) -> usize;
 
-    fn interner(&self) -> &I;
+    fn interner(&self) -> I;
 
     fn db(&self) -> &dyn RustIrDatabase<I>;
 }

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -663,7 +663,7 @@ pub fn program_clauses_that_could_match<I: Interner>(
 fn push_clauses_for_compatible_normalize<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,
-    interner: &I,
+    interner: I,
     trait_id: TraitId<I>,
     associated_ty_id: AssocTypeId<I>,
 ) {

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -201,7 +201,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
         });
     }
 
-    pub fn interner(&self) -> &'me I {
+    pub fn interner(&self) -> I {
         self.db.interner()
     }
 }

--- a/chalk-solve/src/clauses/builtin_traits/unsize.rs
+++ b/chalk-solve/src/clauses/builtin_traits/unsize.rs
@@ -13,16 +13,16 @@ use chalk_ir::{
     QuantifiedWhereClauses, Substitution, TraitId, Ty, TyKind, TypeOutlives, WhereClause,
 };
 
-struct UnsizeParameterCollector<'a, I: Interner> {
-    interner: &'a I,
+struct UnsizeParameterCollector<I: Interner> {
+    interner: I,
     // FIXME should probably use a bitset instead
     parameters: HashSet<usize>,
 }
 
-impl<'a, I: Interner> Visitor<'a, I> for UnsizeParameterCollector<'a, I> {
+impl<I: Interner> Visitor<I> for UnsizeParameterCollector<I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
         self
     }
 
@@ -53,13 +53,13 @@ impl<'a, I: Interner> Visitor<'a, I> for UnsizeParameterCollector<'a, I> {
         ControlFlow::Continue(())
     }
 
-    fn interner(&self) -> &'a I {
+    fn interner(&self) -> I {
         self.interner
     }
 }
 
 fn outer_binder_parameters_used<I: Interner>(
-    interner: &I,
+    interner: I,
     v: &Binders<impl Visit<I> + HasInterner>,
 ) -> HashSet<usize> {
     let mut visitor = UnsizeParameterCollector {
@@ -71,15 +71,15 @@ fn outer_binder_parameters_used<I: Interner>(
 }
 
 // has nothing to do with occurs check
-struct ParameterOccurenceCheck<'a, 'p, I: Interner> {
-    interner: &'a I,
+struct ParameterOccurenceCheck<'p, I: Interner> {
+    interner: I,
     parameters: &'p HashSet<usize>,
 }
 
-impl<'a, 'p, I: Interner> Visitor<'a, I> for ParameterOccurenceCheck<'a, 'p, I> {
+impl<'p, I: Interner> Visitor<I> for ParameterOccurenceCheck<'p, I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'a, I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
         self
     }
 
@@ -117,13 +117,13 @@ impl<'a, 'p, I: Interner> Visitor<'a, I> for ParameterOccurenceCheck<'a, 'p, I> 
         }
     }
 
-    fn interner(&self) -> &'a I {
+    fn interner(&self) -> I {
         self.interner
     }
 }
 
 fn uses_outer_binder_params<I: Interner>(
-    interner: &I,
+    interner: I,
     v: &Binders<impl Visit<I> + HasInterner>,
     parameters: &HashSet<usize>,
 ) -> bool {

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -43,14 +43,14 @@ struct EnvElaborator<'me, 'builder, I: Interner> {
     environment: &'me Environment<I>,
 }
 
-impl<'me, 'builder, I: Interner> Visitor<'me, I> for EnvElaborator<'me, 'builder, I> {
+impl<'me, 'builder, I: Interner> Visitor<I> for EnvElaborator<'me, 'builder, I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'me, I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
         self
     }
 
-    fn interner(&self) -> &'me I {
+    fn interner(&self) -> I {
         self.db.interner()
     }
     #[instrument(level = "debug", skip(self, _outer_binder))]

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -14,14 +14,14 @@ use chalk_ir::{
 };
 use rustc_hash::FxHashMap;
 
-pub struct Generalize<'i, I: Interner> {
+pub struct Generalize<I: Interner> {
     binders: Vec<VariableKind<I>>,
     mapping: FxHashMap<BoundVar, usize>,
-    interner: &'i I,
+    interner: I,
 }
 
-impl<I: Interner> Generalize<'_, I> {
-    pub fn apply<T>(interner: &I, value: T) -> Binders<T::Result>
+impl<I: Interner> Generalize<I> {
+    pub fn apply<T>(interner: I, value: T) -> Binders<T::Result>
     where
         T: HasInterner<Interner = I> + Fold<I>,
         T::Result: HasInterner<Interner = I>,
@@ -41,10 +41,10 @@ impl<I: Interner> Generalize<'_, I> {
     }
 }
 
-impl<'i, I: Interner> Folder<'i, I> for Generalize<'i, I> {
+impl<I: Interner> Folder<I> for Generalize<I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
         self
     }
 
@@ -78,7 +78,7 @@ impl<'i, I: Interner> Folder<'i, I> for Generalize<'i, I> {
         Ok(LifetimeData::BoundVar(new_var).intern(self.interner()))
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 }

--- a/chalk-solve/src/display/bounds.rs
+++ b/chalk-solve/src/display/bounds.rs
@@ -62,7 +62,7 @@ impl<I: Interner> RenderAsRust<I> for QuantifiedInlineBound<I> {
     fn fmt(&self, s: &InternalWriterState<'_, I>, f: &'_ mut Formatter<'_>) -> Result {
         let interner = s.db().interner();
         let s = &s.add_debrujin_index(None);
-        if !self.binders.is_empty(&interner) {
+        if !self.binders.is_empty(interner) {
             write!(
                 f,
                 "forall<{}> ",

--- a/chalk-solve/src/display/stub.rs
+++ b/chalk-solve/src/display/stub.rs
@@ -183,7 +183,7 @@ impl<I: Interner, DB: RustIrDatabase<I>> RustIrDatabase<I> for StubWrapper<'_, D
         self.db.program_clauses_for_env(environment)
     }
 
-    fn interner(&self) -> &I {
+    fn interner(&self) -> I {
         self.db.interner()
     }
 

--- a/chalk-solve/src/ext.rs
+++ b/chalk-solve/src/ext.rs
@@ -4,7 +4,7 @@ use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
 
 pub trait CanonicalExt<T: HasInterner, I: Interner> {
-    fn map<OP, U>(self, interner: &I, op: OP) -> Canonical<U::Result>
+    fn map<OP, U>(self, interner: I, op: OP) -> Canonical<U::Result>
     where
         OP: FnOnce(T::Result) -> U,
         T: Fold<I>,
@@ -24,7 +24,7 @@ where
     /// inference context) are used in place of the quantified free
     /// variables. The result should be in terms of those same
     /// inference variables and will be re-canonicalized.
-    fn map<OP, U>(self, interner: &I, op: OP) -> Canonical<U::Result>
+    fn map<OP, U>(self, interner: I, op: OP) -> Canonical<U::Result>
     where
         OP: FnOnce(T::Result) -> U,
         T: Fold<I>,
@@ -51,8 +51,8 @@ where
 }
 
 pub trait GoalExt<I: Interner> {
-    fn into_peeled_goal(self, interner: &I) -> UCanonical<InEnvironment<Goal<I>>>;
-    fn into_closed_goal(self, interner: &I) -> UCanonical<InEnvironment<Goal<I>>>;
+    fn into_peeled_goal(self, interner: I) -> UCanonical<InEnvironment<Goal<I>>>;
+    fn into_closed_goal(self, interner: I) -> UCanonical<InEnvironment<Goal<I>>>;
 }
 
 impl<I: Interner> GoalExt<I> for Goal<I> {
@@ -62,7 +62,7 @@ impl<I: Interner> GoalExt<I> for Goal<I> {
     /// variables. Assumes that this goal is a "closed goal" which
     /// does not -- at present -- contain any variables. Useful for
     /// REPLs and tests but not much else.
-    fn into_peeled_goal(self, interner: &I) -> UCanonical<InEnvironment<Goal<I>>> {
+    fn into_peeled_goal(self, interner: I) -> UCanonical<InEnvironment<Goal<I>>> {
         let mut infer = InferenceTable::new();
         let peeled_goal = {
             let mut env_goal = InEnvironment::new(&Environment::new(interner), self);
@@ -104,7 +104,7 @@ impl<I: Interner> GoalExt<I> for Goal<I> {
     /// # Panics
     ///
     /// Will panic if this goal does in fact contain free variables.
-    fn into_closed_goal(self, interner: &I) -> UCanonical<InEnvironment<Goal<I>>> {
+    fn into_closed_goal(self, interner: I) -> UCanonical<InEnvironment<Goal<I>>> {
         let mut infer = InferenceTable::new();
         let env_goal = InEnvironment::new(&Environment::new(interner), self);
         let canonical_goal = infer.canonicalize(interner, env_goal).quantified;

--- a/chalk-solve/src/goal_builder.rs
+++ b/chalk-solve/src/goal_builder.rs
@@ -22,7 +22,7 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
     }
 
     /// Returns the interner within the goal builder.
-    pub fn interner(&self) -> &'i I {
+    pub fn interner(&self) -> I {
         self.db.interner()
     }
 

--- a/chalk-solve/src/infer.rs
+++ b/chalk-solve/src/infer.rs
@@ -47,7 +47,7 @@ impl<I: Interner> InferenceTable<I> {
     /// corresponding existential variable, along with the
     /// instantiated result.
     pub fn from_canonical<T>(
-        interner: &I,
+        interner: I,
         num_universes: usize,
         canonical: Canonical<T>,
     ) -> (Self, Substitution<I>, T)
@@ -118,7 +118,7 @@ impl<I: Interner> InferenceTable<I> {
         self.unify.commit(snapshot.unify_snapshot);
     }
 
-    pub fn normalize_ty_shallow(&mut self, interner: &I, leaf: &Ty<I>) -> Option<Ty<I>> {
+    pub fn normalize_ty_shallow(&mut self, interner: I, leaf: &Ty<I>) -> Option<Ty<I>> {
         // An integer/float type variable will never normalize to another
         // variable; but a general type variable might normalize to an
         // integer/float variable. So we potentially need to normalize twice to
@@ -127,26 +127,26 @@ impl<I: Interner> InferenceTable<I> {
             .map(|ty| self.normalize_ty_shallow_inner(interner, &ty).unwrap_or(ty))
     }
 
-    fn normalize_ty_shallow_inner(&mut self, interner: &I, leaf: &Ty<I>) -> Option<Ty<I>> {
+    fn normalize_ty_shallow_inner(&mut self, interner: I, leaf: &Ty<I>) -> Option<Ty<I>> {
         self.probe_var(leaf.inference_var(interner)?)
             .map(|p| p.assert_ty_ref(interner).clone())
     }
 
     pub fn normalize_lifetime_shallow(
         &mut self,
-        interner: &I,
+        interner: I,
         leaf: &Lifetime<I>,
     ) -> Option<Lifetime<I>> {
         self.probe_var(leaf.inference_var(interner)?)
             .map(|p| p.assert_lifetime_ref(interner).clone())
     }
 
-    pub fn normalize_const_shallow(&mut self, interner: &I, leaf: &Const<I>) -> Option<Const<I>> {
+    pub fn normalize_const_shallow(&mut self, interner: I, leaf: &Const<I>) -> Option<Const<I>> {
         self.probe_var(leaf.inference_var(interner)?)
             .map(|p| p.assert_const_ref(interner).clone())
     }
 
-    pub fn ty_root(&mut self, interner: &I, leaf: &Ty<I>) -> Option<Ty<I>> {
+    pub fn ty_root(&mut self, interner: I, leaf: &Ty<I>) -> Option<Ty<I>> {
         Some(
             self.unify
                 .find(leaf.inference_var(interner)?)
@@ -154,7 +154,7 @@ impl<I: Interner> InferenceTable<I> {
         )
     }
 
-    pub fn lifetime_root(&mut self, interner: &I, leaf: &Lifetime<I>) -> Option<Lifetime<I>> {
+    pub fn lifetime_root(&mut self, interner: I, leaf: &Lifetime<I>) -> Option<Lifetime<I>> {
         Some(
             self.unify
                 .find(leaf.inference_var(interner)?)
@@ -196,11 +196,11 @@ impl<I: Interner> InferenceTable<I> {
 }
 
 pub trait ParameterEnaVariableExt<I: Interner> {
-    fn to_generic_arg(&self, interner: &I) -> GenericArg<I>;
+    fn to_generic_arg(&self, interner: I) -> GenericArg<I>;
 }
 
 impl<I: Interner> ParameterEnaVariableExt<I> for ParameterEnaVariable<I> {
-    fn to_generic_arg(&self, interner: &I) -> GenericArg<I> {
+    fn to_generic_arg(&self, interner: I) -> GenericArg<I> {
         // we are matching on kind, so skipping it is fine
         let ena_variable = self.skip_kind();
         match &self.kind {

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -27,7 +27,7 @@ impl<I: Interner> InferenceTable<I> {
     ///
     /// A substitution mapping from the free variables to their re-bound form is
     /// also returned.
-    pub fn canonicalize<T>(&mut self, interner: &I, value: T) -> Canonicalized<T::Result>
+    pub fn canonicalize<T>(&mut self, interner: I, value: T) -> Canonicalized<T::Result>
     where
         T: Fold<I>,
         T::Result: HasInterner<Interner = I>,
@@ -71,7 +71,7 @@ struct Canonicalizer<'q, I: Interner> {
     table: &'q mut InferenceTable<I>,
     free_vars: Vec<ParameterEnaVariable<I>>,
     max_universe: UniverseIndex,
-    interner: &'q I,
+    interner: I,
 }
 
 impl<'q, I: Interner> Canonicalizer<'q, I> {
@@ -107,13 +107,10 @@ impl<'q, I: Interner> Canonicalizer<'q, I> {
     }
 }
 
-impl<'i, I: Interner> Folder<'i, I> for Canonicalizer<'i, I>
-where
-    I: 'i,
-{
+impl<'i, I: Interner> Folder<I> for Canonicalizer<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
         self
     }
 
@@ -257,7 +254,7 @@ where
         }
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 }

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -13,7 +13,7 @@ impl<I: Interner> InferenceTable<I> {
     /// `self.instantiate_canonical(v)`.
     pub(super) fn fresh_subst(
         &mut self,
-        interner: &I,
+        interner: I,
         binders: &[CanonicalVarKind<I>],
     ) -> Substitution<I> {
         Substitution::from_iter(
@@ -26,7 +26,7 @@ impl<I: Interner> InferenceTable<I> {
     }
 
     /// Variant on `instantiate` that takes a `Canonical<T>`.
-    pub fn instantiate_canonical<T>(&mut self, interner: &I, bound: Canonical<T>) -> T::Result
+    pub fn instantiate_canonical<T>(&mut self, interner: I, bound: Canonical<T>) -> T::Result
     where
         T: HasInterner<Interner = I> + Fold<I> + Debug,
     {
@@ -41,7 +41,7 @@ impl<I: Interner> InferenceTable<I> {
     /// argument is referring to `X, 'Y`.
     fn instantiate_in<T>(
         &mut self,
-        interner: &I,
+        interner: I,
         universe: UniverseIndex,
         binders: impl Iterator<Item = VariableKind<I>>,
         arg: T,
@@ -58,9 +58,9 @@ impl<I: Interner> InferenceTable<I> {
 
     /// Variant on `instantiate_in` that takes a `Binders<T>`.
     #[instrument(level = "debug", skip(self, interner))]
-    pub fn instantiate_binders_existentially<'a, T>(
+    pub fn instantiate_binders_existentially<T>(
         &mut self,
-        interner: &'a I,
+        interner: I,
         arg: Binders<T>,
     ) -> T::Result
     where
@@ -78,11 +78,7 @@ impl<I: Interner> InferenceTable<I> {
     }
 
     #[instrument(level = "debug", skip(self, interner))]
-    pub fn instantiate_binders_universally<'a, T>(
-        &mut self,
-        interner: &'a I,
-        arg: Binders<T>,
-    ) -> T::Result
+    pub fn instantiate_binders_universally<T>(&mut self, interner: I, arg: Binders<T>) -> T::Result
     where
         T: Fold<I> + HasInterner<Interner = I>,
     {

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -71,7 +71,7 @@ impl<I: Interner> InferenceTable<I> {
     /// `?T: Clone` in the case where `?T = Vec<i32>`. The current
     /// version would delay processing the negative goal (i.e., return
     /// `None`) until the second unification has occurred.)
-    pub fn invert<T>(&mut self, interner: &I, value: T) -> Option<T::Result>
+    pub fn invert<T>(&mut self, interner: I, value: T) -> Option<T::Result>
     where
         T: Fold<I, Result = T> + HasInterner<Interner = I>,
     {
@@ -99,7 +99,7 @@ impl<I: Interner> InferenceTable<I> {
     /// returning. Just a convenience function.
     pub fn invert_then_canonicalize<T>(
         &mut self,
-        interner: &I,
+        interner: I,
         value: T,
     ) -> Option<Canonical<T::Result>>
     where
@@ -117,11 +117,11 @@ struct Inverter<'q, I: Interner> {
     table: &'q mut InferenceTable<I>,
     inverted_ty: FxHashMap<PlaceholderIndex, EnaVariable<I>>,
     inverted_lifetime: FxHashMap<PlaceholderIndex, EnaVariable<I>>,
-    interner: &'q I,
+    interner: I,
 }
 
 impl<'q, I: Interner> Inverter<'q, I> {
-    fn new(interner: &'q I, table: &'q mut InferenceTable<I>) -> Self {
+    fn new(interner: I, table: &'q mut InferenceTable<I>) -> Self {
         Inverter {
             table,
             inverted_ty: FxHashMap::default(),
@@ -131,13 +131,10 @@ impl<'q, I: Interner> Inverter<'q, I> {
     }
 }
 
-impl<'i, I: Interner> Folder<'i, I> for Inverter<'i, I>
-where
-    I: 'i,
-{
+impl<'i, I: Interner> Folder<I> for Inverter<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
         self
     }
 
@@ -177,7 +174,7 @@ where
         true
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 }

--- a/chalk-solve/src/infer/test.rs
+++ b/chalk-solve/src/infer/test.rs
@@ -11,18 +11,18 @@ use chalk_integration::{arg, lifetime, ty};
 struct TestDatabase;
 impl UnificationDatabase<ChalkIr> for TestDatabase {
     fn fn_def_variance(&self, _fn_def_id: FnDefId<ChalkIr>) -> Variances<ChalkIr> {
-        Variances::from_iter(&ChalkIr, [Variance::Invariant; 20].iter().copied())
+        Variances::from_iter(ChalkIr, [Variance::Invariant; 20].iter().copied())
     }
 
     fn adt_variance(&self, _adt_id: AdtId<ChalkIr>) -> Variances<ChalkIr> {
-        Variances::from_iter(&ChalkIr, [Variance::Invariant; 20].iter().copied())
+        Variances::from_iter(ChalkIr, [Variance::Invariant; 20].iter().copied())
     }
 }
 
 #[test]
 fn universe_error() {
     // exists(A -> forall(X -> A = X)) ---> error
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
     let a = table.new_variable(U0).to_ty(interner);
@@ -41,7 +41,7 @@ fn universe_error() {
 #[test]
 fn cycle_error() {
     // exists(A -> A = foo A) ---> error
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
     let a = table.new_variable(U0).to_ty(interner);
@@ -72,7 +72,7 @@ fn cycle_error() {
 #[test]
 fn cycle_indirect() {
     // exists(A -> A = foo B, A = B) ---> error
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
     let a = table.new_variable(U0).to_ty(interner);
@@ -102,7 +102,7 @@ fn cycle_indirect() {
 #[test]
 fn universe_error_indirect_1() {
     // exists(A -> forall(X -> exists(B -> B = X, A = B))) ---> error
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
     let a = table.new_variable(U0).to_ty(interner);
@@ -132,7 +132,7 @@ fn universe_error_indirect_1() {
 #[test]
 fn universe_error_indirect_2() {
     // exists(A -> forall(X -> exists(B -> B = A, B = X))) ---> error
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
     let a = table.new_variable(U0).to_ty(interner);
@@ -162,7 +162,7 @@ fn universe_error_indirect_2() {
 #[test]
 fn universe_promote() {
     // exists(A -> forall(X -> exists(B -> A = foo(B), A = foo(i32)))) ---> OK
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
     let a = table.new_variable(U0).to_ty(interner);
@@ -192,7 +192,7 @@ fn universe_promote() {
 #[test]
 fn universe_promote_bad() {
     // exists(A -> forall(X -> exists(B -> A = foo(B), B = X))) ---> error
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
     let a = table.new_variable(U0).to_ty(interner);
@@ -224,7 +224,7 @@ fn projection_eq() {
     // exists(A -> A = Item0<<A as Item1>::foo>)
     //                       ^^^^^^^^^^^^ Can A repeat here? For now,
     //                       we say no, but it's an interesting question.
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let environment0 = Environment::new(interner);
     let a = table.new_variable(U0).to_ty(interner);
@@ -255,7 +255,7 @@ fn make_table() -> InferenceTable<ChalkIr> {
 
 #[test]
 fn quantify_simple() {
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table = make_table();
     let _ = table.new_variable(U0);
     let _ = table.new_variable(U1);
@@ -281,7 +281,7 @@ fn quantify_simple() {
 
 #[test]
 fn quantify_bound() {
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table = make_table();
     let environment0 = Environment::new(interner);
 
@@ -324,7 +324,7 @@ fn quantify_bound() {
 
 #[test]
 fn quantify_ty_under_binder() {
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table = make_table();
     let v0 = table.new_variable(U0);
     let v1 = table.new_variable(U0);
@@ -369,7 +369,7 @@ fn quantify_ty_under_binder() {
 
 #[test]
 fn lifetime_constraint_indirect() {
-    let interner = &ChalkIr;
+    let interner = ChalkIr;
     let mut table: InferenceTable<ChalkIr> = InferenceTable::new();
     let _ = table.new_universe(); // U1
 

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -8,7 +8,7 @@ use std::ops::ControlFlow;
 use super::InferenceTable;
 
 impl<I: Interner> InferenceTable<I> {
-    pub fn u_canonicalize<T>(interner: &I, value0: &Canonical<T>) -> UCanonicalized<T::Result>
+    pub fn u_canonicalize<T>(interner: I, value0: &Canonical<T>) -> UCanonicalized<T::Result>
     where
         T: Clone + HasInterner<Interner = I> + Fold<I> + Visit<I>,
         T::Result: HasInterner<Interner = I>,
@@ -80,7 +80,7 @@ pub trait UniverseMapExt {
     fn map_universe_from_canonical(&self, universe: UniverseIndex) -> UniverseIndex;
     fn map_from_canonical<T, I>(
         &self,
-        interner: &I,
+        interner: I,
         canonical_value: &Canonical<T>,
     ) -> Canonical<T::Result>
     where
@@ -159,7 +159,7 @@ impl UniverseMapExt for UniverseMap {
     /// other original universes.
     fn map_from_canonical<T, I>(
         &self,
-        interner: &I,
+        interner: I,
         canonical_value: &Canonical<T>,
     ) -> Canonical<T::Result>
     where
@@ -195,18 +195,15 @@ impl UniverseMapExt for UniverseMap {
 
 /// The `UCollector` is a "no-op" in terms of the value, but along the
 /// way it collects all universes that were found into a vector.
-struct UCollector<'q, 'i, I> {
+struct UCollector<'q, I> {
     universes: &'q mut UniverseMap,
-    interner: &'i I,
+    interner: I,
 }
 
-impl<'i, I: Interner> Visitor<'i, I> for UCollector<'_, 'i, I>
-where
-    I: 'i,
-{
+impl<I: Interner> Visitor<I> for UCollector<'_, I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
         self
     }
 
@@ -223,23 +220,20 @@ where
         true
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 }
 
 struct UMapToCanonical<'q, I> {
-    interner: &'q I,
+    interner: I,
     universes: &'q UniverseMap,
 }
 
-impl<'i, I: Interner> Folder<'i, I> for UMapToCanonical<'i, I>
-where
-    I: 'i,
-{
+impl<'i, I: Interner> Folder<I> for UMapToCanonical<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
         self
     }
 
@@ -298,23 +292,20 @@ where
         .to_const(self.interner(), ty.clone()))
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 }
 
 struct UMapFromCanonical<'q, I> {
-    interner: &'q I,
+    interner: I,
     universes: &'q UniverseMap,
 }
 
-impl<'i, I: Interner> Folder<'i, I> for UMapFromCanonical<'i, I>
-where
-    I: 'i,
-{
+impl<'i, I: Interner> Folder<I> for UMapFromCanonical<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<'i, I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
         self
     }
 
@@ -348,7 +339,7 @@ where
         true
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 }

--- a/chalk-solve/src/infer/var.rs
+++ b/chalk-solve/src/infer/var.rs
@@ -60,28 +60,28 @@ impl<I: Interner> EnaVariable<I> {
     /// Convert this inference variable into a type. When using this
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a type (we can't check it).
-    pub fn to_ty_with_kind(self, interner: &I, kind: TyVariableKind) -> Ty<I> {
+    pub fn to_ty_with_kind(self, interner: I, kind: TyVariableKind) -> Ty<I> {
         self.var.to_ty(interner, kind)
     }
 
     /// Same as `to_ty_with_kind`, but the kind is set to `TyVariableKind::General`.
     /// This should be used instead of `to_ty_with_kind` when creating a new
     /// inference variable (when the kind is not known).
-    pub fn to_ty(self, interner: &I) -> Ty<I> {
+    pub fn to_ty(self, interner: I) -> Ty<I> {
         self.var.to_ty(interner, TyVariableKind::General)
     }
 
     /// Convert this inference variable into a lifetime. When using this
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a lifetime (we can't check it).
-    pub fn to_lifetime(self, interner: &I) -> Lifetime<I> {
+    pub fn to_lifetime(self, interner: I) -> Lifetime<I> {
         self.var.to_lifetime(interner)
     }
 
     /// Convert this inference variable into a const. When using this
     /// method, naturally you should know from context that the kind
     /// of this inference variable is a const (we can't check it).
-    pub fn to_const(self, interner: &I, ty: Ty<I>) -> Const<I> {
+    pub fn to_const(self, interner: I, ty: Ty<I>) -> Const<I> {
         self.var.to_const(interner, ty)
     }
 }
@@ -112,15 +112,15 @@ pub enum InferenceValue<I: Interner> {
 }
 
 impl<I: Interner> InferenceValue<I> {
-    pub fn from_ty(interner: &I, ty: Ty<I>) -> Self {
+    pub fn from_ty(interner: I, ty: Ty<I>) -> Self {
         InferenceValue::Bound(ty.cast(interner))
     }
 
-    pub fn from_lifetime(interner: &I, lifetime: Lifetime<I>) -> Self {
+    pub fn from_lifetime(interner: I, lifetime: Lifetime<I>) -> Self {
         InferenceValue::Bound(lifetime.cast(interner))
     }
 
-    pub fn from_const(interner: &I, constant: Const<I>) -> Self {
+    pub fn from_const(interner: I, constant: Const<I>) -> Self {
         InferenceValue::Bound(constant.cast(interner))
     }
 }

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -123,7 +123,7 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// `program_clauses_for_env` function and then possibly cache the clauses.
     fn program_clauses_for_env(&self, environment: &Environment<I>) -> ProgramClauses<I>;
 
-    fn interner(&self) -> &I;
+    fn interner(&self) -> I;
 
     /// Check if a trait is object safe
     fn is_object_safe(&self, trait_id: TraitId<I>) -> bool;

--- a/chalk-solve/src/logging_db.rs
+++ b/chalk-solve/src/logging_db.rs
@@ -221,7 +221,7 @@ where
         self.ws.db().program_clauses_for_env(environment)
     }
 
-    fn interner(&self) -> &I {
+    fn interner(&self) -> I {
         self.ws.db().interner()
     }
 
@@ -469,7 +469,7 @@ where
         self.db.program_clauses_for_env(environment)
     }
 
-    fn interner(&self) -> &I {
+    fn interner(&self) -> I {
         self.db.interner()
     }
 

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -115,16 +115,13 @@ impl<'i, I: Interner, DB: RustIrDatabase<I>> IdCollector<'i, I, DB> {
     }
 }
 
-impl<'i, I: Interner, DB: RustIrDatabase<I>> Visitor<'i, I> for IdCollector<'i, I, DB>
-where
-    I: 'i,
-{
+impl<'i, I: Interner, DB: RustIrDatabase<I>> Visitor<I> for IdCollector<'i, I, DB> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
         self
     }
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.db.interner()
     }
 

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -61,7 +61,7 @@ impl<I: Interner> Solution<I> {
     //    Clone`.
     //
     // But you get the idea.
-    pub fn combine(self, other: Solution<I>, interner: &I) -> Solution<I> {
+    pub fn combine(self, other: Solution<I>, interner: I) -> Solution<I> {
         use self::Guidance::*;
 
         if self == other {
@@ -100,7 +100,7 @@ impl<I: Interner> Solution<I> {
     }
 
     /// Extract a constrained substitution from this solution, even if ambiguous.
-    pub fn constrained_subst(&self, interner: &I) -> Option<Canonical<ConstrainedSubst<I>>> {
+    pub fn constrained_subst(&self, interner: I) -> Option<Canonical<ConstrainedSubst<I>>> {
         match *self {
             Solution::Unique(ref constrained) => Some(constrained.clone()),
             Solution::Ambig(Guidance::Definite(ref canonical))
@@ -120,7 +120,7 @@ impl<I: Interner> Solution<I> {
 
     /// Determine whether this solution contains type information that *must*
     /// hold, and returns the subst in that case.
-    pub fn definite_subst(&self, interner: &I) -> Option<Canonical<ConstrainedSubst<I>>> {
+    pub fn definite_subst(&self, interner: I) -> Option<Canonical<ConstrainedSubst<I>>> {
         match self {
             Solution::Unique(constrained) => Some(constrained.clone()),
             Solution::Ambig(Guidance::Definite(canonical)) => {
@@ -145,7 +145,7 @@ impl<I: Interner> Solution<I> {
         matches!(*self, Solution::Ambig(_))
     }
 
-    pub fn display<'a>(&'a self, interner: &'a I) -> SolutionDisplay<'a, I> {
+    pub fn display<'a>(&'a self, interner: I) -> SolutionDisplay<'a, I> {
         SolutionDisplay {
             solution: self,
             interner,
@@ -155,23 +155,25 @@ impl<I: Interner> Solution<I> {
 
 pub struct SolutionDisplay<'a, I: Interner> {
     solution: &'a Solution<I>,
-    interner: &'a I,
+    interner: I,
 }
 
 impl<'a, I: Interner> fmt::Display for SolutionDisplay<'a, I> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let SolutionDisplay { solution, interner } = self;
         match solution {
-            Solution::Unique(constrained) => write!(f, "Unique; {}", constrained.display(interner)),
+            Solution::Unique(constrained) => {
+                write!(f, "Unique; {}", constrained.display(*interner))
+            }
             Solution::Ambig(Guidance::Definite(subst)) => write!(
                 f,
                 "Ambiguous; definite substitution {}",
-                subst.display(interner)
+                subst.display(*interner)
             ),
             Solution::Ambig(Guidance::Suggested(subst)) => write!(
                 f,
                 "Ambiguous; suggested substitution {}",
-                subst.display(interner)
+                subst.display(*interner)
             ),
             Solution::Ambig(Guidance::Unknown) => write!(f, "Ambiguous; no inference guidance"),
         }

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -20,7 +20,7 @@ use std::ops::ControlFlow;
 /// - Radial Restraint
 ///   - Grosof and Swift; 2013
 pub fn needs_truncation<I: Interner>(
-    interner: &I,
+    interner: I,
     infer: &mut InferenceTable<I>,
     max_size: usize,
     value: impl Visit<I>,
@@ -31,16 +31,16 @@ pub fn needs_truncation<I: Interner>(
     visitor.max_size > max_size
 }
 
-struct TySizeVisitor<'infer, 'i, I: Interner> {
-    interner: &'i I,
+struct TySizeVisitor<'infer, I: Interner> {
+    interner: I,
     infer: &'infer mut InferenceTable<I>,
     size: usize,
     depth: usize,
     max_size: usize,
 }
 
-impl<'infer, 'i, I: Interner> TySizeVisitor<'infer, 'i, I> {
-    fn new(interner: &'i I, infer: &'infer mut InferenceTable<I>) -> Self {
+impl<'infer, I: Interner> TySizeVisitor<'infer, I> {
+    fn new(interner: I, infer: &'infer mut InferenceTable<I>) -> Self {
         Self {
             interner,
             infer,
@@ -51,10 +51,10 @@ impl<'infer, 'i, I: Interner> TySizeVisitor<'infer, 'i, I> {
     }
 }
 
-impl<'infer, 'i, I: Interner> Visitor<'i, I> for TySizeVisitor<'infer, 'i, I> {
+impl<'infer, I: Interner> Visitor<I> for TySizeVisitor<'infer, I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
         self
     }
 
@@ -79,7 +79,7 @@ impl<'infer, 'i, I: Interner> Visitor<'i, I> for TySizeVisitor<'infer, 'i, I> {
         ControlFlow::Continue(())
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 }
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn one_type() {
         use chalk_integration::interner::ChalkIr;
-        let interner = &ChalkIr;
+        let interner = ChalkIr;
         let mut table = InferenceTable::<chalk_integration::interner::ChalkIr>::new();
         let _u1 = table.new_universe();
 
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn multiple_types() {
         use chalk_integration::interner::ChalkIr;
-        let interner = &ChalkIr;
+        let interner = ChalkIr;
         let mut table = InferenceTable::<chalk_integration::interner::ChalkIr>::new();
         let _u1 = table.new_universe();
 

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -49,33 +49,33 @@ pub struct WfSolver<'a, I: Interner> {
     solver_builder: &'a dyn Fn() -> Box<dyn Solver<I>>,
 }
 
-struct InputTypeCollector<'i, I: Interner> {
+struct InputTypeCollector<I: Interner> {
     types: Vec<Ty<I>>,
-    interner: &'i I,
+    interner: I,
 }
 
-impl<'i, I: Interner> InputTypeCollector<'i, I> {
-    fn new(interner: &'i I) -> Self {
+impl<I: Interner> InputTypeCollector<I> {
+    fn new(interner: I) -> Self {
         Self {
             types: Vec::new(),
             interner,
         }
     }
 
-    fn types_in(interner: &'i I, value: impl Visit<I>) -> Vec<Ty<I>> {
+    fn types_in(interner: I, value: impl Visit<I>) -> Vec<Ty<I>> {
         let mut collector = Self::new(interner);
         value.visit_with(&mut collector, DebruijnIndex::INNERMOST);
         collector.types
     }
 }
 
-impl<'i, I: Interner> Visitor<'i, I> for InputTypeCollector<'i, I> {
+impl<I: Interner> Visitor<I> for InputTypeCollector<I> {
     type BreakTy = ();
-    fn as_dyn(&mut self) -> &mut dyn Visitor<'i, I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
         self
     }
 
-    fn interner(&self) -> &'i I {
+    fn interner(&self) -> I {
         self.interner
     }
 
@@ -491,7 +491,7 @@ fn impl_header_wf_goal<I: Interner>(
 /// Creates the conditions that an impl (and its contents of an impl)
 /// can assume to be true when proving that it is well-formed.
 fn impl_wf_environment<'i, I: Interner>(
-    interner: &'i I,
+    interner: I,
     where_clauses: &'i [QuantifiedWhereClause<I>],
     trait_ref: &'i TraitRef<I>,
 ) -> impl Iterator<Item = ProgramClause<I>> + 'i {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ impl LoadedProgram {
         let peeled_goal = goal.into_peeled_goal(self.db.interner());
         if multiple_answers {
             if self.db.solve_multiple(&peeled_goal, &mut |v, has_next| {
-                println!("{}\n", v.as_ref().map(|v| v.display(&ChalkIr)));
+                println!("{}\n", v.as_ref().map(|v| v.display(ChalkIr)));
                 if has_next {
                     if let Some(ref mut rl) = rl {
                         loop {
@@ -97,7 +97,7 @@ impl LoadedProgram {
             }
         } else {
             match self.db.solve(&peeled_goal) {
-                Some(v) => println!("{}\n", v.display(&ChalkIr)),
+                Some(v) => println!("{}\n", v.display(ChalkIr)),
                 None => println!("No possible solution.\n"),
             }
         }

--- a/tests/display/unique_names.rs
+++ b/tests/display/unique_names.rs
@@ -151,7 +151,7 @@ where
     ) -> chalk_ir::ProgramClauses<I> {
         self.db.program_clauses_for_env(environment)
     }
-    fn interner(&self) -> &I {
+    fn interner(&self) -> I {
         self.db.interner()
     }
     fn is_object_safe(&self, trait_id: chalk_ir::TraitId<I>) -> bool {

--- a/tests/integration/panic.rs
+++ b/tests/integration/panic.rs
@@ -68,7 +68,7 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
         Arc::new(TraitDatum {
             id,
             binders: Binders::new(
-                VariableKinds::empty(&ChalkIr),
+                VariableKinds::empty(ChalkIr),
                 TraitDatumBound {
                     where_clauses: vec![],
                 },
@@ -95,16 +95,16 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
         assert_eq!(id.0.index, 1);
 
         let substitution = Ty::new(
-            &ChalkIr,
-            TyKind::Adt(AdtId(RawId { index: 1 }), Substitution::empty(&ChalkIr)),
+            ChalkIr,
+            TyKind::Adt(AdtId(RawId { index: 1 }), Substitution::empty(ChalkIr)),
         );
 
         let binders = Binders::new(
-            VariableKinds::empty(&ChalkIr),
+            VariableKinds::empty(ChalkIr),
             ImplDatumBound {
                 trait_ref: TraitRef {
                     trait_id: TraitId(RawId { index: 0 }),
-                    substitution: Substitution::from1(&ChalkIr, substitution),
+                    substitution: Substitution::from1(ChalkIr, substitution),
                 },
                 where_clauses: vec![],
             },
@@ -137,7 +137,7 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
         // Only needed because we always access the adt datum for logging
         Arc::new(AdtDatum {
             binders: Binders::empty(
-                &ChalkIr,
+                ChalkIr,
                 AdtDatumBound {
                     variants: vec![],
                     where_clauses: vec![],
@@ -207,15 +207,15 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
             panic!("program_clauses_for_env panic")
         }
 
-        ProgramClauses::empty(&ChalkIr)
+        ProgramClauses::empty(ChalkIr)
     }
 
-    fn interner(&self) -> &ChalkIr {
+    fn interner(&self) -> ChalkIr {
         if let PanickingMethod::Interner = self.panicking_method {
             panic!("interner panic")
         }
 
-        &ChalkIr
+        ChalkIr
     }
 
     fn is_object_safe(&self, trait_id: TraitId<ChalkIr>) -> bool {
@@ -272,23 +272,23 @@ fn prepare_goal() -> UCanonical<InEnvironment<Goal<ChalkIr>>> {
     // Foo: Bar
     UCanonical {
         canonical: Canonical {
-            binders: CanonicalVarKinds::empty(&ChalkIr),
+            binders: CanonicalVarKinds::empty(ChalkIr),
             value: InEnvironment {
-                environment: Environment::new(&ChalkIr),
+                environment: Environment::new(ChalkIr),
                 goal: GoalData::DomainGoal(DomainGoal::Holds(WhereClause::Implemented(TraitRef {
                     trait_id: TraitId(interner::RawId { index: 0 }),
                     substitution: Substitution::from1(
-                        &ChalkIr,
+                        ChalkIr,
                         Ty::new(
-                            &ChalkIr,
+                            ChalkIr,
                             TyKind::Adt(
                                 AdtId(interner::RawId { index: 1 }),
-                                Substitution::empty(&ChalkIr),
+                                Substitution::empty(ChalkIr),
                             ),
                         ),
                     ),
                 })))
-                .intern(&ChalkIr),
+                .intern(ChalkIr),
             },
         },
         universes: 1,

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -17,7 +17,7 @@ mod bench;
 mod coherence;
 mod wf_lowering;
 
-pub fn assert_result(mut result: Option<Solution<ChalkIr>>, expected: &str, interner: &ChalkIr) {
+pub fn assert_result(mut result: Option<Solution<ChalkIr>>, expected: &str, interner: ChalkIr) {
     // sort constraints, since the different solvers may output them in different order
     match &mut result {
         Some(Solution::Unique(solution)) => {
@@ -28,7 +28,7 @@ pub fn assert_result(mut result: Option<Solution<ChalkIr>>, expected: &str, inte
         _ => {}
     }
     let result = match result {
-        Some(v) => format!("{}", v.display(&ChalkIr)),
+        Some(v) => format!("{}", v.display(ChalkIr)),
         None => format!("No possible solution"),
     };
 
@@ -276,7 +276,7 @@ fn solve_goal(program_text: &str, goals: Vec<(&str, SolverChoice, TestGoal)>, co
                                         assert_same(
                                             &format!(
                                                 "{}",
-                                                result.as_ref().map(|v| v.display(&ChalkIr))
+                                                result.as_ref().map(|v| v.display(ChalkIr))
                                             ),
                                             expected,
                                         );
@@ -300,7 +300,7 @@ fn solve_goal(program_text: &str, goals: Vec<(&str, SolverChoice, TestGoal)>, co
                         {
                             Some(solution) => {
                                 assert_same(
-                                    &format!("{}", result.as_ref().map(|v| v.display(&ChalkIr))),
+                                    &format!("{}", result.as_ref().map(|v| v.display(ChalkIr))),
                                     solution,
                                 );
                                 if !next_result {

--- a/tests/test/type_flags.rs
+++ b/tests/test/type_flags.rs
@@ -7,7 +7,7 @@ use chalk_ir::{PlaceholderIndex, TyKind, TypeFlags, UniverseIndex};
 fn placeholder_ty_flags_correct() {
     let placeholder_ty = ty!(placeholder 0);
     assert_eq!(
-        placeholder_ty.data(&ChalkIr).flags,
+        placeholder_ty.data(ChalkIr).flags,
         TypeFlags::HAS_TY_PLACEHOLDER
     );
 }
@@ -19,24 +19,24 @@ fn opaque_ty_flags_correct() {
             0: chalk_integration::interner::RawId { index: 0 },
         },
         substitution: chalk_ir::Substitution::from_iter(
-            &ChalkIr,
+            ChalkIr,
             Some(
                 chalk_ir::ConstData {
                     ty: TyKind::Placeholder(PlaceholderIndex {
                         ui: chalk_ir::UniverseIndex::ROOT,
                         idx: 0,
                     })
-                    .intern(&ChalkIr),
+                    .intern(ChalkIr),
                     value: chalk_ir::ConstValue::InferenceVar(chalk_ir::InferenceVar::from(0)),
                 }
-                .intern(&ChalkIr)
-                .cast(&ChalkIr),
+                .intern(ChalkIr)
+                .cast(ChalkIr),
             ),
         ),
     }))
-    .intern(&ChalkIr);
+    .intern(ChalkIr);
     assert_eq!(
-        opaque_ty.data(&ChalkIr).flags,
+        opaque_ty.data(ChalkIr).flags,
         TypeFlags::HAS_TY_OPAQUE
             | TypeFlags::HAS_CT_INFER
             | TypeFlags::STILL_FURTHER_SPECIALIZABLE
@@ -46,7 +46,7 @@ fn opaque_ty_flags_correct() {
 
 #[test]
 fn dyn_ty_flags_correct() {
-    let internal_ty = TyKind::Scalar(chalk_ir::Scalar::Bool).intern(&ChalkIr);
+    let internal_ty = TyKind::Scalar(chalk_ir::Scalar::Bool).intern(ChalkIr);
     let projection_ty = chalk_ir::ProjectionTy {
         associated_ty_id: chalk_ir::AssocTypeId {
             0: chalk_integration::interner::RawId { index: 0 },
@@ -54,11 +54,11 @@ fn dyn_ty_flags_correct() {
         substitution: empty_substitution!(),
     };
     let bounds = chalk_ir::Binders::<chalk_ir::QuantifiedWhereClauses<ChalkIr>>::empty(
-        &ChalkIr,
+        ChalkIr,
         chalk_ir::QuantifiedWhereClauses::from_iter(
-            &ChalkIr,
+            ChalkIr,
             vec![chalk_ir::Binders::<chalk_ir::WhereClause<ChalkIr>>::empty(
-                &ChalkIr,
+                ChalkIr,
                 chalk_ir::WhereClause::AliasEq(chalk_ir::AliasEq {
                     ty: internal_ty,
                     alias: chalk_ir::AliasTy::Projection(projection_ty),
@@ -70,9 +70,9 @@ fn dyn_ty_flags_correct() {
         lifetime: lifetime!(placeholder 5),
         bounds,
     };
-    let ty = TyKind::Dyn(dyn_ty).intern(&ChalkIr);
+    let ty = TyKind::Dyn(dyn_ty).intern(ChalkIr);
     assert_eq!(
-        ty.data(&ChalkIr).flags,
+        ty.data(ChalkIr).flags,
         TypeFlags::HAS_TY_PROJECTION
             | TypeFlags::HAS_RE_PLACEHOLDER
             | TypeFlags::HAS_FREE_LOCAL_REGIONS
@@ -82,8 +82,8 @@ fn dyn_ty_flags_correct() {
 
 #[test]
 fn flagless_ty_has_no_flags() {
-    let ty = TyKind::Str.intern(&ChalkIr);
-    assert_eq!(ty.data(&ChalkIr).flags, TypeFlags::empty());
+    let ty = TyKind::Str.intern(ChalkIr);
+    assert_eq!(ty.data(ChalkIr).flags, TypeFlags::empty());
 
     let fn_ty = TyKind::Function(chalk_ir::FnPointer {
         num_binders: 0,
@@ -94,18 +94,18 @@ fn flagless_ty_has_no_flags() {
             variadic: false,
         },
     })
-    .intern(&ChalkIr);
-    assert_eq!(fn_ty.data(&ChalkIr).flags, TypeFlags::empty());
+    .intern(ChalkIr);
+    assert_eq!(fn_ty.data(ChalkIr).flags, TypeFlags::empty());
 }
 
 #[test]
 fn static_and_bound_lifetimes() {
     let substitutions = chalk_ir::Substitution::from_iter(
-        &ChalkIr,
+        ChalkIr,
         vec![
-            chalk_ir::GenericArgData::Lifetime(chalk_ir::LifetimeData::Static.intern(&ChalkIr))
-                .intern(&ChalkIr),
-            chalk_ir::GenericArgData::Lifetime(lifetime!(bound 5)).intern(&ChalkIr),
+            chalk_ir::GenericArgData::Lifetime(chalk_ir::LifetimeData::Static.intern(ChalkIr))
+                .intern(ChalkIr),
+            chalk_ir::GenericArgData::Lifetime(lifetime!(bound 5)).intern(ChalkIr),
         ],
     );
 
@@ -115,10 +115,10 @@ fn static_and_bound_lifetimes() {
         },
         substitutions,
     )
-    .intern(&ChalkIr);
+    .intern(ChalkIr);
 
     assert_eq!(
-        ty.data(&ChalkIr).flags,
+        ty.data(ChalkIr).flags,
         TypeFlags::HAS_FREE_REGIONS | TypeFlags::HAS_RE_LATE_BOUND
     );
 }


### PR DESCRIPTION
The [`chalk_ir::interner::Interner`](https://rust-lang.github.io/chalk/chalk_ir/interner/trait.Interner.html) trait has `Copy` as a supertrait.  We can therefore use owned copies of `I: Interner` throughout, rather than `&I` references.  This simplifies the API, removing lifetime parameters from numerous items which, in turn, should simplify user code.