### PR TITLE
Allow `test` invocations to elide empty `program` declarations

### DIFF
--- a/tests/test/constants.rs
+++ b/tests/test/constants.rs
@@ -108,8 +108,6 @@ fn generic_impl() {
 #[test]
 fn placeholders_eq() {
     test! {
-        program {}
-
         goal {
             forall<const C, const D> {
                 C = D

--- a/tests/test/misc.rs
+++ b/tests/test/misc.rs
@@ -807,7 +807,6 @@ fn endless_loop() {
 #[test]
 fn env_bound_vars() {
     test! {
-        program {}
         goal {
             exists<'a> {
                 if (WellFormed(&'a ())) {

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -55,6 +55,11 @@ macro_rules! test {
         let (program, goals) = parse_test_data!(program $program $($goals)*);
         solve_goal(program, goals, false)
     }};
+
+    // If `program` is omitted, default to an empty one.
+    ($($goals:tt)*) => {
+        test!(program {} $($goals)*)
+    };
 }
 
 macro_rules! parse_test_data {

--- a/tests/test/never.rs
+++ b/tests/test/never.rs
@@ -3,7 +3,6 @@ use super::*;
 #[test]
 fn never_is_well_formed() {
     test! {
-        program { }
         goal {
             WellFormed(!)
         } yields {

--- a/tests/test/numerics.rs
+++ b/tests/test/numerics.rs
@@ -129,8 +129,6 @@ fn float_ambiguity() {
 #[test]
 fn integer_and_float_are_specialized_ty_kinds() {
     test! {
-        program {}
-
         goal {
             exists<T, int N> {
                 T = N, N = usize
@@ -154,8 +152,6 @@ fn integer_and_float_are_specialized_ty_kinds() {
 #[test]
 fn general_ty_kind_becomes_specific() {
     test! {
-        program {}
-
         goal {
             exists<T, int N> {
                 T = N, T = char
@@ -178,8 +174,6 @@ fn general_ty_kind_becomes_specific() {
 #[test]
 fn integers_are_not_floats() {
     test! {
-        program {}
-
         goal {
             exists<int I, float F> {
                 I = F

--- a/tests/test/refs.rs
+++ b/tests/test/refs.rs
@@ -44,8 +44,6 @@ fn immut_refs_are_sized() {
 #[test]
 fn mut_refs_are_well_formed() {
     test! {
-        program { }
-
         goal {
             forall<'a, T> { WellFormed(&'a mut T) }
         } yields {

--- a/tests/test/scalars.rs
+++ b/tests/test/scalars.rs
@@ -116,8 +116,6 @@ fn scalar_trait_impl() {
 #[test]
 fn scalars_are_well_formed() {
     test! {
-        program { }
-
         goal { WellFormed(i8) } yields { "Unique" }
         goal { WellFormed(i16) } yields { "Unique" }
         goal { WellFormed(i32) } yields { "Unique" }

--- a/tests/test/string.rs
+++ b/tests/test/string.rs
@@ -15,7 +15,6 @@ fn str_trait_impl() {
 #[test]
 fn str_is_well_formed() {
     test! {
-        program {}
         goal { WellFormed(str) } yields { "Unique" }
     }
 }

--- a/tests/test/subtype.rs
+++ b/tests/test/subtype.rs
@@ -55,9 +55,6 @@ fn struct_lifetime_variance() {
 #[test]
 fn ref_lifetime_variance() {
     test! {
-        program {
-        }
-
         goal {
             forall<'a, 'b> {
                 Subtype(&'a u32, &'b u32)
@@ -74,9 +71,6 @@ fn ref_lifetime_variance() {
 #[test]
 fn fn_lifetime_variance_args() {
     test! {
-        program {
-        }
-
         goal {
             for<'a, 'b> fn(&'a u32, &'b u32) = for<'a> fn(&'a u32, &'a u32)
         } yields[SolverChoice::recursive_default()] {
@@ -100,9 +94,6 @@ fn fn_lifetime_variance_args() {
 #[test]
 fn fn_lifetime_variance_with_return_type() {
     test! {
-        program {
-        }
-
         goal {
             Subtype(for<'a, 'b> fn(&'a u32, &'b u32) -> &'a u32, for<'a> fn(&'a u32, &'a u32) -> &'a u32)
         } yields {
@@ -151,8 +142,6 @@ fn generalize() {
 #[test]
 fn multi_lifetime() {
     test! {
-        program {}
-
         goal {
             forall<'a, 'b> {
                 exists<U> {
@@ -183,8 +172,6 @@ fn multi_lifetime() {
 #[test]
 fn multi_lifetime_inverted() {
     test! {
-        program {}
-
         goal {
             forall<'a, 'b> {
                 exists<U> {
@@ -347,9 +334,6 @@ fn multi_lifetime_invariant_struct() {
 #[test]
 fn multi_lifetime_slice() {
     test! {
-        program {
-        }
-
         goal {
             forall<'a, 'b> {
                 exists<U> {
@@ -385,9 +369,6 @@ fn multi_lifetime_slice() {
 #[test]
 fn multi_lifetime_tuple() {
     test! {
-        program {
-        }
-
         goal {
             forall<'a, 'b> {
                 exists<U> {
@@ -423,9 +404,6 @@ fn multi_lifetime_tuple() {
 #[test]
 fn multi_lifetime_array() {
     test! {
-        program {
-        }
-
         goal {
             forall<'a, 'b> {
                 exists<U> {
@@ -543,9 +521,6 @@ fn generalize_invariant_struct() {
 #[test]
 fn generalize_slice() {
     test! {
-        program {
-        }
-
         goal {
             forall<'a, 'b> {
                 exists<U> {
@@ -581,9 +556,6 @@ fn generalize_slice() {
 #[test]
 fn generalize_tuple() {
     test! {
-        program {
-        }
-
         goal {
             forall<'a, 'b> {
                 exists<U> {
@@ -619,9 +591,6 @@ fn generalize_tuple() {
 #[test]
 fn generalize_2tuple() {
     test! {
-        program {
-        }
-
         goal {
             forall<'a, 'b, 'c, 'd> {
                 exists<U> {
@@ -659,9 +628,6 @@ fn generalize_2tuple() {
 #[test]
 fn generalize_array() {
     test! {
-        program {
-        }
-
         goal {
             forall<'a, 'b> {
                 exists<U> {

--- a/tests/test/unify.rs
+++ b/tests/test/unify.rs
@@ -180,9 +180,6 @@ fn forall_equality() {
 #[test]
 fn unify_quantified_lifetimes() {
     test! {
-        program {
-        }
-
         // Check that `'a` (here, `'^0.0`) is not unified
         // with `'!1_0`, because they belong to incompatible
         // universes.

--- a/tests/test/wf_goals.rs
+++ b/tests/test/wf_goals.rs
@@ -111,8 +111,6 @@ fn drop_compatible() {
 #[test]
 fn placeholder_wf() {
     test! {
-        program { }
-
         goal {
             forall<T> { WellFormed(T) }
         } yields {


### PR DESCRIPTION
This is a bit silly, but there are quite a few of these in `tests/subtype.rs`.