### PR TITLE
Fix clippy warnings

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -84,7 +84,7 @@ fn find_interner(s: &mut synstructure::Structure) -> (TokenStream, DeriveKind) {
 
     let generic_param0 = get_generic_param(input);
 
-    if let Some(param) = has_interner(&generic_param0) {
+    if let Some(param) = has_interner(generic_param0) {
         // HasInterner bound:
         //
         // Example:
@@ -98,7 +98,7 @@ fn find_interner(s: &mut synstructure::Structure) -> (TokenStream, DeriveKind) {
         );
 
         (quote! { _I }, DeriveKind::FromHasInterner)
-    } else if let Some(i) = is_interner(&generic_param0) {
+    } else if let Some(i) = is_interner(generic_param0) {
         // Interner bound:
         //
         // Example:

--- a/chalk-engine/src/context.rs
+++ b/chalk-engine/src/context.rs
@@ -27,10 +27,7 @@ pub enum AnswerResult<I: Interner> {
 
 impl<I: Interner> AnswerResult<I> {
     pub fn is_answer(&self) -> bool {
-        match self {
-            Self::Answer(_) => true,
-            _ => false,
-        }
+        matches!(self, Self::Answer(_))
     }
 
     pub fn answer(self) -> CompleteAnswer<I> {
@@ -41,17 +38,11 @@ impl<I: Interner> AnswerResult<I> {
     }
 
     pub fn is_no_more_solutions(&self) -> bool {
-        match self {
-            Self::NoMoreSolutions => true,
-            _ => false,
-        }
+        matches!(self, Self::NoMoreSolutions)
     }
 
     pub fn is_quantum_exceeded(&self) -> bool {
-        match self {
-            Self::QuantumExceeded => true,
-            _ => false,
-        }
+        matches!(self, Self::QuantumExceeded)
     }
 }
 

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -951,7 +951,7 @@ impl<'forest, I: Interner> SolveState<'forest, I> {
                 Ok(_) => {
                     debug!(?strand, "merged answer into current strand");
                     canonical_strand =
-                        Forest::canonicalize_strand_from(&self.context, &mut infer, &strand);
+                        Forest::canonicalize_strand_from(self.context, &mut infer, &strand);
                     self.stack.top().active_strand = Some(canonical_strand);
                     return Ok(());
                 }

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -687,7 +687,7 @@ impl<'forest, I: Interner> SolveState<'forest, I> {
                         ex_clause.answer_time.increment();
 
                         // Ok, we've applied the answer to this Strand.
-                        return Ok(());
+                        Ok(())
                     }
 
                     // This answer led nowhere. Give up for now, but of course
@@ -700,7 +700,7 @@ impl<'forest, I: Interner> SolveState<'forest, I> {
 
                         // Now we want to propogate back to the up with `QuantumExceeded`
                         self.unwind_stack();
-                        return Err(RootSearchFail::QuantumExceeded);
+                        Err(RootSearchFail::QuantumExceeded)
                     }
                 }
             }
@@ -749,9 +749,9 @@ impl<'forest, I: Interner> SolveState<'forest, I> {
                 strand.ex_clause.ambiguous = true;
 
                 // Strand is ambigious.
-                return Ok(());
+                Ok(())
             }
-        };
+        }
     }
 
     /// This is called when the selected subgoal for a strand has floundered.
@@ -1224,7 +1224,7 @@ impl<'forest, I: Interner> SolveState<'forest, I> {
 
             // Now we yield with `QuantumExceeded`
             self.unwind_stack();
-            return Err(RootSearchFail::QuantumExceeded);
+            Err(RootSearchFail::QuantumExceeded)
         } else {
             debug!("table part of a cycle");
 
@@ -1267,7 +1267,7 @@ impl<'forest, I: Interner> SolveState<'forest, I> {
             self.forest.tables[table].enqueue_strand(active_strand);
 
             // The strand isn't active, but the table is, so just continue
-            return Ok(());
+            Ok(())
         }
     }
 

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -1483,7 +1483,7 @@ impl<'forest, I: Interner> SolveState<'forest, I> {
             .collect();
 
         let subst = Canonical {
-            binders: binders.clone(),
+            binders: binders,
             value: AnswerSubst {
                 subst,
                 constraints: Constraints::from_iter(self.context.program().interner(), constraints),

--- a/chalk-engine/src/logic.rs
+++ b/chalk-engine/src/logic.rs
@@ -1483,7 +1483,7 @@ impl<'forest, I: Interner> SolveState<'forest, I> {
             .collect();
 
         let subst = Canonical {
-            binders: binders,
+            binders,
             value: AnswerSubst {
                 subst,
                 constraints: Constraints::from_iter(self.context.program().interner(), constraints),

--- a/chalk-engine/src/slg/aggregate.rs
+++ b/chalk-engine/src/slg/aggregate.rs
@@ -31,7 +31,7 @@ impl<I: Interner> AggregateOps<I> for SlgContextOps<'_, I> {
         should_continue: impl std::ops::Fn() -> bool,
     ) -> Option<Solution<I>> {
         let interner = self.program.interner();
-        let CompleteAnswer { subst, ambiguous } = match answers.next_answer(|| should_continue()) {
+        let CompleteAnswer { subst, ambiguous } = match answers.next_answer(&should_continue) {
             AnswerResult::NoMoreSolutions => {
                 // No answers at all
                 return None;
@@ -47,7 +47,7 @@ impl<I: Interner> AggregateOps<I> for SlgContextOps<'_, I> {
         };
 
         // Exactly 1 unconditional answer?
-        let next_answer = answers.peek_answer(|| should_continue());
+        let next_answer = answers.peek_answer(&should_continue);
         if next_answer.is_quantum_exceeded() {
             if subst.value.subst.is_identity_subst(interner) {
                 return Some(Solution::Ambig(Guidance::Unknown));
@@ -95,7 +95,7 @@ impl<I: Interner> AggregateOps<I> for SlgContextOps<'_, I> {
                 }
             }
 
-            let new_subst = match answers.next_answer(|| should_continue()) {
+            let new_subst = match answers.next_answer(&should_continue) {
                 AnswerResult::Answer(answer1) => answer1.subst,
                 AnswerResult::Floundered => {
                     // FIXME: this doesn't trigger for any current tests

--- a/chalk-engine/src/slg/resolvent.rs
+++ b/chalk-engine/src/slg/resolvent.rs
@@ -329,7 +329,7 @@ impl<I: Interner> AnswerSubstitutor<'_, I> {
         let result = self.table.relate(
             interner,
             db,
-            &self.environment,
+            self.environment,
             variance,
             answer_param,
             &GenericArg::new(interner, pending_shifted),

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -45,7 +45,7 @@ impl<I: Interner> Fold<I> for Strand<I> {
         Ok(Strand {
             ex_clause: self.ex_clause.fold_with(folder, outer_binder)?,
             last_pursued_time: self.last_pursued_time,
-            selected_subgoal: self.selected_subgoal.clone(),
+            selected_subgoal: self.selected_subgoal,
         })
     }
 }

--- a/chalk-engine/src/table.rs
+++ b/chalk-engine/src/table.rs
@@ -83,7 +83,7 @@ impl<I: Interner> Table<I> {
     }
 
     pub(crate) fn take_strands(&mut self) -> VecDeque<CanonicalStrand<I>> {
-        mem::replace(&mut self.strands, VecDeque::new())
+        mem::take(&mut self.strands)
     }
 
     /// Remove the next strand from the queue that meets the given criteria

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -40,7 +40,7 @@ impl ChalkDatabase {
 
     pub fn with_program<R>(&self, op: impl FnOnce(&Program) -> R) -> R {
         let program = &self.checked_program().unwrap();
-        tls::set_current_program(&program, || op(&program))
+        tls::set_current_program(program, || op(program))
     }
 
     pub fn parse_and_lower_goal(&self, text: &str) -> Result<Goal<ChalkIr>, ChalkError> {

--- a/chalk-integration/src/interner.rs
+++ b/chalk-integration/src/interner.rs
@@ -241,7 +241,7 @@ impl Interner for ChalkIr {
         Arc::new(TyData { kind, flags })
     }
 
-    fn ty_data<'a>(self, ty: &'a Arc<TyData<ChalkIr>>) -> &'a TyData<Self> {
+    fn ty_data(self, ty: &Arc<TyData<ChalkIr>>) -> &TyData<Self> {
         ty
     }
 
@@ -249,7 +249,7 @@ impl Interner for ChalkIr {
         lifetime
     }
 
-    fn lifetime_data<'a>(self, lifetime: &'a LifetimeData<ChalkIr>) -> &'a LifetimeData<ChalkIr> {
+    fn lifetime_data(self, lifetime: &LifetimeData<ChalkIr>) -> &LifetimeData<ChalkIr> {
         lifetime
     }
 
@@ -257,7 +257,7 @@ impl Interner for ChalkIr {
         Arc::new(constant)
     }
 
-    fn const_data<'a>(self, constant: &'a Arc<ConstData<ChalkIr>>) -> &'a ConstData<ChalkIr> {
+    fn const_data(self, constant: &Arc<ConstData<ChalkIr>>) -> &ConstData<ChalkIr> {
         constant
     }
 
@@ -269,10 +269,7 @@ impl Interner for ChalkIr {
         generic_arg
     }
 
-    fn generic_arg_data<'a>(
-        self,
-        generic_arg: &'a GenericArgData<ChalkIr>,
-    ) -> &'a GenericArgData<ChalkIr> {
+    fn generic_arg_data(self, generic_arg: &GenericArgData<ChalkIr>) -> &GenericArgData<ChalkIr> {
         generic_arg
     }
 
@@ -280,7 +277,7 @@ impl Interner for ChalkIr {
         Arc::new(goal)
     }
 
-    fn goal_data<'a>(self, goal: &'a Arc<GoalData<ChalkIr>>) -> &'a GoalData<ChalkIr> {
+    fn goal_data(self, goal: &Arc<GoalData<ChalkIr>>) -> &GoalData<ChalkIr> {
         goal
     }
 
@@ -291,7 +288,7 @@ impl Interner for ChalkIr {
         data.into_iter().collect()
     }
 
-    fn goals_data<'a>(self, goals: &'a Vec<Goal<ChalkIr>>) -> &'a [Goal<ChalkIr>] {
+    fn goals_data(self, goals: &Vec<Goal<ChalkIr>>) -> &[Goal<ChalkIr>] {
         goals
     }
 
@@ -302,10 +299,7 @@ impl Interner for ChalkIr {
         data.into_iter().collect()
     }
 
-    fn substitution_data<'a>(
-        self,
-        substitution: &'a Vec<GenericArg<ChalkIr>>,
-    ) -> &'a [GenericArg<ChalkIr>] {
+    fn substitution_data(self, substitution: &Vec<GenericArg<ChalkIr>>) -> &[GenericArg<ChalkIr>] {
         substitution
     }
 
@@ -313,10 +307,7 @@ impl Interner for ChalkIr {
         data
     }
 
-    fn program_clause_data<'a>(
-        self,
-        clause: &'a ProgramClauseData<Self>,
-    ) -> &'a ProgramClauseData<Self> {
+    fn program_clause_data(self, clause: &ProgramClauseData<Self>) -> &ProgramClauseData<Self> {
         clause
     }
 
@@ -327,10 +318,7 @@ impl Interner for ChalkIr {
         data.into_iter().collect()
     }
 
-    fn program_clauses_data<'a>(
-        self,
-        clauses: &'a Vec<ProgramClause<Self>>,
-    ) -> &'a [ProgramClause<Self>] {
+    fn program_clauses_data(self, clauses: &Vec<ProgramClause<Self>>) -> &[ProgramClause<Self>] {
         clauses
     }
 
@@ -341,10 +329,10 @@ impl Interner for ChalkIr {
         data.into_iter().collect()
     }
 
-    fn quantified_where_clauses_data<'a>(
+    fn quantified_where_clauses_data(
         self,
-        clauses: &'a Self::InternedQuantifiedWhereClauses,
-    ) -> &'a [QuantifiedWhereClause<Self>] {
+        clauses: &Self::InternedQuantifiedWhereClauses,
+    ) -> &[QuantifiedWhereClause<Self>] {
         clauses
     }
     fn intern_generic_arg_kinds<E>(
@@ -354,10 +342,10 @@ impl Interner for ChalkIr {
         data.into_iter().collect()
     }
 
-    fn variable_kinds_data<'a>(
+    fn variable_kinds_data(
         self,
-        variable_kinds: &'a Self::InternedVariableKinds,
-    ) -> &'a [VariableKind<ChalkIr>] {
+        variable_kinds: &Self::InternedVariableKinds,
+    ) -> &[VariableKind<ChalkIr>] {
         variable_kinds
     }
 
@@ -368,10 +356,10 @@ impl Interner for ChalkIr {
         data.into_iter().collect()
     }
 
-    fn canonical_var_kinds_data<'a>(
+    fn canonical_var_kinds_data(
         self,
-        canonical_var_kinds: &'a Self::InternedCanonicalVarKinds,
-    ) -> &'a [CanonicalVarKind<ChalkIr>] {
+        canonical_var_kinds: &Self::InternedCanonicalVarKinds,
+    ) -> &[CanonicalVarKind<ChalkIr>] {
         canonical_var_kinds
     }
 
@@ -382,10 +370,10 @@ impl Interner for ChalkIr {
         data.into_iter().collect()
     }
 
-    fn constraints_data<'a>(
+    fn constraints_data(
         self,
-        constraints: &'a Self::InternedConstraints,
-    ) -> &'a [InEnvironment<Constraint<Self>>] {
+        constraints: &Self::InternedConstraints,
+    ) -> &[InEnvironment<Constraint<Self>>] {
         constraints
     }
 
@@ -396,7 +384,7 @@ impl Interner for ChalkIr {
         data.into_iter().collect()
     }
 
-    fn variances_data<'a>(self, variances: &'a Self::InternedVariances) -> &'a [Variance] {
+    fn variances_data(self, variances: &Self::InternedVariances) -> &[Variance] {
         variances
     }
 }

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -526,8 +526,8 @@ impl LowerWithEnv for InlineBound {
 
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
         Ok(match self {
-            InlineBound::TraitBound(b) => rust_ir::InlineBound::TraitBound(b.lower(&env)?),
-            InlineBound::AliasEqBound(b) => rust_ir::InlineBound::AliasEqBound(b.lower(&env)?),
+            InlineBound::TraitBound(b) => rust_ir::InlineBound::TraitBound(b.lower(env)?),
+            InlineBound::AliasEqBound(b) => rust_ir::InlineBound::AliasEqBound(b.lower(env)?),
         })
     }
 }
@@ -664,7 +664,7 @@ impl LowerWithEnv for Ty {
         let interner = env.interner();
         Ok(match self {
             Ty::Id { name } => {
-                let parameter = env.lookup_generic_arg(&name)?;
+                let parameter = env.lookup_generic_arg(name)?;
                 parameter.ty(interner).map(|ty| ty.clone()).ok_or_else(|| {
                     RustIrError::IncorrectParameterKind {
                         identifier: name.clone(),
@@ -736,7 +736,7 @@ impl LowerWithEnv for Ty {
                         chalk_ir::TyKind::$tykind($id, substitution).intern(interner)
                     }};
                 }
-                match env.lookup_type(&name)? {
+                match env.lookup_type(name)? {
                     TypeLookup::Parameter(_) => {
                         return Err(RustIrError::CannotApplyTypeParameter(name.clone()))
                     }
@@ -846,7 +846,7 @@ impl LowerWithEnv for GenericArg {
         match self {
             GenericArg::Ty(ref t) => Ok(t.lower(env)?.cast(interner)),
             GenericArg::Lifetime(ref l) => Ok(l.lower(env)?.cast(interner)),
-            GenericArg::Id(name) => env.lookup_generic_arg(&name),
+            GenericArg::Id(name) => env.lookup_generic_arg(name),
             GenericArg::Const(c) => Ok(c.lower(env)?.cast(interner)),
         }
     }
@@ -859,7 +859,7 @@ impl LowerWithEnv for Lifetime {
         let interner = env.interner();
         match self {
             Lifetime::Id { name } => {
-                let parameter = env.lookup_generic_arg(&name)?;
+                let parameter = env.lookup_generic_arg(name)?;
                 parameter.lifetime(interner).copied().ok_or_else(|| {
                     RustIrError::IncorrectParameterKind {
                         identifier: name.clone(),
@@ -901,7 +901,7 @@ impl LowerWithEnv for (&Impl, ImplId<ChalkIr>, &AssociatedTyValueIds) {
                 ))?;
             }
 
-            let where_clauses = impl_.where_clauses.lower(&env)?;
+            let where_clauses = impl_.where_clauses.lower(env)?;
             debug!(where_clauses = ?trait_ref);
             Ok(rust_ir::ImplDatumBound {
                 trait_ref,
@@ -1065,8 +1065,8 @@ impl LowerWithEnv for Goal {
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
         let interner = env.interner();
         match self {
-            Goal::ForAll(ids, g) => (&**g, chalk_ir::QuantifierKind::ForAll, ids).lower(&env),
-            Goal::Exists(ids, g) => (&**g, chalk_ir::QuantifierKind::Exists, ids).lower(&env),
+            Goal::ForAll(ids, g) => (&**g, chalk_ir::QuantifierKind::ForAll, ids).lower(env),
+            Goal::Exists(ids, g) => (&**g, chalk_ir::QuantifierKind::Exists, ids).lower(env),
             Goal::Implies(hyp, g) => {
                 // We "elaborate" implied bounds by lowering goals like `T: Trait` and
                 // `T: Trait<Assoc = U>` to `FromEnv(T: Trait)` and `FromEnv(T: Trait<Assoc = U>)`

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -42,7 +42,11 @@ impl Lower for Program {
 
         // Make a vector mapping each thing in `items` to an id,
         // based just on its position:
-        let raw_ids = self.items.iter().map(|_| lowerer.next_item_id()).collect();
+        let raw_ids = self
+            .items
+            .iter()
+            .map(|_| lowerer.next_item_id())
+            .collect::<Vec<_>>();
 
         lowerer.extract_associated_types(self, &raw_ids)?;
         lowerer.extract_ids(self, &raw_ids)?;

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -200,7 +200,7 @@ impl LowerWithEnv for QuantifiedWhereClause {
     /// `Implemented(T: Foo)` and `ProjectionEq(<T as Foo>::Item = U)`.
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
         let variable_kinds = self.variable_kinds.iter().map(|k| k.lower());
-        let binders = env.in_binders(variable_kinds, |env| Ok(self.where_clause.lower(env)?))?;
+        let binders = env.in_binders(variable_kinds, |env| self.where_clause.lower(env))?;
         Ok(binders.into_iter().collect())
     }
 }
@@ -785,7 +785,7 @@ impl LowerWithEnv for Ty {
                 types.len(),
                 chalk_ir::Substitution::from_fallible(
                     interner,
-                    types.iter().map(|t| Ok(t.lower(env)?)),
+                    types.iter().map(|t| t.lower(env)),
                 )?,
             )
             .intern(interner),

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -285,7 +285,7 @@ impl LowerWithEnv for (&AdtDefn, chalk_ir::AdtId<ChalkIr>) {
     fn lower(&self, env: &Env) -> LowerResult<Self::Lowered> {
         let (adt_defn, adt_id) = self;
 
-        if adt_defn.flags.fundamental && adt_defn.all_parameters().len() < 1 {
+        if adt_defn.flags.fundamental && adt_defn.all_parameters().is_empty() {
             return Err(RustIrError::InvalidFundamentalTypesParameters(
                 adt_defn.name.clone(),
             ));
@@ -669,7 +669,7 @@ impl LowerWithEnv for Ty {
         Ok(match self {
             Ty::Id { name } => {
                 let parameter = env.lookup_generic_arg(name)?;
-                parameter.ty(interner).map(|ty| ty.clone()).ok_or_else(|| {
+                parameter.ty(interner).cloned().ok_or_else(|| {
                     RustIrError::IncorrectParameterKind {
                         identifier: name.clone(),
                         expected: Kind::Ty,

--- a/chalk-integration/src/lowering/env.rs
+++ b/chalk-integration/src/lowering/env.rs
@@ -177,12 +177,12 @@ impl Env<'_> {
     }
 
     pub fn lookup_trait(&self, name: &Identifier) -> LowerResult<TraitId<ChalkIr>> {
-        if let Some(_) = self.parameter_map.get(&name.str) {
+        if let Some(&id) = self.trait_ids.get(&name.str) {
+            Ok(id)
+        } else if self.parameter_map.get(&name.str).is_some()
+            || self.adt_ids.get(&name.str).is_some()
+        {
             Err(RustIrError::NotTrait(name.clone()))
-        } else if let Some(_) = self.adt_ids.get(&name.str) {
-            Err(RustIrError::NotTrait(name.clone()))
-        } else if let Some(id) = self.trait_ids.get(&name.str) {
-            Ok(*id)
         } else {
             Err(RustIrError::InvalidTraitName(name.clone()))
         }

--- a/chalk-integration/src/lowering/env.rs
+++ b/chalk-integration/src/lowering/env.rs
@@ -253,7 +253,7 @@ impl Env<'_> {
             .chain(binders)
             .collect();
         if parameter_map.len() != self.parameter_map.len() + len {
-            Err(RustIrError::DuplicateOrShadowedParameters)?;
+            return Err(RustIrError::DuplicateOrShadowedParameters);
         }
         Ok(Env {
             parameter_map,

--- a/chalk-integration/src/lowering/env.rs
+++ b/chalk-integration/src/lowering/env.rs
@@ -219,7 +219,7 @@ impl Env<'_> {
     ) -> LowerResult<&AssociatedTyLookup> {
         self.associated_ty_lookups
             .get(&(trait_id, ident.str.clone()))
-            .ok_or(RustIrError::MissingAssociatedType(ident.clone()))
+            .ok_or_else(|| RustIrError::MissingAssociatedType(ident.clone()))
     }
 
     /// Introduces new parameters, shifting the indices of existing

--- a/chalk-integration/src/lowering/program_lowerer.rs
+++ b/chalk-integration/src/lowering/program_lowerer.rs
@@ -53,7 +53,7 @@ impl ProgramLowerer {
     pub fn extract_associated_types(
         &mut self,
         program: &Program,
-        raw_ids: &Vec<RawId>,
+        raw_ids: &[RawId],
     ) -> LowerResult<()> {
         for (item, &raw_id) in program.items.iter().zip(raw_ids) {
             match item {
@@ -86,7 +86,7 @@ impl ProgramLowerer {
         Ok(())
     }
 
-    pub fn extract_ids(&mut self, program: &Program, raw_ids: &Vec<RawId>) -> LowerResult<()> {
+    pub fn extract_ids(&mut self, program: &Program, raw_ids: &[RawId]) -> LowerResult<()> {
         for (item, &raw_id) in program.items.iter().zip(raw_ids) {
             match item {
                 Item::AdtDefn(defn) => {
@@ -140,7 +140,7 @@ impl ProgramLowerer {
         Ok(())
     }
 
-    pub fn lower(self, program: &Program, raw_ids: &Vec<RawId>) -> LowerResult<LoweredProgram> {
+    pub fn lower(self, program: &Program, raw_ids: &[RawId]) -> LowerResult<LoweredProgram> {
         let mut adt_data = BTreeMap::new();
         let mut adt_reprs = BTreeMap::new();
         let mut adt_variances = BTreeMap::new();

--- a/chalk-integration/src/lowering/program_lowerer.rs
+++ b/chalk-integration/src/lowering/program_lowerer.rs
@@ -59,7 +59,7 @@ impl ProgramLowerer {
             match item {
                 Item::TraitDefn(d) => {
                     if d.flags.auto && !d.assoc_ty_defns.is_empty() {
-                        Err(RustIrError::AutoTraitAssociatedTypes(d.name.clone()))?;
+                        return Err(RustIrError::AutoTraitAssociatedTypes(d.name.clone()));
                     }
                     for defn in &d.assoc_ty_defns {
                         let addl_variable_kinds = defn.all_parameters();

--- a/chalk-integration/src/lowering/program_lowerer.rs
+++ b/chalk-integration/src/lowering/program_lowerer.rs
@@ -246,7 +246,7 @@ impl ProgramLowerer {
                     let upvars =
                         empty_env.in_binders(defn.all_parameters(), |env| {
                             let upvar_tys: LowerResult<Vec<chalk_ir::Ty<ChalkIr>>> =
-                                defn.upvars.iter().map(|ty| ty.lower(&env)).collect();
+                                defn.upvars.iter().map(|ty| ty.lower(env)).collect();
                             let substitution = chalk_ir::Substitution::from_iter(
                                 ChalkIr,
                                 upvar_tys?.into_iter().map(|ty| ty.cast(ChalkIr)),
@@ -295,8 +295,8 @@ impl ProgramLowerer {
 
                         let binders = empty_env.in_binders(variable_kinds, |env| {
                             Ok(rust_ir::AssociatedTyDatumBound {
-                                bounds: assoc_ty_defn.bounds.lower(&env)?,
-                                where_clauses: assoc_ty_defn.where_clauses.lower(&env)?,
+                                bounds: assoc_ty_defn.bounds.lower(env)?,
+                                where_clauses: assoc_ty_defn.where_clauses.lower(env)?,
                             })
                         })?;
 
@@ -361,7 +361,7 @@ impl ProgramLowerer {
                         // Introduce the parameters declared on the opaque type definition.
                         // So if we have `type Foo<P1..Pn> = impl Trait<T1..Tn>`, this would introduce `P1..Pn`
                         let binders = empty_env.in_binders(variable_kinds, |env| {
-                            let hidden_ty = opaque_ty.ty.lower(&env)?;
+                            let hidden_ty = opaque_ty.ty.lower(env)?;
                             hidden_opaque_types.insert(opaque_ty_id, Arc::new(hidden_ty));
 
                             // Introduce a variable to represent the hidden "self type". This will be used in the bounds.
@@ -376,7 +376,7 @@ impl ProgramLowerer {
                                         let interner = env.interner();
                                         Ok(opaque_ty
                                             .bounds
-                                            .lower(&env)?
+                                            .lower(env)?
                                             .iter()
                                             .flat_map(|qil| {
                                                 // Instantiate the bounds with the innermost bound variable, which represents Self, as the self type.
@@ -430,11 +430,11 @@ impl ProgramLowerer {
                         .collect::<Vec<_>>();
 
                     let input_output = empty_env.in_binders(variable_kinds.clone(), |env| {
-                        let yield_type = defn.yield_ty.lower(&env)?;
-                        let resume_type = defn.resume_ty.lower(&env)?;
-                        let return_type = defn.return_ty.lower(&env)?;
+                        let yield_type = defn.yield_ty.lower(env)?;
+                        let resume_type = defn.resume_ty.lower(env)?;
+                        let return_type = defn.return_ty.lower(env)?;
                         let upvars: Result<Vec<_>, _> =
-                            defn.upvars.iter().map(|ty| ty.lower(&env)).collect();
+                            defn.upvars.iter().map(|ty| ty.lower(env)).collect();
 
                         Ok(GeneratorInputOutputDatum {
                             resume_type,
@@ -447,7 +447,7 @@ impl ProgramLowerer {
                     let inner_types = empty_env.in_binders(variable_kinds, |env| {
                         let witnesses = env.in_binders(witness_lifetimes, |env| {
                             let witnesses: Result<Vec<_>, _> =
-                                defn.witness_types.iter().map(|ty| ty.lower(&env)).collect();
+                                defn.witness_types.iter().map(|ty| ty.lower(env)).collect();
                             witnesses
                         })?;
 

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -213,7 +213,7 @@ impl tls::DebugContext for Program {
             associated_ty_data.trait_id,
             Angle(&trait_params[1..]),
             associated_ty_data.name,
-            Angle(&other_params)
+            Angle(other_params)
         )
     }
 
@@ -448,10 +448,10 @@ impl RustIrDatabase<ChalkIr> for Program {
                 trait_id == trait_ref.trait_id && {
                     assert_eq!(trait_ref.substitution.len(interner), parameters.len());
                     <[_] as CouldMatch<[_]>>::could_match(
-                        &parameters,
+                        parameters,
                         interner,
                         self.unification_database(),
-                        &trait_ref.substitution.as_slice(interner),
+                        trait_ref.substitution.as_slice(interner),
                     )
                 }
             })

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -447,8 +447,7 @@ impl RustIrDatabase<ChalkIr> for Program {
                 let trait_ref = &impl_datum.binders.skip_binders().trait_ref;
                 trait_id == trait_ref.trait_id && {
                     assert_eq!(trait_ref.substitution.len(interner), parameters.len());
-                    <[_] as CouldMatch<[_]>>::could_match(
-                        parameters,
+                    parameters.could_match(
                         interner,
                         self.unification_database(),
                         trait_ref.substitution.as_slice(interner),
@@ -594,12 +593,11 @@ impl RustIrDatabase<ChalkIr> for Program {
     fn discriminant_type(&self, ty: Ty<ChalkIr>) -> Ty<ChalkIr> {
         let interner = self.interner();
         match ty.data(interner).kind {
-            TyKind::Adt(id, _) => {
-                let repr = self.adt_repr(id);
-                repr.int
-                    .clone()
-                    .unwrap_or(TyKind::Scalar(Scalar::Int(IntTy::Isize)).intern(interner))
-            }
+            TyKind::Adt(id, _) => self
+                .adt_repr(id)
+                .int
+                .clone()
+                .unwrap_or_else(|| TyKind::Scalar(Scalar::Int(IntTy::Isize)).intern(interner)),
             TyKind::Generator(..) => TyKind::Scalar(Scalar::Uint(UintTy::U32)).intern(interner),
             _ => TyKind::Scalar(Scalar::Uint(UintTy::U8)).intern(interner),
         }

--- a/chalk-ir/src/could_match.rs
+++ b/chalk-ir/src/could_match.rs
@@ -41,7 +41,7 @@ where
                 let matches = |a: &Substitution<I>, b: &Substitution<I>| {
                     a.iter(interner)
                         .zip(b.iter(interner))
-                        .all(|(p_a, p_b)| p_a.could_match(interner, self.db, &p_b))
+                        .all(|(p_a, p_b)| p_a.could_match(interner, self.db, p_b))
                 };
                 let could_match = match (a.kind(interner), b.kind(interner)) {
                     (TyKind::Adt(id_a, substitution_a), TyKind::Adt(id_b, substitution_b)) => {
@@ -91,11 +91,11 @@ where
                         TyKind::Ref(mutability_b, lifetime_b, ty_b),
                     ) => {
                         mutability_a == mutability_b
-                            && lifetime_a.could_match(interner, self.db, &lifetime_b)
-                            && ty_a.could_match(interner, self.db, &ty_b)
+                            && lifetime_a.could_match(interner, self.db, lifetime_b)
+                            && ty_a.could_match(interner, self.db, ty_b)
                     }
                     (TyKind::Raw(mutability_a, ty_a), TyKind::Raw(mutability_b, ty_b)) => {
-                        mutability_a == mutability_b && ty_a.could_match(interner, self.db, &ty_b)
+                        mutability_a == mutability_b && ty_a.could_match(interner, self.db, ty_b)
                     }
                     (TyKind::Never, TyKind::Never) => true,
                     (TyKind::Array(ty_a, const_a), TyKind::Array(ty_b, const_b)) => {

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -320,7 +320,7 @@ impl<I: Interner> VariableKinds<I> {
     }
 
     /// Helper method for debugging variable kinds.
-    pub fn inner_debug<'a>(&'a self, interner: I) -> VariableKindsInnerDebug<'a, I> {
+    pub fn inner_debug(&self, interner: I) -> VariableKindsInnerDebug<'_, I> {
         VariableKindsInnerDebug {
             variable_kinds: self,
             interner,
@@ -420,7 +420,7 @@ impl<'a, I: Interner> Debug for GoalsDebug<'a, I> {
 
 impl<I: Interner> Goals<I> {
     /// Show debug output for `Goals`.
-    pub fn debug<'a>(&'a self, interner: I) -> GoalsDebug<'a, I> {
+    pub fn debug(&self, interner: I) -> GoalsDebug<'_, I> {
         GoalsDebug {
             goals: self,
             interner,
@@ -476,7 +476,7 @@ impl<'a, I: Interner> Debug for ProgramClauseImplicationDebug<'a, I> {
 
 impl<I: Interner> ProgramClauseImplication<I> {
     /// Show debug output for the program clause implication.
-    pub fn debug<'a>(&'a self, interner: I) -> ProgramClauseImplicationDebug<'a, I> {
+    pub fn debug(&self, interner: I) -> ProgramClauseImplicationDebug<'_, I> {
         ProgramClauseImplicationDebug {
             pci: self,
             interner,
@@ -556,7 +556,7 @@ impl<'a, I: Interner> Debug for TyKindDebug<'a, I> {
 
 impl<I: Interner> TyKind<I> {
     /// Show debug output for the application type.
-    pub fn debug<'a>(&'a self, interner: I) -> TyKindDebug<'a, I> {
+    pub fn debug(&self, interner: I) -> TyKindDebug<'_, I> {
         TyKindDebug { ty: self, interner }
     }
 }
@@ -595,7 +595,7 @@ impl<'a, I: Interner> Debug for SubstitutionDebug<'a, I> {
 
 impl<I: Interner> Substitution<I> {
     /// Show debug output for the substitution.
-    pub fn debug<'a>(&'a self, interner: I) -> SubstitutionDebug<'a, I> {
+    pub fn debug(&self, interner: I) -> SubstitutionDebug<'_, I> {
         SubstitutionDebug {
             substitution: self,
             interner,
@@ -715,7 +715,7 @@ impl<'a, I: Interner> Debug for ProjectionTyDebug<'a, I> {
 
 impl<I: Interner> ProjectionTy<I> {
     /// Show debug output for the projection type.
-    pub fn debug<'a>(&'a self, interner: I) -> ProjectionTyDebug<'a, I> {
+    pub fn debug(&self, interner: I) -> ProjectionTyDebug<'_, I> {
         ProjectionTyDebug {
             projection_ty: self,
             interner,
@@ -746,7 +746,7 @@ impl<'a, I: Interner> Debug for OpaqueTyDebug<'a, I> {
 
 impl<I: Interner> OpaqueTy<I> {
     /// Show debug output for the opaque type.
-    pub fn debug<'a>(&'a self, interner: I) -> OpaqueTyDebug<'a, I> {
+    pub fn debug(&self, interner: I) -> OpaqueTyDebug<'_, I> {
         OpaqueTyDebug {
             opaque_ty: self,
             interner,
@@ -880,7 +880,7 @@ impl<I: Interner> Debug for CanonicalVarKinds<I> {
 
 impl<T: HasInterner + Display> Canonical<T> {
     /// Display the canonicalized item.
-    pub fn display<'a>(&'a self, interner: T::Interner) -> CanonicalDisplay<'a, T> {
+    pub fn display(&self, interner: T::Interner) -> CanonicalDisplay<'_, T> {
         CanonicalDisplay {
             canonical: self,
             interner,

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -182,7 +182,7 @@ pub trait Folder<I: Interner> {
         } else {
             let bound_var = bound_var.shifted_in_from(outer_binder);
             Ok(ConstData {
-                ty: ty.clone().fold_with(self.as_dyn(), outer_binder)?,
+                ty: ty.fold_with(self.as_dyn(), outer_binder)?,
                 value: ConstValue::<I>::BoundVar(bound_var),
             }
             .intern(self.interner()))

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -93,7 +93,7 @@ impl<I: Interner> Fold<I> for Substitution<I> {
             .iter(interner)
             .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
-        Ok(Substitution::from_fallible(interner, folded)?)
+        Substitution::from_fallible(interner, folded)
     }
 }
 
@@ -109,7 +109,7 @@ impl<I: Interner> Fold<I> for Goals<I> {
             .iter(interner)
             .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
-        Ok(Goals::from_fallible(interner, folded)?)
+        Goals::from_fallible(interner, folded)
     }
 }
 
@@ -125,7 +125,7 @@ impl<I: Interner> Fold<I> for ProgramClauses<I> {
             .iter(interner)
             .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
-        Ok(ProgramClauses::from_fallible(interner, folded)?)
+        ProgramClauses::from_fallible(interner, folded)
     }
 }
 
@@ -141,7 +141,7 @@ impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
             .iter(interner)
             .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
-        Ok(QuantifiedWhereClauses::from_fallible(interner, folded)?)
+        QuantifiedWhereClauses::from_fallible(interner, folded)
     }
 }
 
@@ -157,7 +157,7 @@ impl<I: Interner> Fold<I> for Constraints<I> {
             .iter(interner)
             .cloned()
             .map(|p| p.fold_with(folder, outer_binder));
-        Ok(Constraints::from_fallible(interner, folded)?)
+        Constraints::from_fallible(interner, folded)
     }
 }
 

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -473,7 +473,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
     fn intern_ty(self, kind: TyKind<Self>) -> Self::InternedType;
 
     /// Lookup the `TyKind` from an interned type.
-    fn ty_data<'a>(self, ty: &'a Self::InternedType) -> &'a TyData<Self>;
+    fn ty_data(self, ty: &Self::InternedType) -> &TyData<Self>;
 
     /// Create an "interned" lifetime from `lifetime`. This is not
     /// normally invoked directly; instead, you invoke
@@ -482,7 +482,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
     fn intern_lifetime(self, lifetime: LifetimeData<Self>) -> Self::InternedLifetime;
 
     /// Lookup the `LifetimeData` that was interned to create a `InternedLifetime`.
-    fn lifetime_data<'a>(self, lifetime: &'a Self::InternedLifetime) -> &'a LifetimeData<Self>;
+    fn lifetime_data(self, lifetime: &Self::InternedLifetime) -> &LifetimeData<Self>;
 
     /// Create an "interned" const from `const`. This is not
     /// normally invoked directly; instead, you invoke
@@ -491,7 +491,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
     fn intern_const(self, constant: ConstData<Self>) -> Self::InternedConst;
 
     /// Lookup the `ConstData` that was interned to create a `InternedConst`.
-    fn const_data<'a>(self, constant: &'a Self::InternedConst) -> &'a ConstData<Self>;
+    fn const_data(self, constant: &Self::InternedConst) -> &ConstData<Self>;
 
     /// Determine whether two concrete const values are equal.
     fn const_eq(
@@ -508,10 +508,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
     fn intern_generic_arg(self, data: GenericArgData<Self>) -> Self::InternedGenericArg;
 
     /// Lookup the `LifetimeData` that was interned to create a `InternedLifetime`.
-    fn generic_arg_data<'a>(
-        self,
-        lifetime: &'a Self::InternedGenericArg,
-    ) -> &'a GenericArgData<Self>;
+    fn generic_arg_data(self, lifetime: &Self::InternedGenericArg) -> &GenericArgData<Self>;
 
     /// Create an "interned" goal from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -520,7 +517,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
     fn intern_goal(self, data: GoalData<Self>) -> Self::InternedGoal;
 
     /// Lookup the `GoalData` that was interned to create a `InternedGoal`.
-    fn goal_data<'a>(self, goal: &'a Self::InternedGoal) -> &'a GoalData<Self>;
+    fn goal_data(self, goal: &Self::InternedGoal) -> &GoalData<Self>;
 
     /// Create an "interned" goals from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -532,7 +529,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
     ) -> Result<Self::InternedGoals, E>;
 
     /// Lookup the `GoalsData` that was interned to create a `InternedGoals`.
-    fn goals_data<'a>(self, goals: &'a Self::InternedGoals) -> &'a [Goal<Self>];
+    fn goals_data(self, goals: &Self::InternedGoals) -> &[Goal<Self>];
 
     /// Create an "interned" substitution from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -544,10 +541,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
     ) -> Result<Self::InternedSubstitution, E>;
 
     /// Lookup the `SubstitutionData` that was interned to create a `InternedSubstitution`.
-    fn substitution_data<'a>(
-        self,
-        substitution: &'a Self::InternedSubstitution,
-    ) -> &'a [GenericArg<Self>];
+    fn substitution_data(self, substitution: &Self::InternedSubstitution) -> &[GenericArg<Self>];
 
     /// Create an "interned" program clause from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -556,10 +550,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
     fn intern_program_clause(self, data: ProgramClauseData<Self>) -> Self::InternedProgramClause;
 
     /// Lookup the `ProgramClauseData` that was interned to create a `ProgramClause`.
-    fn program_clause_data<'a>(
-        self,
-        clause: &'a Self::InternedProgramClause,
-    ) -> &'a ProgramClauseData<Self>;
+    fn program_clause_data(self, clause: &Self::InternedProgramClause) -> &ProgramClauseData<Self>;
 
     /// Create an "interned" program clauses from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -571,10 +562,8 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
     ) -> Result<Self::InternedProgramClauses, E>;
 
     /// Lookup the `ProgramClauseData` that was interned to create a `ProgramClause`.
-    fn program_clauses_data<'a>(
-        self,
-        clauses: &'a Self::InternedProgramClauses,
-    ) -> &'a [ProgramClause<Self>];
+    fn program_clauses_data(self, clauses: &Self::InternedProgramClauses)
+        -> &[ProgramClause<Self>];
 
     /// Create an "interned" quantified where clauses from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -587,10 +576,10 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
 
     /// Lookup the slice of `QuantifiedWhereClause` that was interned to
     /// create a `QuantifiedWhereClauses`.
-    fn quantified_where_clauses_data<'a>(
+    fn quantified_where_clauses_data(
         self,
-        clauses: &'a Self::InternedQuantifiedWhereClauses,
-    ) -> &'a [QuantifiedWhereClause<Self>];
+        clauses: &Self::InternedQuantifiedWhereClauses,
+    ) -> &[QuantifiedWhereClause<Self>];
 
     /// Create an "interned" parameter kinds from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -603,10 +592,10 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
 
     /// Lookup the slice of `VariableKinds` that was interned to
     /// create a `VariableKinds`.
-    fn variable_kinds_data<'a>(
+    fn variable_kinds_data(
         self,
-        variable_kinds: &'a Self::InternedVariableKinds,
-    ) -> &'a [VariableKind<Self>];
+        variable_kinds: &Self::InternedVariableKinds,
+    ) -> &[VariableKind<Self>];
 
     /// Create "interned" variable kinds with universe index from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -619,10 +608,10 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
 
     /// Lookup the slice of `CanonicalVariableKind` that was interned to
     /// create a `CanonicalVariableKinds`.
-    fn canonical_var_kinds_data<'a>(
+    fn canonical_var_kinds_data(
         self,
-        canonical_var_kinds: &'a Self::InternedCanonicalVarKinds,
-    ) -> &'a [CanonicalVarKind<Self>];
+        canonical_var_kinds: &Self::InternedCanonicalVarKinds,
+    ) -> &[CanonicalVarKind<Self>];
 
     /// Create "interned" constraints from `data`. This is not
     /// normally invoked dirctly; instead, you invoke
@@ -635,10 +624,10 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
 
     /// Lookup the slice of `Constraint` that was interned to
     /// create a `Constraints`.
-    fn constraints_data<'a>(
+    fn constraints_data(
         self,
-        constraints: &'a Self::InternedConstraints,
-    ) -> &'a [InEnvironment<Constraint<Self>>];
+        constraints: &Self::InternedConstraints,
+    ) -> &[InEnvironment<Constraint<Self>>];
 
     /// Create "interned" variances from `data`. This is not
     /// normally invoked directly; instead, you invoke
@@ -651,7 +640,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
 
     /// Lookup the slice of `Variance` that was interned to
     /// create a `Variances`.
-    fn variances_data<'a>(self, variances: &'a Self::InternedVariances) -> &'a [Variance];
+    fn variances_data(self, variances: &Self::InternedVariances) -> &[Variance];
 }
 
 /// Implemented by types that have an associated interner (which

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1681,7 +1681,7 @@ impl<I: Interner> Copy for TraitRef<I> where I::InternedSubstitution: Copy {}
 
 impl<I: Interner> TraitRef<I> {
     /// Gets all type parameters in this trait ref, including `Self`.
-    pub fn type_parameters<'a>(&'a self, interner: I) -> impl Iterator<Item = Ty<I>> + 'a {
+    pub fn type_parameters(&self, interner: I) -> impl Iterator<Item = Ty<I>> + '_ {
         self.substitution
             .iter(interner)
             .filter_map(move |p| p.ty(interner))
@@ -2714,7 +2714,7 @@ impl<I: Interner> Substitution<I> {
     }
 
     /// Gets an iterator of all type parameters.
-    pub fn type_parameters<'a>(&'a self, interner: I) -> impl Iterator<Item = Ty<I>> + 'a {
+    pub fn type_parameters(&self, interner: I) -> impl Iterator<Item = Ty<I>> + '_ {
         self.iter(interner)
             .filter_map(move |p| p.ty(interner))
             .cloned()

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -486,26 +486,20 @@ impl<I: Interner> Ty<I> {
 
     /// Returns true if this is an `Alias`.
     pub fn is_alias(&self, interner: I) -> bool {
-        match self.kind(interner) {
-            TyKind::Alias(..) => true,
-            _ => false,
-        }
+        matches!(self.kind(interner), TyKind::Alias(..))
     }
 
     /// Returns true if this is an `IntTy` or `UintTy`.
     pub fn is_integer(&self, interner: I) -> bool {
-        match self.kind(interner) {
-            TyKind::Scalar(Scalar::Int(_)) | TyKind::Scalar(Scalar::Uint(_)) => true,
-            _ => false,
-        }
+        matches!(
+            self.kind(interner),
+            TyKind::Scalar(Scalar::Int(_) | Scalar::Uint(_))
+        )
     }
 
     /// Returns true if this is a `FloatTy`.
     pub fn is_float(&self, interner: I) -> bool {
-        match self.kind(interner) {
-            TyKind::Scalar(Scalar::Float(_)) => true,
-            _ => false,
-        }
+        matches!(self.kind(interner), TyKind::Scalar(Scalar::Float(_)))
     }
 
     /// Returns `Some(adt_id)` if this is an ADT, `None` otherwise

--- a/chalk-ir/src/visit.rs
+++ b/chalk-ir/src/visit.rs
@@ -239,7 +239,7 @@ where
         let interner = visitor.interner();
         match self.kind(interner) {
             TyKind::BoundVar(bound_var) => {
-                if let Some(_) = bound_var.shifted_out_to(outer_binder) {
+                if bound_var.shifted_out_to(outer_binder).is_some() {
                     visitor.visit_free_var(*bound_var, outer_binder)
                 } else {
                     ControlFlow::Continue(())
@@ -320,7 +320,7 @@ impl<I: Interner> SuperVisit<I> for Lifetime<I> {
         let interner = visitor.interner();
         match self.data(interner) {
             LifetimeData::BoundVar(bound_var) => {
-                if let Some(_) = bound_var.shifted_out_to(outer_binder) {
+                if bound_var.shifted_out_to(outer_binder).is_some() {
                     visitor.visit_free_var(*bound_var, outer_binder)
                 } else {
                     ControlFlow::Continue(())
@@ -357,7 +357,7 @@ impl<I: Interner> SuperVisit<I> for Const<I> {
         let interner = visitor.interner();
         match &self.data(interner).value {
             ConstValue::BoundVar(bound_var) => {
-                if let Some(_) = bound_var.shifted_out_to(outer_binder) {
+                if bound_var.shifted_out_to(outer_binder).is_some() {
                     visitor.visit_free_var(*bound_var, outer_binder)
                 } else {
                     ControlFlow::Continue(())

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -525,10 +525,7 @@ pub enum FnArgs {
 
 impl FnArgs {
     pub fn is_variadic(&self) -> bool {
-        match self {
-            Self::Variadic(..) => true,
-            _ => false,
-        }
+        matches!(self, Self::Variadic(..))
     }
 
     pub fn to_tys(self) -> Vec<Ty> {

--- a/chalk-parse/src/lib.rs
+++ b/chalk-parse/src/lib.rs
@@ -16,14 +16,14 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 pub fn parse_program(text: &str) -> Result<ast::Program> {
     match parser::ProgramParser::new().parse(text) {
         Ok(v) => Ok(v),
-        Err(e) => Err(format!("parse error: {}", e))?,
+        Err(e) => Err(format!("parse error: {}", e).into()),
     }
 }
 
 pub fn parse_ty(text: &str) -> Result<ast::Ty> {
     match parser::TyParser::new().parse(text) {
         Ok(v) => Ok(v),
-        Err(e) => Err(format!("error parsing `{}`: {}", text, e))?,
+        Err(e) => Err(format!("error parsing `{}`: {}", text, e).into()),
     }
 }
 
@@ -45,24 +45,17 @@ pub fn parse_goal(text: &str) -> Result<Box<ast::Goal>> {
                     "parse error: {}\n{}",
                     e,
                     position_string(location, location + 1)
-                ))?,
+                )
+                .into()),
                 ParseError::UnrecognizedToken {
                     token: (start, _, end),
                     ..
-                } => Err(format!(
-                    "parse error: {}\n{}",
-                    e,
-                    position_string(start, end)
-                ))?,
+                } => Err(format!("parse error: {}\n{}", e, position_string(start, end)).into()),
                 ParseError::ExtraToken {
                     token: (start, _, end),
                     ..
-                } => Err(format!(
-                    "parse error: {}\n{}",
-                    e,
-                    position_string(start, end)
-                ))?,
-                _ => Err(format!("parse error: {}", e))?,
+                } => Err(format!("parse error: {}\n{}", e, position_string(start, end)).into()),
+                _ => Err(format!("parse error: {}", e).into()),
             }
         }
     }

--- a/chalk-parse/src/lib.rs
+++ b/chalk-parse/src/lib.rs
@@ -9,54 +9,50 @@ pub mod ast;
 lalrpop_mod!(pub parser);
 
 use lalrpop_util::ParseError;
-use std::fmt::Write;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 pub fn parse_program(text: &str) -> Result<ast::Program> {
-    match parser::ProgramParser::new().parse(text) {
-        Ok(v) => Ok(v),
-        Err(e) => Err(format!("parse error: {}", e).into()),
-    }
+    parser::ProgramParser::new()
+        .parse(text)
+        .map_err(|e| format!("parse error: {}", e).into())
 }
 
 pub fn parse_ty(text: &str) -> Result<ast::Ty> {
-    match parser::TyParser::new().parse(text) {
-        Ok(v) => Ok(v),
-        Err(e) => Err(format!("error parsing `{}`: {}", text, e).into()),
-    }
+    parser::TyParser::new()
+        .parse(text)
+        .map_err(|e| format!("error parsing `{}`: {}", text, e).into())
 }
 
 pub fn parse_goal(text: &str) -> Result<Box<ast::Goal>> {
-    match parser::GoalParser::new().parse(text) {
-        Ok(v) => Ok(v),
-        Err(e) => {
-            let position_string = |start: usize, end: usize| {
-                let mut output = String::new();
-                let text = text.replace("\n", " ").replace("\r", " ");
-                writeln!(output, "position: `{}`", text).expect("str-write cannot fail");
-                output.push_str(&" ".repeat(11 + start));
-                output.push_str(&"^".repeat(end - start));
-                output.push_str("\n");
-                output
-            };
-            match e {
-                ParseError::InvalidToken { location } => Err(format!(
-                    "parse error: {}\n{}",
-                    e,
-                    position_string(location, location + 1)
-                )
-                .into()),
-                ParseError::UnrecognizedToken {
-                    token: (start, _, end),
-                    ..
-                } => Err(format!("parse error: {}\n{}", e, position_string(start, end)).into()),
-                ParseError::ExtraToken {
-                    token: (start, _, end),
-                    ..
-                } => Err(format!("parse error: {}\n{}", e, position_string(start, end)).into()),
-                _ => Err(format!("parse error: {}", e).into()),
+    parser::GoalParser::new().parse(text).map_err(|e| {
+        let mut output = format!("parse error: {}", &e);
+        if let Some(s) = match e {
+            ParseError::InvalidToken { location } => {
+                Some(position_string(text, location, location + 1))
             }
+            ParseError::UnrecognizedToken {
+                token: (start, _, end),
+                ..
+            } => Some(position_string(text, start, end)),
+            ParseError::ExtraToken {
+                token: (start, _, end),
+                ..
+            } => Some(position_string(text, start, end)),
+            _ => None,
+        } {
+            output.push('\n');
+            output += &s;
         }
-    }
+        output.into()
+    })
+}
+
+fn position_string(text: &str, start: usize, end: usize) -> String {
+    let text = text.replace('\n', " ").replace('\r', " ");
+    let mut output = format!("position: `{}`", text);
+    output += &" ".repeat(11 + start);
+    output += &"^".repeat(end - start);
+    output.push('\n');
+    output
 }

--- a/chalk-recursive/src/fixed_point.rs
+++ b/chalk-recursive/src/fixed_point.rs
@@ -123,14 +123,14 @@ where
     ) -> V {
         // First check the cache.
         if let Some(cache) = &self.cache {
-            if let Some(value) = cache.get(&goal) {
+            if let Some(value) = cache.get(goal) {
                 debug!("solve_reduced_goal: cache hit, value={:?}", value);
                 return value.clone();
             }
         }
 
         // Next, check if the goal is in the search tree already.
-        if let Some(dfn) = self.search_graph.lookup(&goal) {
+        if let Some(dfn) = self.search_graph.lookup(goal) {
             // Check if this table is still on the stack.
             if let Some(depth) = self.search_graph[dfn].stack_depth {
                 self.stack[depth].flag_cycle();
@@ -157,9 +157,9 @@ where
             let coinductive_goal = solver_stuff.is_coinductive_goal(goal);
             let initial_solution = solver_stuff.initial_value(goal, coinductive_goal);
             let depth = self.stack.push(coinductive_goal);
-            let dfn = self.search_graph.insert(&goal, depth, initial_solution);
+            let dfn = self.search_graph.insert(goal, depth, initial_solution);
 
-            let subgoal_minimums = self.solve_new_subgoal(&goal, depth, dfn, solver_stuff);
+            let subgoal_minimums = self.solve_new_subgoal(goal, depth, dfn, solver_stuff);
 
             self.search_graph[dfn].links = subgoal_minimums;
             self.search_graph[dfn].stack_depth = None;
@@ -209,7 +209,7 @@ where
         // so this function will eventually be constant and the loop terminates.
         loop {
             let minimums = &mut Minimums::new();
-            let current_answer = solver_stuff.solve_iteration(self, &canonical_goal, minimums);
+            let current_answer = solver_stuff.solve_iteration(self, canonical_goal, minimums);
 
             debug!(
                 "solve_new_subgoal: loop iteration result = {:?} with minimums {:?}",

--- a/chalk-recursive/src/fixed_point.rs
+++ b/chalk-recursive/src/fixed_point.rs
@@ -125,7 +125,7 @@ where
         if let Some(cache) = &self.cache {
             if let Some(value) = cache.get(goal) {
                 debug!("solve_reduced_goal: cache hit, value={:?}", value);
-                return value.clone();
+                return value;
             }
         }
 

--- a/chalk-recursive/src/fixed_point/cache.rs
+++ b/chalk-recursive/src/fixed_point/cache.rs
@@ -41,7 +41,7 @@ where
     /// Record a cache result.
     pub fn get(&self, goal: &K) -> Option<V> {
         let data = self.data.lock().unwrap();
-        if let Some(result) = data.cache.get(&goal) {
+        if let Some(result) = data.cache.get(goal) {
             debug!(?goal, ?result, "Cache hit");
             Some(result.clone())
         } else {

--- a/chalk-recursive/src/fulfill.rs
+++ b/chalk-recursive/src/fulfill.rs
@@ -495,7 +495,7 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>> Fulfill<'s, I, Solver> {
                 }
             }
 
-            self.obligations.extend(obligations.drain(..));
+            self.obligations.append(&mut obligations);
             debug!("end of round, {} obligations left", self.obligations.len());
         }
 

--- a/chalk-recursive/src/fulfill.rs
+++ b/chalk-recursive/src/fulfill.rs
@@ -317,7 +317,7 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>> Fulfill<'s, I, Solver> {
                 self.push_obligation(Obligation::Prove(in_env));
             }
             GoalData::EqGoal(EqGoal { a, b }) => {
-                self.unify(&environment, Variance::Invariant, &a, &b)?;
+                self.unify(environment, Variance::Invariant, &a, &b)?;
             }
             GoalData::SubtypeGoal(SubtypeGoal { a, b }) => {
                 let a_norm = self.infer.normalize_ty_shallow(interner, a);
@@ -334,7 +334,7 @@ impl<'s, I: Interner, Solver: SolveDatabase<I>> Fulfill<'s, I, Solver> {
                 ) {
                     self.cannot_prove = true;
                 } else {
-                    self.unify(&environment, Variance::Covariant, &a, &b)?;
+                    self.unify(environment, Variance::Covariant, &a, &b)?;
                 }
             }
             GoalData::CannotProve => {

--- a/chalk-recursive/src/fulfill.rs
+++ b/chalk-recursive/src/fulfill.rs
@@ -26,10 +26,7 @@ enum Outcome {
 
 impl Outcome {
     fn is_complete(&self) -> bool {
-        match *self {
-            Outcome::Complete => true,
-            _ => false,
-        }
+        matches!(self, Outcome::Complete)
     }
 }
 

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -142,7 +142,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
             }
         }
 
-        let (infer, subst, goal) = self.new_inference_table(&canonical_goal);
+        let (infer, subst, goal) = self.new_inference_table(canonical_goal);
         clauses.extend(
             db.program_clauses_for_env(&goal.environment)
                 .iter(db.interner())
@@ -163,7 +163,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
             let infer = infer.clone();
             let subst = subst.clone();
             let goal = goal.clone();
-            let res = match Fulfill::new_with_clause(self, infer, subst, goal, &implication) {
+            let res = match Fulfill::new_with_clause(self, infer, subst, goal, implication) {
                 Ok(fulfill) => (fulfill.solve(minimums), implication.skip_binders().priority),
                 Err(e) => (Err(e), ClausePriority::High),
             };

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -865,7 +865,7 @@ fn match_ty<I: Interner>(
     ty: &Ty<I>,
 ) -> Result<(), Floundered> {
     let interner = builder.interner();
-    Ok(match ty.kind(interner) {
+    match ty.kind(interner) {
         TyKind::InferenceVar(_, _) => {
             panic!("Inference vars not allowed when getting program clauses")
         }
@@ -1080,7 +1080,8 @@ fn match_ty<I: Interner>(
                 builder.push_clause(WellFormed::Ty(ty.clone()), wf_goals);
             });
         }
-    })
+    }
+    Ok(())
 }
 
 fn match_alias_ty<I: Interner>(

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -485,7 +485,7 @@ pub fn program_clauses_that_could_match<I: Interner>(
                 let generalized = generalize::Generalize::apply(db.interner(), trait_ref.clone());
                 builder.push_binders(generalized, |builder, trait_ref| {
                     let ty = trait_ref.self_type_parameter(interner);
-                    push_auto_trait_impls(builder, trait_id, &ty.kind(interner))
+                    push_auto_trait_impls(builder, trait_id, ty.kind(interner))
                 })?;
             }
 
@@ -584,7 +584,7 @@ pub fn program_clauses_that_could_match<I: Interner>(
         | DomainGoal::IsUpstream(ty)
         | DomainGoal::DownstreamType(ty)
         | DomainGoal::IsFullyVisible(ty)
-        | DomainGoal::IsLocal(ty) => match_ty(builder, environment, &ty)?,
+        | DomainGoal::IsLocal(ty) => match_ty(builder, environment, ty)?,
         DomainGoal::FromEnv(_) => (), // Computed in the environment
         DomainGoal::Normalize(Normalize { alias, ty: _ }) => match alias {
             AliasTy::Projection(proj) => {

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -1025,7 +1025,7 @@ fn match_ty<I: Interner>(
         TyKind::Closure(_, _) | TyKind::Generator(_, _) | TyKind::GeneratorWitness(_, _) => {
             let ty = generalize::Generalize::apply(builder.db.interner(), ty.clone());
             builder.push_binders(ty, |builder, ty| {
-                builder.push_fact(WellFormed::Ty(ty.clone()));
+                builder.push_fact(WellFormed::Ty(ty));
             });
         }
         TyKind::Placeholder(_) => {
@@ -1041,9 +1041,7 @@ fn match_ty<I: Interner>(
             .to_program_clauses(builder, environment),
         TyKind::Function(_quantified_ty) => {
             let ty = generalize::Generalize::apply(builder.db.interner(), ty.clone());
-            builder.push_binders(ty, |builder, ty| {
-                builder.push_fact(WellFormed::Ty(ty.clone()))
-            });
+            builder.push_binders(ty, |builder, ty| builder.push_fact(WellFormed::Ty(ty)));
         }
         TyKind::BoundVar(_) => return Err(Floundered),
         TyKind::Dyn(dyn_ty) => {
@@ -1062,7 +1060,6 @@ fn match_ty<I: Interner>(
             builder.push_binders(generalized_ty, |builder, dyn_ty| {
                 let bounds = dyn_ty
                     .bounds
-                    .clone()
                     .substitute(interner, &[ty.clone().cast::<GenericArg<I>>(interner)]);
 
                 let mut wf_goals = Vec::new();

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -1089,12 +1089,11 @@ fn match_alias_ty<I: Interner>(
     environment: &Environment<I>,
     alias: &AliasTy<I>,
 ) {
-    match alias {
-        AliasTy::Projection(projection_ty) => builder
+    if let AliasTy::Projection(projection_ty) = alias {
+        builder
             .db
             .associated_ty_data(projection_ty.associated_ty_id)
-            .to_program_clauses(builder, environment),
-        _ => (),
+            .to_program_clauses(builder, environment)
     }
 }
 

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -105,7 +105,7 @@ pub fn needs_impl_for_tys<I: Interner>(
     builder.push_clause(
         trait_ref,
         tys.map(|ty| TraitRef {
-            trait_id: trait_id,
+            trait_id,
             substitution: Substitution::from1(db.interner(), ty),
         }),
     );

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -42,7 +42,7 @@ pub fn add_builtin_program_clauses<I: Interner>(
                 clone::add_clone_program_clauses(db, builder, trait_ref, ty, binders)?;
             }
             WellKnownTrait::FnOnce | WellKnownTrait::FnMut | WellKnownTrait::Fn => {
-                fn_family::add_fn_trait_program_clauses(db, builder, well_known, self_ty)?;
+                fn_family::add_fn_trait_program_clauses(db, builder, well_known, self_ty);
             }
             WellKnownTrait::Unsize => {
                 unsize::add_unsize_program_clauses(db, builder, trait_ref, ty)
@@ -72,7 +72,7 @@ pub fn add_builtin_assoc_program_clauses<I: Interner>(
             let generalized = generalize::Generalize::apply(db.interner(), self_ty);
 
             builder.push_binders(generalized, |builder, self_ty| {
-                fn_family::add_fn_trait_program_clauses(db, builder, well_known, self_ty)?;
+                fn_family::add_fn_trait_program_clauses(db, builder, well_known, self_ty);
                 Ok(())
             })
         }

--- a/chalk-solve/src/clauses/builtin_traits/copy.rs
+++ b/chalk-solve/src/clauses/builtin_traits/copy.rs
@@ -43,7 +43,7 @@ pub fn add_copy_program_clauses<I: Interner>(
             push_tuple_copy_conditions(db, builder, trait_ref, arity, substitution)
         }
         TyKind::Array(ty, _) => {
-            needs_impl_for_tys(db, builder, trait_ref, iter::once(ty.clone()));
+            needs_impl_for_tys(db, builder, trait_ref, iter::once(ty));
         }
         TyKind::FnDef(_, _) => {
             builder.push_fact(trait_ref);

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -110,7 +110,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
             Ok(())
         }
         TyKind::Closure(closure_id, substitution) => {
-            let closure_kind = db.closure_kind(*closure_id, &substitution);
+            let closure_kind = db.closure_kind(*closure_id, substitution);
             let trait_matches = match (well_known, closure_kind) {
                 (WellKnownTrait::Fn, ClosureKind::Fn) => true,
                 (WellKnownTrait::FnMut, ClosureKind::FnMut)
@@ -121,8 +121,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
             if !trait_matches {
                 return Ok(());
             }
-            let closure_inputs_and_output =
-                db.closure_inputs_and_output(*closure_id, &substitution);
+            let closure_inputs_and_output = db.closure_inputs_and_output(*closure_id, substitution);
             push_clauses_for_apply(
                 db,
                 builder,

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -3,8 +3,7 @@ use crate::rust_ir::{ClosureKind, FnDefInputsAndOutputDatum, WellKnownTrait};
 use crate::{Interner, RustIrDatabase, TraitRef};
 use chalk_ir::cast::Cast;
 use chalk_ir::{
-    AliasTy, Binders, Floundered, Normalize, ProjectionTy, Safety, Substitution, TraitId, Ty,
-    TyKind,
+    AliasTy, Binders, Normalize, ProjectionTy, Safety, Substitution, TraitId, Ty, TyKind,
 };
 
 fn push_clauses<I: Interner>(
@@ -86,7 +85,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
     builder: &mut ClauseBuilder<'_, I>,
     well_known: WellKnownTrait,
     self_ty: Ty<I>,
-) -> Result<(), Floundered> {
+) {
     let interner = db.interner();
     let trait_id = db.well_known_trait_id(well_known).unwrap();
 
@@ -107,7 +106,6 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
                     bound.inputs_and_output,
                 );
             }
-            Ok(())
         }
         TyKind::Closure(closure_id, substitution) => {
             let closure_kind = db.closure_kind(*closure_id, substitution);
@@ -118,7 +116,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
                     | (WellKnownTrait::FnOnce, _)
             );
             if !trait_matches {
-                return Ok(());
+                return;
             }
             let closure_inputs_and_output = db.closure_inputs_and_output(*closure_id, substitution);
             push_clauses_for_apply(
@@ -129,7 +127,6 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
                 self_ty,
                 closure_inputs_and_output,
             );
-            Ok(())
         }
         TyKind::Function(fn_val) if fn_val.sig.safety == Safety::Safe && !fn_val.sig.variadic => {
             let bound_ref = fn_val.clone().into_binders(interner);
@@ -152,8 +149,7 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
                     output_ty,
                 );
             });
-            Ok(())
         }
-        _ => Ok(()),
+        _ => {}
     }
 }

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -111,13 +111,12 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
         }
         TyKind::Closure(closure_id, substitution) => {
             let closure_kind = db.closure_kind(*closure_id, substitution);
-            let trait_matches = match (well_known, closure_kind) {
-                (WellKnownTrait::Fn, ClosureKind::Fn) => true,
-                (WellKnownTrait::FnMut, ClosureKind::FnMut)
-                | (WellKnownTrait::FnMut, ClosureKind::Fn) => true,
-                (WellKnownTrait::FnOnce, _) => true,
-                _ => false,
-            };
+            let trait_matches = matches!(
+                (well_known, closure_kind),
+                (WellKnownTrait::Fn, ClosureKind::Fn)
+                    | (WellKnownTrait::FnMut, ClosureKind::FnMut | ClosureKind::Fn)
+                    | (WellKnownTrait::FnOnce, _)
+            );
             if !trait_matches {
                 return Ok(());
             }

--- a/chalk-solve/src/clauses/builtin_traits/unsize.rs
+++ b/chalk-solve/src/clauses/builtin_traits/unsize.rs
@@ -136,9 +136,9 @@ fn uses_outer_binder_params<I: Interner>(
     matches!(flow, ControlFlow::Break(_))
 }
 
-fn principal_id<'a, I: Interner>(
+fn principal_id<I: Interner>(
     db: &dyn RustIrDatabase<I>,
-    bounds: &'a Binders<QuantifiedWhereClauses<I>>,
+    bounds: &Binders<QuantifiedWhereClauses<I>>,
 ) -> Option<TraitId<I>> {
     let interner = db.interner();
 

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -67,7 +67,7 @@ impl<'me, 'builder, I: Interner> Visitor<I> for EnvElaborator<'me, 'builder, I> 
 
             _ => {
                 // This shouldn't fail because of the above clauses
-                match_ty(self.builder, self.environment, &ty)
+                match_ty(self.builder, self.environment, ty)
                     .map_err(|_| ())
                     .unwrap()
             }

--- a/chalk-solve/src/display.rs
+++ b/chalk-solve/src/display.rs
@@ -153,7 +153,7 @@ fn display_self_where_clauses_as_bounds<'a, I: Interner>(
                             WhereClause::AliasEq(alias_eq) => match &alias_eq.alias {
                                 AliasTy::Projection(projection_ty) => {
                                     let (assoc_ty_datum, trait_params, assoc_type_params) =
-                                        s.db().split_projection(&projection_ty);
+                                        s.db().split_projection(projection_ty);
                                     display_trait_with_assoc_ty_value(
                                         s,
                                         assoc_ty_datum,

--- a/chalk-solve/src/display/bounds.rs
+++ b/chalk-solve/src/display/bounds.rs
@@ -131,7 +131,7 @@ impl<I: Interner> RenderAsRust<I> for AliasEq<I> {
         match &self.alias {
             AliasTy::Projection(projection_ty) => {
                 let (assoc_ty_datum, trait_params, assoc_type_params) =
-                    s.db().split_projection(&projection_ty);
+                    s.db().split_projection(projection_ty);
                 // An alternate form might be `<{} as {}<{}>>::{}<{}> = {}` (with same
                 // parameter ordering). This alternate form would require type equality
                 // constraints (https://github.com/rust-lang/rust/issues/20041).

--- a/chalk-solve/src/display/items.rs
+++ b/chalk-solve/src/display/items.rs
@@ -442,7 +442,7 @@ impl<I: Interner> RenderAsRust<I> for AssociatedTyValue<I> {
             .split_associated_ty_value_parameters(&display_params, self);
 
         write!(f, "{}type {}", s.indent(), assoc_ty_data.id.display(s))?;
-        write_joined_non_empty_list!(f, "<{}>", &assoc_ty_value_display, ", ")?;
+        write_joined_non_empty_list!(f, "<{}>", assoc_ty_value_display, ", ")?;
         write!(f, " = {};", value.ty.display(s))?;
         Ok(())
     }

--- a/chalk-solve/src/display/ty.rs
+++ b/chalk-solve/src/display/ty.rs
@@ -142,7 +142,7 @@ impl<I: Interner> RenderAsRust<I> for ProjectionTy<I> {
         // trait_params is X, A1, A2, A3,
         // assoc_type_params is B1, B2, B3,
         // assoc_ty_datum stores info about Y and Z.
-        let (assoc_ty_datum, trait_params, assoc_type_params) = s.db().split_projection(&self);
+        let (assoc_ty_datum, trait_params, assoc_type_params) = s.db().split_projection(self);
         write!(
             f,
             "<{} as {}>::{}",

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -136,7 +136,7 @@ impl<'i, I: Interner> Folder<I> for Canonicalizer<'i, I> {
     ) -> Fallible<Const<I>> {
         let interner = self.interner;
         self.max_universe = max(self.max_universe, universe.ui);
-        Ok(universe.to_const(interner, ty.clone()))
+        Ok(universe.to_const(interner, ty))
     }
 
     fn forbid_free_vars(&self) -> bool {

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -30,7 +30,7 @@ impl<I: Interner> InferenceTable<I> {
     where
         T: HasInterner<Interner = I> + Fold<I> + Debug,
     {
-        let subst = self.fresh_subst(interner, &bound.binders.as_slice(interner));
+        let subst = self.fresh_subst(interner, bound.binders.as_slice(interner));
         subst.apply(bound.value, interner)
     }
 

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -289,7 +289,7 @@ impl<'i, I: Interner> Folder<I> for UMapToCanonical<'i, I> {
             ui: universe,
             idx: universe0.idx,
         }
-        .to_const(self.interner(), ty.clone()))
+        .to_const(self.interner(), ty))
     }
 
     fn interner(&self) -> I {

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -360,11 +360,11 @@ impl<'t, I: Interner> Unifier<'t, I> {
     fn unify_var_var(&mut self, a: InferenceVar, b: InferenceVar) -> Fallible<()> {
         let var1 = EnaVariable::from(a);
         let var2 = EnaVariable::from(b);
-        Ok(self
-            .table
+        self.table
             .unify
             .unify_var_var(var1, var2)
-            .expect("unification of two unbound variables cannot fail"))
+            .expect("unification of two unbound variables cannot fail");
+        Ok(())
     }
 
     /// Unify a general inference variable with a specific inference variable
@@ -1001,7 +1001,8 @@ impl<'t, I: Interner> Unifier<'t, I> {
             | (&LifetimeData::Erased, &LifetimeData::Placeholder(_))
             | (&LifetimeData::Erased, &LifetimeData::Empty(_)) => {
                 if a != b {
-                    Ok(self.push_lifetime_outlives_goals(variance, a.clone(), b.clone()))
+                    self.push_lifetime_outlives_goals(variance, a.clone(), b.clone());
+                    Ok(())
                 } else {
                     Ok(())
                 }
@@ -1041,11 +1042,12 @@ impl<'t, I: Interner> Unifier<'t, I> {
                 "{:?} in {:?} cannot see {:?}; pushing constraint",
                 var, var_ui, value_ui
             );
-            Ok(self.push_lifetime_outlives_goals(
+            self.push_lifetime_outlives_goals(
                 variance,
                 var.to_lifetime(self.interner),
                 value.clone(),
-            ))
+            );
+            Ok(())
         }
     }
 
@@ -1082,11 +1084,11 @@ impl<'t, I: Interner> Unifier<'t, I> {
                 debug!(?var1, ?var2, "relate_ty_ty");
                 let var1 = EnaVariable::from(var1);
                 let var2 = EnaVariable::from(var2);
-                Ok(self
-                    .table
+                self.table
                     .unify
                     .unify_var_var(var1, var2)
-                    .expect("unification of two unbound variables cannot fail"))
+                    .expect("unification of two unbound variables cannot fail");
+                Ok(())
             }
 
             // Unifying an inference variables with a non-inference variable.

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -1290,7 +1290,7 @@ impl<'i, I: Interner> Folder<I> for OccursCheck<'_, 'i, I> {
         if self.universe_index < universe.ui {
             Err(NoSolution)
         } else {
-            Ok(universe.to_const(interner, ty.clone())) // no need to shift, not relative to depth
+            Ok(universe.to_const(interner, ty)) // no need to shift, not relative to depth
         }
     }
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -677,10 +677,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
                                     let lifetime = lifetime_var.to_lifetime(interner);
                                     let ty_var = self.table.new_variable(universe_index);
                                     let ty = ty_var.to_ty(interner);
-                                    WhereClause::TypeOutlives(TypeOutlives {
-                                        ty: ty,
-                                        lifetime: lifetime,
-                                    })
+                                    WhereClause::TypeOutlives(TypeOutlives { ty, lifetime })
                                 }
                                 WhereClause::LifetimeOutlives(_) => {
                                     unreachable!("dyn Trait never contains LifetimeOutlive bounds")

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -184,11 +184,11 @@ impl<'t, I: Interner> Unifier<'t, I> {
             (_, &TyKind::Alias(ref alias)) => self.relate_alias_ty(variance.invert(), alias, a),
             (&TyKind::Alias(ref alias), _) => self.relate_alias_ty(variance, alias, b),
 
-            (&TyKind::InferenceVar(var, kind), ty_data @ _) => {
+            (&TyKind::InferenceVar(var, kind), ty_data) => {
                 let ty = ty_data.clone().intern(interner);
                 self.relate_var_ty(variance, var, kind, &ty)
             }
-            (ty_data @ _, &TyKind::InferenceVar(var, kind)) => {
+            (ty_data, &TyKind::InferenceVar(var, kind)) => {
                 // We need to invert the variance if inference var is `b` because we pass it in
                 // as `a` to relate_var_ty
                 let ty = ty_data.clone().intern(interner);

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -760,9 +760,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
     ) -> Lifetime<I> {
         let interner = self.interner;
         match lifetime.data(interner) {
-            LifetimeData::BoundVar(_) => {
-                return lifetime.clone();
-            }
+            LifetimeData::BoundVar(_) => lifetime.clone(),
             _ => {
                 if matches!(variance, Variance::Invariant) {
                     lifetime.clone()
@@ -779,9 +777,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
         let interner = self.interner;
         let data = const_.data(interner);
         match data.value {
-            ConstValue::BoundVar(_) => {
-                return const_.clone();
-            }
+            ConstValue::BoundVar(_) => const_.clone(),
             _ => {
                 let ena_var = self.table.new_variable(universe_index);
                 ena_var.to_const(interner, data.ty.clone())

--- a/chalk-solve/src/logging_db.rs
+++ b/chalk-solve/src/logging_db.rs
@@ -210,7 +210,9 @@ where
         well_known_trait: crate::rust_ir::WellKnownTrait,
     ) -> Option<TraitId<I>> {
         let trait_id = self.ws.db().well_known_trait_id(well_known_trait);
-        trait_id.map(|id| self.record(id));
+        if let Some(id) = trait_id {
+            self.record(id);
+        }
         trait_id
     }
 

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -135,7 +135,7 @@ impl<'i, I: Interner, DB: RustIrDatabase<I>> Visitor<I> for IdCollector<'i, I, D
             TyKind::Adt(adt, _) => self.record(*adt),
             TyKind::FnDef(fn_def, _) => self.record(*fn_def),
             TyKind::OpaqueType(opaque, _) => self.record(*opaque),
-            TyKind::Alias(alias) => self.visit_alias(&alias),
+            TyKind::Alias(alias) => self.visit_alias(alias),
             TyKind::BoundVar(..) => (),
             TyKind::Dyn(..) => (),
             TyKind::Function(..) => (),

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -33,8 +33,8 @@ use indexmap::IndexSet;
 /// references parent. IdCollector solves this by collecting all of the directly
 /// related identifiers, allowing those to be rendered as well, ensuring name
 /// resolution is successful.
-pub fn collect_unrecorded_ids<'i, I: Interner, DB: RustIrDatabase<I>>(
-    db: &'i DB,
+pub fn collect_unrecorded_ids<I: Interner, DB: RustIrDatabase<I>>(
+    db: &DB,
     identifiers: &'_ IndexSet<RecordedItemId<I>>,
 ) -> IndexSet<RecordedItemId<I>> {
     let mut collector = IdCollector {

--- a/chalk-solve/src/solve.rs
+++ b/chalk-solve/src/solve.rs
@@ -145,7 +145,7 @@ impl<I: Interner> Solution<I> {
         matches!(*self, Solution::Ambig(_))
     }
 
-    pub fn display<'a>(&'a self, interner: I) -> SolutionDisplay<'a, I> {
+    pub fn display(&self, interner: I) -> SolutionDisplay<'_, I> {
         SolutionDisplay {
             solution: self,
             interner,

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -48,7 +48,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
     /// Given a projection `<P0 as Trait<P1..Pn>>::Item<Pn..Pm>`,
     /// returns the trait parameters `[P0..Pn]` (see
     /// `split_projection`).
-    fn trait_ref_from_projection<'p>(&self, projection: &'p ProjectionTy<I>) -> TraitRef<I> {
+    fn trait_ref_from_projection(&self, projection: &ProjectionTy<I>) -> TraitRef<I> {
         let interner = self.interner();
         let (associated_ty_data, trait_params, _) = self.split_projection(projection);
         TraitRef {

--- a/chalk-solve/src/split.rs
+++ b/chalk-solve/src/split.rs
@@ -50,7 +50,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
     /// `split_projection`).
     fn trait_ref_from_projection<'p>(&self, projection: &'p ProjectionTy<I>) -> TraitRef<I> {
         let interner = self.interner();
-        let (associated_ty_data, trait_params, _) = self.split_projection(&projection);
+        let (associated_ty_data, trait_params, _) = self.split_projection(projection);
         TraitRef {
             trait_id: associated_ty_data.trait_id,
             substitution: Substitution::from_iter(interner, trait_params),
@@ -132,7 +132,7 @@ pub trait Split<I: Interner>: RustIrDatabase<I> {
         // Get the trait ref from the impl -- so in our example above
         // this would be `Box<!T>: Foo`.
         let (impl_parameters, atv_parameters) =
-            self.split_associated_ty_value_parameters(&parameters, associated_ty_value);
+            self.split_associated_ty_value_parameters(parameters, associated_ty_value);
         let trait_ref = {
             let opaque_ty_ref = impl_datum.binders.map_ref(|b| &b.trait_ref).cloned();
             debug!(?opaque_ty_ref);

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -358,7 +358,7 @@ where
         // We make a goal like
         //
         // forall<T>
-        let goal = gb.forall(&bound, opaque_ty_id, |gb, _, bound, opaque_ty_id| {
+        let goal = gb.forall(bound, opaque_ty_id, |gb, _, bound, opaque_ty_id| {
             let interner = gb.interner();
 
             let subst = Substitution::from1(interner, gb.db().hidden_opaque_type(opaque_ty_id));
@@ -460,7 +460,7 @@ fn impl_header_wf_goal<I: Interner>(
 
         // if (WC && input types are well formed) { ... }
         gb.implies(
-            impl_wf_environment(interner, &where_clauses, &trait_ref),
+            impl_wf_environment(interner, where_clauses, trait_ref),
             |gb| {
                 // We retrieve all the input types of the where clauses appearing on the trait impl,
                 // e.g. in:
@@ -574,7 +574,7 @@ fn compute_assoc_ty_goal<I: Interner>(
 
             let (impl_parameters, projection) = db
                 .impl_parameters_and_projection_from_associated_ty_value(
-                    &assoc_ty_substitution.as_slice(interner),
+                    assoc_ty_substitution.as_slice(interner),
                     assoc_ty,
                 );
 
@@ -739,7 +739,7 @@ impl WfWellKnownConstraints {
 
                 // if (WC) { ... }
                 gb.implies(
-                    impl_wf_environment(interner, &where_clauses, &trait_ref),
+                    impl_wf_environment(interner, where_clauses, trait_ref),
                     |gb| -> Goal<I> {
                         let db = gb.db();
 
@@ -954,7 +954,7 @@ impl WfWellKnownConstraints {
                 |gb, _, (goal, trait_ref, where_clauses), ()| {
                     let interner = gb.interner();
                     gb.implies(
-                        impl_wf_environment(interner, &where_clauses, &trait_ref),
+                        impl_wf_environment(interner, where_clauses, trait_ref),
                         |_| goal,
                     )
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,17 +213,17 @@ fn process(
         // Let's do a sanity check before going forward.
         let _ = chalk_prog.db.checked_program()?;
         *prog = Some(chalk_prog);
-    } else if command.starts_with("load ") {
+    } else if let Some(filename) = command.strip_prefix("load ") {
         // Load a .chalk file.
-        let filename = &command["load ".len()..];
         let chalk_prog = load_program(args, filename)?;
         // Let's do a sanity check before going forward.
         let _ = chalk_prog.db.checked_program()?;
         *prog = Some(chalk_prog);
-    } else if command.starts_with("debug ") {
-        match command.split_whitespace().nth(1) {
-            Some(level) => std::env::set_var("CHALK_DEBUG", level),
-            None => println!("debug <level> set debug level to <level>"),
+    } else if let Some(level) = command.strip_prefix("debug ") {
+        if level.is_empty() {
+            println!("debug <level> set debug level to <level>");
+        } else {
+            std::env::set_var("CHALK_DEBUG", level);
         }
     } else {
         // The command is either "print", "lowered", or a goal.

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ where
             Err(ReadlineError::Eof) => break,
 
             // Some other error occurred.
-            Err(e) => Err(e)?,
+            Err(e) => return Err(e.into()),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,7 @@ fn process(
 fn load_program(args: &Args, filename: &str) -> Result<LoadedProgram> {
     let mut text = String::new();
     File::open(filename)?.read_to_string(&mut text)?;
-    Ok(LoadedProgram::new(text, args.solver_choice())?)
+    LoadedProgram::new(text, args.solver_choice())
 }
 
 /// Print out help for commands in interpreter mode.

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ impl LoadedProgram {
         let goal = lower_goal(&*chalk_parse::parse_goal(text)?, &*program)?;
         let peeled_goal = goal.into_peeled_goal(self.db.interner());
         if multiple_answers {
-            if self.db.solve_multiple(&peeled_goal, &mut |v, has_next| {
+            let no_more_solutions = self.db.solve_multiple(&peeled_goal, &mut |v, has_next| {
                 println!("{}\n", v.as_ref().map(|v| v.display(ChalkIr)));
                 if has_next {
                     if let Some(ref mut rl) = rl {
@@ -94,7 +94,8 @@ impl LoadedProgram {
                 } else {
                     true
                 }
-            }) {
+            });
+            if no_more_solutions {
                 println!("No more solutions");
             }
         } else {
@@ -290,7 +291,7 @@ fn read_program(rl: &mut rustyline::Editor<()>) -> Result<String> {
 
 impl Args {
     fn solver_choice(&self) -> SolverChoice {
-        match self.flag_solver.as_ref().map(String::as_str) {
+        match self.flag_solver.as_deref() {
             None | Some("slg") => SolverChoice::SLG {
                 max_size: self.flag_overflow_depth,
                 expected_answers: None,

--- a/tests/display/unique_names.rs
+++ b/tests/display/unique_names.rs
@@ -217,7 +217,7 @@ pub fn write_program_duplicated_names(db: &Program) -> String {
 ///
 /// Only checks that the resulting program parses, not that it matches any
 /// particular format. Use returned data to perform further checks.
-pub fn run_reparse_with_duplicate_names<'a>(program_text: &'a str) -> ReparseTestResult<'a> {
+pub fn run_reparse_with_duplicate_names(program_text: &str) -> ReparseTestResult<'_> {
     let original_db = chalk_integration::db::ChalkDatabase::with(program_text, <_>::default());
     let original_program = original_db.program_ir().unwrap_or_else(|e| {
         panic!(

--- a/tests/display/util.rs
+++ b/tests/display/util.rs
@@ -12,8 +12,8 @@ use regex::Regex;
 use std::{fmt::Debug, sync::Arc};
 
 pub fn strip_leading_trailing_braces(input: &str) -> &str {
-    assert!(input.starts_with("{"));
-    assert!(input.ends_with("}"));
+    assert!(input.starts_with('{'));
+    assert!(input.ends_with('}'));
 
     &input[1..input.len() - 1]
 }

--- a/tests/display/util.rs
+++ b/tests/display/util.rs
@@ -74,9 +74,7 @@ pub fn program_item_ids(program: &Program) -> impl Iterator<Item = RecordedItemI
 
     // then discard the RawId since the RecordedItemId has the same information,
     // and is what we actually want to consume.
-    let ids = ids.into_iter().map(|(_, id)| id);
-
-    ids
+    ids.into_iter().map(|(_, id)| id)
 }
 
 /// Sends all items in a `chalk_integration::Program` through `display` code and
@@ -146,9 +144,9 @@ fn program_diff(original: &impl Debug, produced: &impl Debug) -> String {
     let produced = format!("{:#?}", produced);
     for line in diff::lines(&original, &produced) {
         match line {
-            diff::Result::Left(l) => write!(out, "-{}\n", l),
-            diff::Result::Both(l, _) => write!(out, " {}\n", l),
-            diff::Result::Right(r) => write!(out, "+{}\n", r),
+            diff::Result::Left(l) => writeln!(out, "-{}", l),
+            diff::Result::Both(l, _) => writeln!(out, " {}", l),
+            diff::Result::Right(r) => writeln!(out, "+{}", r),
         }
         .expect("writing to string never fails");
     }

--- a/tests/logging_db/util.rs
+++ b/tests/logging_db/util.rs
@@ -30,8 +30,8 @@ pub fn logging_db_output_sufficient(
     goals: Vec<(&str, Vec<SolverChoice>, TestGoal)>,
 ) {
     println!("program {}", program_text);
-    assert!(program_text.starts_with("{"));
-    assert!(program_text.ends_with("}"));
+    assert!(program_text.starts_with('{'));
+    assert!(program_text.ends_with('}'));
 
     let goals = goals
         .iter()
@@ -53,8 +53,8 @@ pub fn logging_db_output_sufficient(
                 println!("----------------------------------------------------------------------");
                 println!("---- first run on original test code ---------------------------------");
                 println!("goal {}", goal_text);
-                assert!(goal_text.starts_with("{"));
-                assert!(goal_text.ends_with("}"));
+                assert!(goal_text.starts_with('{'));
+                assert!(goal_text.ends_with('}'));
                 let goal = lower_goal(
                     &*chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1]).unwrap(),
                     &*program,
@@ -95,8 +95,8 @@ pub fn logging_db_output_sufficient(
             println!("----------------------------------------------------------------------");
             println!("---- second run on code output by logger -----------------------------");
             println!("goal {}", goal_text);
-            assert!(goal_text.starts_with("{"));
-            assert!(goal_text.ends_with("}"));
+            assert!(goal_text.starts_with('{'));
+            assert!(goal_text.ends_with('}'));
             let goal = lower_goal(
                 &*chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1]).unwrap(),
                 &*new_program,

--- a/tests/logging_db/util.rs
+++ b/tests/logging_db/util.rs
@@ -35,7 +35,7 @@ pub fn logging_db_output_sufficient(
 
     let goals = goals
         .iter()
-        .flat_map(|(a, bs, c)| bs.into_iter().map(move |b| (a, b, c)));
+        .flat_map(|(a, bs, c)| bs.iter().map(move |b| (a, b, c)));
 
     let output_text = {
         let db = ChalkDatabase::with(

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -243,8 +243,8 @@ fn solve_goal(
 ) {
     with_tracing_logs(|| {
         println!("program {}", program_text);
-        assert!(program_text.starts_with("{"));
-        assert!(program_text.ends_with("}"));
+        assert!(program_text.starts_with('{'));
+        assert!(program_text.ends_with('}'));
 
         let mut db = ChalkDatabase::with(
             &program_text[1..program_text.len() - 1],
@@ -294,8 +294,8 @@ fn solve_goal(
             chalk_integration::tls::set_current_program(&program, || {
                 println!("----------------------------------------------------------------------");
                 println!("goal {}", goal_text);
-                assert!(goal_text.starts_with("{"));
-                assert!(goal_text.ends_with("}"));
+                assert!(goal_text.starts_with('{'));
+                assert!(goal_text.ends_with('}'));
                 let goal = lower_goal(
                     &*chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1]).unwrap(),
                     &*program,
@@ -377,8 +377,8 @@ fn solve_aggregated(
         chalk_integration::tls::set_current_program(&program, || {
             println!("----------------------------------------------------------------------");
             println!("goal {}", goal_text);
-            assert!(goal_text.starts_with("{"));
-            assert!(goal_text.ends_with("}"));
+            assert!(goal_text.starts_with('{'));
+            assert!(goal_text.ends_with('}'));
             let goal = lower_goal(
                 &*chalk_parse::parse_goal(&goal_text[1..goal_text.len() - 1]).unwrap(),
                 &*program,

--- a/tests/test/mod.rs
+++ b/tests/test/mod.rs
@@ -24,17 +24,14 @@ mod wf_lowering;
 
 fn format_solution(mut result: Option<Solution<ChalkIr>>, interner: ChalkIr) -> String {
     // sort constraints, since the different solvers may output them in different order
-    match &mut result {
-        Some(Solution::Unique(solution)) => {
-            let mut sorted = solution.value.constraints.as_slice(interner).to_vec();
-            sorted.sort_by_key(|c| format!("{:?}", c));
-            solution.value.constraints = Constraints::from_iter(interner, sorted);
-        }
-        _ => {}
+    if let Some(Solution::Unique(solution)) = &mut result {
+        let mut sorted = solution.value.constraints.as_slice(interner).to_vec();
+        sorted.sort_by_key(|c| format!("{:?}", c));
+        solution.value.constraints = Constraints::from_iter(interner, sorted);
     }
     match result {
-        Some(v) => format!("{}", v.display(ChalkIr)),
-        None => format!("No possible solution"),
+        Some(v) => v.display(ChalkIr).to_string(),
+        None => "No possible solution".to_string(),
     }
 }
 
@@ -310,7 +307,7 @@ fn solve_goal(
                         assert_result(result, expected, db.interner());
                     }
                     TestGoal::All(expected) => {
-                        let mut expected = expected.into_iter();
+                        let mut expected = expected.iter();
                         assert!(
                             db.solve_multiple(&peeled_goal, &mut |result, next_result| {
                                 match expected.next() {
@@ -334,7 +331,7 @@ fn solve_goal(
                         }
                     }
                     TestGoal::First(expected) => {
-                        let mut expected = expected.into_iter();
+                        let mut expected = expected.iter();
                         db.solve_multiple(&peeled_goal, &mut |result, next_result| match expected
                             .next()
                         {

--- a/tests/test/type_flags.rs
+++ b/tests/test/type_flags.rs
@@ -15,9 +15,7 @@ fn placeholder_ty_flags_correct() {
 #[test]
 fn opaque_ty_flags_correct() {
     let opaque_ty = TyKind::Alias(chalk_ir::AliasTy::Opaque(chalk_ir::OpaqueTy {
-        opaque_ty_id: chalk_ir::OpaqueTyId {
-            0: chalk_integration::interner::RawId { index: 0 },
-        },
+        opaque_ty_id: chalk_ir::OpaqueTyId(chalk_integration::interner::RawId { index: 0 }),
         substitution: chalk_ir::Substitution::from_iter(
             ChalkIr,
             Some(
@@ -48,9 +46,7 @@ fn opaque_ty_flags_correct() {
 fn dyn_ty_flags_correct() {
     let internal_ty = TyKind::Scalar(chalk_ir::Scalar::Bool).intern(ChalkIr);
     let projection_ty = chalk_ir::ProjectionTy {
-        associated_ty_id: chalk_ir::AssocTypeId {
-            0: chalk_integration::interner::RawId { index: 0 },
-        },
+        associated_ty_id: chalk_ir::AssocTypeId(chalk_integration::interner::RawId { index: 0 }),
         substitution: empty_substitution!(),
     };
     let bounds = chalk_ir::Binders::<chalk_ir::QuantifiedWhereClauses<ChalkIr>>::empty(
@@ -110,9 +106,7 @@ fn static_and_bound_lifetimes() {
     );
 
     let ty = TyKind::Adt(
-        chalk_ir::AdtId {
-            0: chalk_integration::interner::RawId { index: 0 },
-        },
+        chalk_ir::AdtId(chalk_integration::interner::RawId { index: 0 }),
         substitutions,
     )
     .intern(ChalkIr);


### PR DESCRIPTION
This PR contains:

* Trivial Clippy fixes such as `needless_borrow`, `redundant_clone`, `match_like_matches_macro`, `try_err`, `needless_return`, ...
* Small local refactors, which I will point out in comments.

Each type of change is in a separate commit, except for the last commit that has a mix of unique changes.

The 18 remaining clippy errors are a bit more substantial.