### PR TITLE
Rename folding/visiting traits

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,7 +12,7 @@
         - [Application types](./types/rust_types/application_ty.md)
     - [Rust lifetimes](./types/rust_lifetimes.md)
     - [Operations](./types/operations.md)
-        - [Fold and the Folder trait](./types/operations/fold.md)
+        - [TypeFoldable and the Folder trait](./types/operations/fold.md)
 - [Lowering Rust IR to logic](./clauses.md)
     - [Goals and clauses](./clauses/goals_and_clauses.md)
     - [Type equality and unification](./clauses/type_equality.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,7 +12,7 @@
         - [Application types](./types/rust_types/application_ty.md)
     - [Rust lifetimes](./types/rust_lifetimes.md)
     - [Operations](./types/operations.md)
-        - [TypeFoldable and the Folder trait](./types/operations/fold.md)
+        - [TypeFoldable and the TypeFolder trait](./types/operations/fold.md)
 - [Lowering Rust IR to logic](./clauses.md)
     - [Goals and clauses](./clauses/goals_and_clauses.md)
     - [Type equality and unification](./clauses/type_equality.md)

--- a/book/src/types/operations/fold.md
+++ b/book/src/types/operations/fold.md
@@ -1,4 +1,4 @@
-# TypeFoldable and the Folder trait
+# TypeFoldable and the TypeFolder trait
 
 The [`TypeFoldable`] trait permits one to traverse a type or other term in the
 chalk-ir and make a copy of it, possibly making small substitutions or
@@ -17,39 +17,39 @@ let output_ty = input_ty.fold_with(&mut folder, 0);
 
 [`TypeFoldable::fold_with`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.TypeFoldable.html#tymethod.fold_with
 
-The folder is some instance of the [`Folder`] trait. This trait
+The folder is some instance of the [`TypeFolder`] trait. This trait
 defines a few key callbacks that allow you to substitute different
 values as the fold proceeds. For example, when a type is folded, the
 folder can substitute a new type in its place.
 
-[`Folder`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.Folder.html
+[`TypeFolder`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.TypeFolder.html
 
 ## Uses for folders
 
 A common use for `TypeFoldable` is to permit a substitution -- that is,
 replacing generic type parameters with their values.
 
-## From TypeFoldable to Folder to TypeSuperFoldable and back again
+## From TypeFoldable to TypeFolder to TypeSuperFoldable and back again
 
 The overall flow of folding is like this.
 
 1. [`TypeFoldable::fold_with`] is invoked on the outermost term. It recursively
    walks the term.
 2. For those sorts of terms (types, lifetimes, goals, program clauses) that have
-   callbacks in the [`Folder`] trait, invoking [`TypeFoldable::fold_with`] will in turn
-   invoke the corresponding method on the [`Folder`] trait, such as `Folder::fold_ty`.
-3. The default implementation of `Folder::fold_ty`, in turn, invokes
+   callbacks in the [`TypeFolder`] trait, invoking [`TypeFoldable::fold_with`] will in turn
+   invoke the corresponding method on the [`TypeFolder`] trait, such as `TypeFolder::fold_ty`.
+3. The default implementation of `TypeFolder::fold_ty`, in turn, invokes
    `TypeSuperFoldable::super_fold_with`.  This will recursively fold the
    contents of the type. In some cases, the `super_fold_with`
-   implementation invokes more specialized methods on [`Folder`], such
-   as [`Folder::fold_free_var_ty`], which makes it easier to write
+   implementation invokes more specialized methods on [`TypeFolder`], such
+   as [`TypeFolder::fold_free_var_ty`], which makes it easier to write
    folders that just intercept *certain* types.
 
-[`Folder::fold_free_var_ty`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.Folder.html#method.fold_free_var_ty
+[`TypeFolder::fold_free_var_ty`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.TypeFolder.html#method.fold_free_var_ty
 
 Thus, as a user, you can customize folding by:
 
-* Defining your own `Folder` type
+* Defining your own `TypeFolder` type
 * Implementing the appropriate methods to "intercept" types/lifetimes/etc at the right level of
   detail
 * In those methods, if you find a case where you would prefer not to
@@ -58,7 +58,7 @@ Thus, as a user, you can customize folding by:
 
 ## The `binders` argument
 
-Each callback in the [`Folder`] trait takes a `binders` argument. This indicates
+Each callback in the [`TypeFolder`] trait takes a `binders` argument. This indicates
 the number of binders that we have traversed during folding, which is relevant for De Bruijn indices.
 So e.g. a bound variable with depth 1, if invoked with a `binders` value of 1, indicates something that was bound to something external to the fold.
 
@@ -85,7 +85,7 @@ also implement `TypeFoldable` for common collection types like `Vec` as well
 as tuples, references, etc.
 
 The `TypeSuperFoldable` trait should only be implemented for those types that
-have a callback defined on the `Folder` trait (e.g., types and
+have a callback defined on the `TypeFolder` trait (e.g., types and
 lifetimes).
 
 ## Derives

--- a/book/src/types/operations/fold.md
+++ b/book/src/types/operations/fold.md
@@ -1,13 +1,13 @@
-# Fold and the Folder trait
+# TypeFoldable and the Folder trait
 
-The [`Fold`] trait permits one to traverse a type or other term in the
+The [`TypeFoldable`] trait permits one to traverse a type or other term in the
 chalk-ir and make a copy of it, possibly making small substitutions or
 alterations along the way. Folding also allows copying a term from one
 interner to another.
 
-[`Fold`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.Fold.html
+[`TypeFoldable`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.TypeFoldable.html
 
-To use the [`Fold`] trait, one invokes the [`Fold::fold_with`] method, supplying some
+To use the [`TypeFoldable`] trait, one invokes the [`TypeFoldable::fold_with`] method, supplying some
 "folder" as well as the number of "in scope binders" for that term (typically `0`
 to start):
 
@@ -15,7 +15,7 @@ to start):
 let output_ty = input_ty.fold_with(&mut folder, 0);
 ```
 
-[`Fold::fold_with`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.Fold.html#tymethod.fold_with
+[`TypeFoldable::fold_with`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.TypeFoldable.html#tymethod.fold_with
 
 The folder is some instance of the [`Folder`] trait. This trait
 defines a few key callbacks that allow you to substitute different
@@ -26,17 +26,17 @@ folder can substitute a new type in its place.
 
 ## Uses for folders
 
-A common use for `Fold` is to permit a substitution -- that is,
+A common use for `TypeFoldable` is to permit a substitution -- that is,
 replacing generic type parameters with their values.
 
-## From Fold to Folder to SuperFold and back again
+## From TypeFoldable to Folder to SuperFold and back again
 
 The overall flow of folding is like this.
 
-1. [`Fold::fold_with`] is invoked on the outermost term. It recursively
+1. [`TypeFoldable::fold_with`] is invoked on the outermost term. It recursively
    walks the term.
 2. For those sorts of terms (types, lifetimes, goals, program clauses) that have
-   callbacks in the [`Folder`] trait, invoking [`Fold::fold_with`] will in turn
+   callbacks in the [`Folder`] trait, invoking [`TypeFoldable::fold_with`] will in turn
    invoke the corresponding method on the [`Folder`] trait, such as `Folder::fold_ty`.
 3. The default implementation of `Folder::fold_ty`, in turn, invokes
    `SuperFold::super_fold_with`.  This will recursively fold the
@@ -70,18 +70,18 @@ Foo<'a>: for<'b> Bar<'b>
 
 In this case, `Foo<'a>` gets visited with depth 0 and `Bar<'b>` gets visited with depth 1.
 
-## The `Fold::Result` associated type
+## The `TypeFoldable::Result` associated type
 
-The `Fold` trait defines a [`Result`] associated type, indicating the
+The `TypeFoldable` trait defines a [`Result`] associated type, indicating the
 type that will result from folding.
 
-[`Result`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.Fold.html#associatedtype.Result
+[`Result`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.TypeFoldable.html#associatedtype.Result
 
-## When to implement the Fold and SuperFold traits
+## When to implement the TypeFoldable and SuperFold traits
 
 Any piece of IR that represents a kind of "term" (e.g., a type, part
-of a type, or a goal, etc) in the logic should implement `Fold`. We
-also implement `Fold` for common collection types like `Vec` as well
+of a type, or a goal, etc) in the logic should implement `TypeFoldable`. We
+also implement `TypeFoldable` for common collection types like `Vec` as well
 as tuples, references, etc.
 
 The `SuperFold` trait should only be implemented for those types that
@@ -90,12 +90,12 @@ lifetimes).
 
 ## Derives
 
-Using the `chalk-derive` crate, you can auto-derive the `Fold` trait.
+Using the `chalk-derive` crate, you can auto-derive the `TypeFoldable` trait.
 There isn't presently a derive for `SuperFold` since it is very rare
-to require it. The derive for `Fold` is a bit cludgy and requires:
+to require it. The derive for `TypeFoldable` is a bit cludgy and requires:
 
-* You must import `Fold` into scope.
-* The type you are deriving `Fold` on must have either:
+* You must import `TypeFoldable` into scope.
+* The type you are deriving `TypeFoldable` on must have either:
   * A type parameter that has a `Interner` bound, like `I: Interner`
   * A type parameter that has a `HasInterner` bound, like `I: HasInterner`
   * The `has_interner(XXX)` attribute.

--- a/book/src/types/operations/fold.md
+++ b/book/src/types/operations/fold.md
@@ -29,7 +29,7 @@ folder can substitute a new type in its place.
 A common use for `TypeFoldable` is to permit a substitution -- that is,
 replacing generic type parameters with their values.
 
-## From TypeFoldable to Folder to SuperFold and back again
+## From TypeFoldable to Folder to TypeSuperFoldable and back again
 
 The overall flow of folding is like this.
 
@@ -39,7 +39,7 @@ The overall flow of folding is like this.
    callbacks in the [`Folder`] trait, invoking [`TypeFoldable::fold_with`] will in turn
    invoke the corresponding method on the [`Folder`] trait, such as `Folder::fold_ty`.
 3. The default implementation of `Folder::fold_ty`, in turn, invokes
-   `SuperFold::super_fold_with`.  This will recursively fold the
+   `TypeSuperFoldable::super_fold_with`.  This will recursively fold the
    contents of the type. In some cases, the `super_fold_with`
    implementation invokes more specialized methods on [`Folder`], such
    as [`Folder::fold_free_var_ty`], which makes it easier to write
@@ -53,7 +53,7 @@ Thus, as a user, you can customize folding by:
 * Implementing the appropriate methods to "intercept" types/lifetimes/etc at the right level of
   detail
 * In those methods, if you find a case where you would prefer not to
-  substitute a new value, then invoke `SuperFold::super_fold_with` to
+  substitute a new value, then invoke `TypeSuperFoldable::super_fold_with` to
   return to the default behavior.
 
 ## The `binders` argument
@@ -77,21 +77,21 @@ type that will result from folding.
 
 [`Result`]: https://rust-lang.github.io/chalk/chalk_ir/fold/trait.TypeFoldable.html#associatedtype.Result
 
-## When to implement the TypeFoldable and SuperFold traits
+## When to implement the TypeFoldable and TypeSuperFoldable traits
 
 Any piece of IR that represents a kind of "term" (e.g., a type, part
 of a type, or a goal, etc) in the logic should implement `TypeFoldable`. We
 also implement `TypeFoldable` for common collection types like `Vec` as well
 as tuples, references, etc.
 
-The `SuperFold` trait should only be implemented for those types that
+The `TypeSuperFoldable` trait should only be implemented for those types that
 have a callback defined on the `Folder` trait (e.g., types and
 lifetimes).
 
 ## Derives
 
 Using the `chalk-derive` crate, you can auto-derive the `TypeFoldable` trait.
-There isn't presently a derive for `SuperFold` since it is very rare
+There isn't presently a derive for `TypeSuperFoldable` since it is very rare
 to require it. The derive for `TypeFoldable` is a bit cludgy and requires:
 
 * You must import `TypeFoldable` into scope.

--- a/book/src/what_is_chalk/crates.md
+++ b/book/src/what_is_chalk/crates.md
@@ -19,7 +19,7 @@ The following crate is an implementation detail, used internally by `chalk-solve
 
 * The `chalk-engine` crate, which defines the actual engine that solves logical predicate. This
   engine is quite general and not really specific to Rust.
-* The `chalk-derive` crate defines custom derives for the `chalk_ir::fold::Fold` trait and other
+* The `chalk-derive` crate defines custom derives for the `chalk_ir::fold::TypeFoldable` trait and other
   such things.
 
 ## Crates for standalone REPL and testing
@@ -37,11 +37,11 @@ define a kind of "minimal embedding" of chalk.
 
 ## The chalk-solve crate
 
-| The `chalk-solve` crate | |
-|---|--- |
-| Purpose:  | to solve a given goal |
-| Depends on IR:  | chalk-ir and rust-ir   |
-| Context required:  | `RustIrDatabase` |
+| The `chalk-solve` crate |                       |
+| ----------------------- | --------------------- |
+| Purpose:                | to solve a given goal |
+| Depends on IR:          | chalk-ir and rust-ir  |
+| Context required:       | `RustIrDatabase`      |
 
 The `chalk-solve` crate exposes a key type called `Solver`.  This is a
 solver that, given a goal (expressed in chalk-ir) will solve the goal
@@ -60,11 +60,11 @@ provide needed context for the solver -- notably, the solver can ask:
 
 ## The chalk-engine crate
 
-| The `chalk-engine` crate  |   |
-|---|--- |
-| Purpose:  | define the base solving strategy |
-| IR:  | none   |
-| Context required:  | `Context` trait |
+| The `chalk-engine` crate |                                  |
+| ------------------------ | -------------------------------- |
+| Purpose:                 | define the base solving strategy |
+| IR:                      | none                             |
+| Context required:        | `Context` trait                  |
 
 For the purposes of chalk, the `chalk-engine` crate is effectively
 encapsulated by `chalk-solve`.  It defines the base SLG engine. It is

--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -183,7 +183,7 @@ fn derive_any_type_visitable(
         quote! {
             fn #method_name <B>(
                 &self,
-                visitor: &mut dyn ::chalk_ir::visit::Visitor < #interner, BreakTy = B >,
+                visitor: &mut dyn ::chalk_ir::visit::TypeVisitor < #interner, BreakTy = B >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
             ) -> std::ops::ControlFlow<B> {
                 match *self {

--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -119,7 +119,7 @@ enum DeriveKind {
 
 decl_derive!([HasInterner, attributes(has_interner)] => derive_has_interner);
 decl_derive!([TypeVisitable, attributes(has_interner)] => derive_type_visitable);
-decl_derive!([SuperVisit, attributes(has_interner)] => derive_super_visit);
+decl_derive!([TypeSuperVisitable, attributes(has_interner)] => derive_type_super_visitable);
 decl_derive!([TypeFoldable, attributes(has_interner)] => derive_type_foldable);
 decl_derive!([Zip, attributes(has_interner)] => derive_zip);
 
@@ -148,11 +148,11 @@ fn derive_type_visitable(s: synstructure::Structure) -> TokenStream {
     )
 }
 
-/// Same as TypeVisitable, but derives SuperVisit instead
-fn derive_super_visit(s: synstructure::Structure) -> TokenStream {
+/// Same as TypeVisitable, but derives TypeSuperVisitable instead
+fn derive_type_super_visitable(s: synstructure::Structure) -> TokenStream {
     derive_any_type_visitable(
         s,
-        parse_quote! { SuperVisit },
+        parse_quote! { TypeSuperVisitable },
         parse_quote! { super_visit_with },
     )
 }

--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -299,7 +299,7 @@ fn derive_type_foldable(mut s: synstructure::Structure) -> TokenStream {
 
             fn fold_with<E>(
                 self,
-                folder: &mut dyn ::chalk_ir::fold::Folder < #interner, Error = E >,
+                folder: &mut dyn ::chalk_ir::fold::TypeFolder < #interner, Error = E >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
             ) -> ::std::result::Result<Self::Result, E> {
                 Ok(match self { #body })

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -56,7 +56,7 @@
 use std::cmp::min;
 use std::usize;
 
-use chalk_derive::{Fold, HasInterner, Visit};
+use chalk_derive::{HasInterner, TypeFoldable, Visit};
 use chalk_ir::interner::Interner;
 use chalk_ir::{
     AnswerSubst, Canonical, ConstrainedSubst, Constraint, DebruijnIndex, Goal, InEnvironment,
@@ -78,13 +78,13 @@ mod table;
 mod tables;
 
 index_struct! {
-    pub struct TableIndex { // FIXME: pub b/c Fold
+    pub struct TableIndex { // FIXME: pub b/c TypeFoldable
         value: usize,
     }
 }
 
 /// The paper describes these as `A :- D | G`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, Visit, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
 pub struct ExClause<I: Interner> {
     /// The substitution which, applied to the goal of our table,
     /// would yield A.
@@ -168,7 +168,7 @@ impl TimeStamp {
 ///
 /// trying to solve `?T: Foo` would immediately require solving `?T:
 /// Sized`, and hence would flounder.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit)]
 pub struct FlounderedSubgoal<I: Interner> {
     /// Literal that floundered.
     pub floundered_literal: Literal<I>,
@@ -209,7 +209,7 @@ pub struct CompleteAnswer<I: Interner> {
 }
 
 /// Either `A` or `~A`, where `A` is a `Env |- Goal`.
-#[derive(Clone, Debug, Fold, Visit)]
+#[derive(Clone, Debug, TypeFoldable, Visit)]
 pub enum Literal<I: Interner> {
     // FIXME: pub b/c fold
     Positive(InEnvironment<Goal<I>>),

--- a/chalk-engine/src/lib.rs
+++ b/chalk-engine/src/lib.rs
@@ -56,7 +56,7 @@
 use std::cmp::min;
 use std::usize;
 
-use chalk_derive::{HasInterner, TypeFoldable, Visit};
+use chalk_derive::{HasInterner, TypeFoldable, TypeVisitable};
 use chalk_ir::interner::Interner;
 use chalk_ir::{
     AnswerSubst, Canonical, ConstrainedSubst, Constraint, DebruijnIndex, Goal, InEnvironment,
@@ -84,7 +84,7 @@ index_struct! {
 }
 
 /// The paper describes these as `A :- D | G`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner)]
 pub struct ExClause<I: Interner> {
     /// The substitution which, applied to the goal of our table,
     /// would yield A.
@@ -168,7 +168,7 @@ impl TimeStamp {
 ///
 /// trying to solve `?T: Foo` would immediately require solving `?T:
 /// Sized`, and hence would flounder.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable)]
 pub struct FlounderedSubgoal<I: Interner> {
     /// Literal that floundered.
     pub floundered_literal: Literal<I>,
@@ -209,7 +209,7 @@ pub struct CompleteAnswer<I: Interner> {
 }
 
 /// Either `A` or `~A`, where `A` is a `Env |- Goal`.
-#[derive(Clone, Debug, TypeFoldable, Visit)]
+#[derive(Clone, Debug, TypeFoldable, TypeVisitable)]
 pub enum Literal<I: Interner> {
     // FIXME: pub b/c fold
     Positive(InEnvironment<Goal<I>>),

--- a/chalk-engine/src/normalize_deep.rs
+++ b/chalk-engine/src/normalize_deep.rs
@@ -1,5 +1,5 @@
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{Fold, Folder};
+use chalk_ir::fold::{Folder, TypeFoldable};
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
 use chalk_solve::infer::InferenceTable;
@@ -21,7 +21,7 @@ impl<I: Interner> DeepNormalizer<'_, I> {
     /// See also `InferenceTable::canonicalize`, which -- during real
     /// processing -- is often used to capture the "current state" of
     /// variables.
-    pub fn normalize_deep<T: Fold<I>>(
+    pub fn normalize_deep<T: TypeFoldable<I>>(
         table: &mut InferenceTable<I>,
         interner: I,
         value: T,

--- a/chalk-engine/src/normalize_deep.rs
+++ b/chalk-engine/src/normalize_deep.rs
@@ -1,5 +1,5 @@
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{Folder, TypeFoldable};
+use chalk_ir::fold::{TypeFoldable, TypeFolder};
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
 use chalk_solve::infer::InferenceTable;
@@ -35,10 +35,10 @@ impl<I: Interner> DeepNormalizer<'_, I> {
     }
 }
 
-impl<I: Interner> Folder<I> for DeepNormalizer<'_, I> {
+impl<I: Interner> TypeFolder<I> for DeepNormalizer<'_, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-engine/src/slg/resolvent.rs
+++ b/chalk-engine/src/slg/resolvent.rs
@@ -3,7 +3,7 @@ use crate::slg::ResolventOps;
 use crate::{ExClause, Literal, TimeStamp};
 use chalk_ir::cast::Caster;
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::Fold;
+use chalk_ir::fold::TypeFoldable;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::zip::{Zip, Zipper};
 use chalk_ir::*;
@@ -708,7 +708,7 @@ impl<'i, I: Interner> Zipper<I> for AnswerSubstitutor<'i, I> {
         pending: &Binders<T>,
     ) -> Fallible<()>
     where
-        T: HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>,
+        T: HasInterner<Interner = I> + Zip<I> + TypeFoldable<I, Result = T>,
     {
         self.outer_binder.shift_in();
         Zip::zip_with(

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -3,7 +3,7 @@ use crate::{ExClause, TableIndex, TimeStamp};
 use std::fmt::Debug;
 
 use chalk_derive::HasInterner;
-use chalk_ir::fold::{Fold, Folder};
+use chalk_ir::fold::{Folder, TypeFoldable};
 use chalk_ir::interner::Interner;
 use chalk_ir::{Canonical, DebruijnIndex, UniverseMap};
 
@@ -35,7 +35,7 @@ pub(crate) struct SelectedSubgoal {
     pub(crate) universe_map: UniverseMap,
 }
 
-impl<I: Interner> Fold<I> for Strand<I> {
+impl<I: Interner> TypeFoldable<I> for Strand<I> {
     type Result = Strand<I>;
     fn fold_with<E>(
         self,

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -3,7 +3,7 @@ use crate::{ExClause, TableIndex, TimeStamp};
 use std::fmt::Debug;
 
 use chalk_derive::HasInterner;
-use chalk_ir::fold::{Folder, TypeFoldable};
+use chalk_ir::fold::{TypeFoldable, TypeFolder};
 use chalk_ir::interner::Interner;
 use chalk_ir::{Canonical, DebruijnIndex, UniverseMap};
 
@@ -39,7 +39,7 @@ impl<I: Interner> TypeFoldable<I> for Strand<I> {
     type Result = Strand<I>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         Ok(Strand {

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -331,9 +331,9 @@ pub trait TypeFoldable<I: Interner>: Debug {
 }
 
 /// For types where "fold" invokes a callback on the `Folder`, the
-/// `SuperFold` trait captures the recursive behavior that folds all
+/// `TypeSuperFoldable` trait captures the recursive behavior that folds all
 /// the contents of the type.
-pub trait SuperFold<I: Interner>: TypeFoldable<I> {
+pub trait TypeSuperFoldable<I: Interner>: TypeFoldable<I> {
     /// Recursively folds the value.
     fn super_fold_with<E>(
         self,
@@ -358,7 +358,7 @@ impl<I: Interner> TypeFoldable<I> for Ty<I> {
 }
 
 /// "Super fold" for a type invokes te more detailed callbacks on the type
-impl<I> SuperFold<I> for Ty<I>
+impl<I> TypeSuperFoldable<I> for Ty<I>
 where
     I: Interner,
 {
@@ -481,7 +481,7 @@ impl<I: Interner> TypeFoldable<I> for Lifetime<I> {
     }
 }
 
-impl<I> SuperFold<I> for Lifetime<I>
+impl<I> TypeSuperFoldable<I> for Lifetime<I>
 where
     I: Interner,
 {
@@ -533,7 +533,7 @@ impl<I: Interner> TypeFoldable<I> for Const<I> {
     }
 }
 
-impl<I> SuperFold<I> for Const<I>
+impl<I> TypeSuperFoldable<I> for Const<I>
 where
     I: Interner,
 {
@@ -585,7 +585,7 @@ impl<I: Interner> TypeFoldable<I> for Goal<I> {
 }
 
 /// Superfold folds recursively.
-impl<I: Interner> SuperFold<I> for Goal<I> {
+impl<I: Interner> TypeSuperFoldable<I> for Goal<I> {
     fn super_fold_with<E>(
         self,
         folder: &mut dyn Folder<I, Error = E>,

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -17,7 +17,7 @@ pub use self::subst::Subst;
 /// certain changes applied. The idea is that it contains methods that
 /// let you swap types/lifetimes for new types/lifetimes; meanwhile,
 /// each bit of IR implements the `TypeFoldable` trait which, given a
-/// `Folder`, will reconstruct itself, invoking the folder's methods
+/// `TypeFolder`, will reconstruct itself, invoking the folder's methods
 /// to transform each of the types/lifetimes embedded within.
 ///
 /// # Usage patterns
@@ -29,14 +29,14 @@ pub use self::subst::Subst;
 /// more often, just free existential variables) that appear within
 /// the term.
 ///
-/// For this reason, the `Folder` trait extends two other traits that
+/// For this reason, the `TypeFolder` trait extends two other traits that
 /// contain methods that are invoked when just those particular
 ///
 /// In particular, folders can intercept references to free variables
 /// (either existentially or universally quantified) and replace them
 /// with other types/lifetimes as appropriate.
 ///
-/// To create a folder `F`, one never implements `Folder` directly, but instead
+/// To create a folder `F`, one never implements `TypeFolder` directly, but instead
 /// implements one of each of these three sub-traits:
 ///
 /// - `FreeVarFolder` -- folds `BoundVar` instances that appear free
@@ -54,19 +54,19 @@ pub use self::subst::Subst;
 /// ```rust,ignore
 /// let x = x.fold_with(&mut folder, 0);
 /// ```
-pub trait Folder<I: Interner> {
+pub trait TypeFolder<I: Interner> {
     /// The type this folder returns when folding fails. This is
     /// commonly [`NoSolution`].
     type Error;
 
     /// Creates a `dyn` value from this folder. Unfortunately, this
-    /// must be added manually to each impl of Folder; it permits the
-    /// default implements below to create a `&mut dyn Folder` from
+    /// must be added manually to each impl of TypeFolder; it permits the
+    /// default implements below to create a `&mut dyn TypeFolder` from
     /// `Self` without knowing what `Self` is (by invoking this
-    /// method). Effectively, this limits impls of `Folder` to types
+    /// method). Effectively, this limits impls of `TypeFolder` to types
     /// for which we are able to create a dyn value (i.e., not `[T]`
     /// types).
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error>;
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error>;
 
     /// Top-level callback: invoked for each `Ty<I>` that is
     /// encountered when folding. By default, invokes
@@ -305,7 +305,7 @@ pub trait Folder<I: Interner> {
     fn interner(&self) -> I;
 }
 
-/// Applies the given `Folder` to a value, producing a folded result
+/// Applies the given `TypeFolder` to a value, producing a folded result
 /// of type `Self::Result`. The result type is typically the same as
 /// the source type, but in some cases we convert from borrowed
 /// to owned as well (e.g., the folder for `&T` will fold to a fresh
@@ -325,19 +325,19 @@ pub trait TypeFoldable<I: Interner>: Debug {
     /// constructs.
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E>;
 }
 
-/// For types where "fold" invokes a callback on the `Folder`, the
+/// For types where "fold" invokes a callback on the `TypeFolder`, the
 /// `TypeSuperFoldable` trait captures the recursive behavior that folds all
 /// the contents of the type.
 pub trait TypeSuperFoldable<I: Interner>: TypeFoldable<I> {
     /// Recursively folds the value.
     fn super_fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E>;
 }
@@ -350,7 +350,7 @@ impl<I: Interner> TypeFoldable<I> for Ty<I> {
 
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         folder.fold_ty(self, outer_binder)
@@ -364,7 +364,7 @@ where
 {
     fn super_fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Ty<I>, E> {
         let interner = folder.interner();
@@ -474,7 +474,7 @@ impl<I: Interner> TypeFoldable<I> for Lifetime<I> {
 
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         folder.fold_lifetime(self, outer_binder)
@@ -487,7 +487,7 @@ where
 {
     fn super_fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Lifetime<I>, E> {
         let interner = folder.interner();
@@ -526,7 +526,7 @@ impl<I: Interner> TypeFoldable<I> for Const<I> {
 
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         folder.fold_const(self, outer_binder)
@@ -539,7 +539,7 @@ where
 {
     fn super_fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Const<I>, E> {
         let interner = folder.interner();
@@ -577,7 +577,7 @@ impl<I: Interner> TypeFoldable<I> for Goal<I> {
 
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         folder.fold_goal(self, outer_binder)
@@ -588,7 +588,7 @@ impl<I: Interner> TypeFoldable<I> for Goal<I> {
 impl<I: Interner> TypeSuperFoldable<I> for Goal<I> {
     fn super_fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let interner = folder.interner();
@@ -609,7 +609,7 @@ impl<I: Interner> TypeFoldable<I> for ProgramClause<I> {
 
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         folder.fold_program_clause(self, outer_binder)

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -16,7 +16,7 @@ pub use self::subst::Subst;
 /// some term -- that is, some bit of IR, such as a `Goal` -- with
 /// certain changes applied. The idea is that it contains methods that
 /// let you swap types/lifetimes for new types/lifetimes; meanwhile,
-/// each bit of IR implements the `Fold` trait which, given a
+/// each bit of IR implements the `TypeFoldable` trait which, given a
 /// `Folder`, will reconstruct itself, invoking the folder's methods
 /// to transform each of the types/lifetimes embedded within.
 ///
@@ -49,7 +49,7 @@ pub use self::subst::Subst;
 ///   that appear in the term being folded (use
 ///   `DefaultPlaceholderFolder` to ignore/forbid these altogether)
 ///
-/// To **apply** a folder, use the `Fold::fold_with` method, like so
+/// To **apply** a folder, use the `TypeFoldable::fold_with` method, like so
 ///
 /// ```rust,ignore
 /// let x = x.fold_with(&mut folder, 0);
@@ -310,11 +310,11 @@ pub trait Folder<I: Interner> {
 /// the source type, but in some cases we convert from borrowed
 /// to owned as well (e.g., the folder for `&T` will fold to a fresh
 /// `T`; well, actually `T::Result`).
-pub trait Fold<I: Interner>: Debug {
+pub trait TypeFoldable<I: Interner>: Debug {
     /// The type of value that will be produced once folding is done.
     /// Typically this is `Self`, unless `Self` contains borrowed
     /// values, in which case owned values are produced (for example,
-    /// one can fold over a `&T` value where `T: Fold`, in which case
+    /// one can fold over a `&T` value where `T: TypeFoldable`, in which case
     /// you get back a `T`, not a `&T`).
     type Result;
 
@@ -333,7 +333,7 @@ pub trait Fold<I: Interner>: Debug {
 /// For types where "fold" invokes a callback on the `Folder`, the
 /// `SuperFold` trait captures the recursive behavior that folds all
 /// the contents of the type.
-pub trait SuperFold<I: Interner>: Fold<I> {
+pub trait SuperFold<I: Interner>: TypeFoldable<I> {
     /// Recursively folds the value.
     fn super_fold_with<E>(
         self,
@@ -345,7 +345,7 @@ pub trait SuperFold<I: Interner>: Fold<I> {
 /// "Folding" a type invokes the `fold_ty` method on the folder; this
 /// usually (in turn) invokes `super_fold_ty` to fold the individual
 /// parts.
-impl<I: Interner> Fold<I> for Ty<I> {
+impl<I: Interner> TypeFoldable<I> for Ty<I> {
     type Result = Ty<I>;
 
     fn fold_with<E>(
@@ -469,7 +469,7 @@ where
 /// "Folding" a lifetime invokes the `fold_lifetime` method on the folder; this
 /// usually (in turn) invokes `super_fold_lifetime` to fold the individual
 /// parts.
-impl<I: Interner> Fold<I> for Lifetime<I> {
+impl<I: Interner> TypeFoldable<I> for Lifetime<I> {
     type Result = Lifetime<I>;
 
     fn fold_with<E>(
@@ -521,7 +521,7 @@ where
 /// "Folding" a const invokes the `fold_const` method on the folder; this
 /// usually (in turn) invokes `super_fold_const` to fold the individual
 /// parts.
-impl<I: Interner> Fold<I> for Const<I> {
+impl<I: Interner> TypeFoldable<I> for Const<I> {
     type Result = Const<I>;
 
     fn fold_with<E>(
@@ -572,7 +572,7 @@ where
 
 /// Folding a goal invokes the `fold_goal` callback (which will, by
 /// default, invoke super-fold).
-impl<I: Interner> Fold<I> for Goal<I> {
+impl<I: Interner> TypeFoldable<I> for Goal<I> {
     type Result = Goal<I>;
 
     fn fold_with<E>(
@@ -604,7 +604,7 @@ impl<I: Interner> SuperFold<I> for Goal<I> {
 /// Folding a program clause invokes the `fold_program_clause`
 /// callback on the folder (which will, by default, invoke the
 /// `super_fold_with` method on the program clause).
-impl<I: Interner> Fold<I> for ProgramClause<I> {
+impl<I: Interner> TypeFoldable<I> for ProgramClause<I> {
     type Result = ProgramClause<I>;
 
     fn fold_with<E>(

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -1,11 +1,11 @@
-//! This module contains impls of `Fold` for those types that
+//! This module contains impls of `TypeFoldable` for those types that
 //! introduce binders.
 //!
-//! The more interesting impls of `Fold` remain in the `fold` module.
+//! The more interesting impls of `TypeFoldable` remain in the `fold` module.
 
 use crate::*;
 
-impl<I: Interner> Fold<I> for FnPointer<I> {
+impl<I: Interner> TypeFoldable<I> for FnPointer<I> {
     type Result = FnPointer<I>;
     fn fold_with<E>(
         self,
@@ -29,10 +29,10 @@ impl<I: Interner> Fold<I> for FnPointer<I> {
     }
 }
 
-impl<T, I: Interner> Fold<I> for Binders<T>
+impl<T, I: Interner> TypeFoldable<I> for Binders<T>
 where
-    T: HasInterner<Interner = I> + Fold<I>,
-    <T as Fold<I>>::Result: HasInterner<Interner = I>,
+    T: HasInterner<Interner = I> + TypeFoldable<I>,
+    <T as TypeFoldable<I>>::Result: HasInterner<Interner = I>,
     I: Interner,
 {
     type Result = Binders<T::Result>;
@@ -53,11 +53,11 @@ where
     }
 }
 
-impl<I, T> Fold<I> for Canonical<T>
+impl<I, T> TypeFoldable<I> for Canonical<T>
 where
     I: Interner,
-    T: HasInterner<Interner = I> + Fold<I>,
-    <T as Fold<I>>::Result: HasInterner<Interner = I>,
+    T: HasInterner<Interner = I> + TypeFoldable<I>,
+    <T as TypeFoldable<I>>::Result: HasInterner<Interner = I>,
 {
     type Result = Canonical<T::Result>;
     fn fold_with<E>(

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -9,7 +9,7 @@ impl<I: Interner> TypeFoldable<I> for FnPointer<I> {
     type Result = FnPointer<I>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let FnPointer {
@@ -38,7 +38,7 @@ where
     type Result = Binders<T::Result>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let Binders {
@@ -62,7 +62,7 @@ where
     type Result = Canonical<T::Result>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let Canonical {

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -1,14 +1,14 @@
-//! This module contains "rote and uninteresting" impls of `Fold` for
-//! various types. In general, we prefer to derive `Fold`, but
+//! This module contains "rote and uninteresting" impls of `TypeFoldable` for
+//! various types. In general, we prefer to derive `TypeFoldable`, but
 //! sometimes that doesn't work for whatever reason.
 //!
-//! The more interesting impls of `Fold` remain in the `fold` module.
+//! The more interesting impls of `TypeFoldable` remain in the `fold` module.
 
 use super::in_place;
 use crate::*;
 use std::marker::PhantomData;
 
-impl<T: Fold<I>, I: Interner> Fold<I> for Vec<T> {
+impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Vec<T> {
     type Result = Vec<T::Result>;
     fn fold_with<E>(
         self,
@@ -19,7 +19,7 @@ impl<T: Fold<I>, I: Interner> Fold<I> for Vec<T> {
     }
 }
 
-impl<T: Fold<I>, I: Interner> Fold<I> for Box<T> {
+impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Box<T> {
     type Result = Box<T::Result>;
     fn fold_with<E>(
         self,
@@ -32,7 +32,7 @@ impl<T: Fold<I>, I: Interner> Fold<I> for Box<T> {
 
 macro_rules! tuple_fold {
     ($($n:ident),*) => {
-        impl<$($n: Fold<I>,)* I: Interner> Fold<I> for ($($n,)*) {
+        impl<$($n: TypeFoldable<I>,)* I: Interner> TypeFoldable<I> for ($($n,)*) {
             type Result = ($($n::Result,)*);
             fn fold_with<Error>(self, folder: &mut dyn Folder<I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self::Result, Error>
             {
@@ -49,7 +49,7 @@ tuple_fold!(A, B, C);
 tuple_fold!(A, B, C, D);
 tuple_fold!(A, B, C, D, E);
 
-impl<T: Fold<I>, I: Interner> Fold<I> for Option<T> {
+impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Option<T> {
     type Result = Option<T::Result>;
     fn fold_with<E>(
         self,
@@ -63,7 +63,7 @@ impl<T: Fold<I>, I: Interner> Fold<I> for Option<T> {
     }
 }
 
-impl<I: Interner> Fold<I> for GenericArg<I> {
+impl<I: Interner> TypeFoldable<I> for GenericArg<I> {
     type Result = GenericArg<I>;
     fn fold_with<E>(
         self,
@@ -80,7 +80,7 @@ impl<I: Interner> Fold<I> for GenericArg<I> {
     }
 }
 
-impl<I: Interner> Fold<I> for Substitution<I> {
+impl<I: Interner> TypeFoldable<I> for Substitution<I> {
     type Result = Substitution<I>;
     fn fold_with<E>(
         self,
@@ -97,7 +97,7 @@ impl<I: Interner> Fold<I> for Substitution<I> {
     }
 }
 
-impl<I: Interner> Fold<I> for Goals<I> {
+impl<I: Interner> TypeFoldable<I> for Goals<I> {
     type Result = Goals<I>;
     fn fold_with<E>(
         self,
@@ -113,7 +113,7 @@ impl<I: Interner> Fold<I> for Goals<I> {
     }
 }
 
-impl<I: Interner> Fold<I> for ProgramClauses<I> {
+impl<I: Interner> TypeFoldable<I> for ProgramClauses<I> {
     type Result = ProgramClauses<I>;
     fn fold_with<E>(
         self,
@@ -129,7 +129,7 @@ impl<I: Interner> Fold<I> for ProgramClauses<I> {
     }
 }
 
-impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
+impl<I: Interner> TypeFoldable<I> for QuantifiedWhereClauses<I> {
     type Result = QuantifiedWhereClauses<I>;
     fn fold_with<E>(
         self,
@@ -145,7 +145,7 @@ impl<I: Interner> Fold<I> for QuantifiedWhereClauses<I> {
     }
 }
 
-impl<I: Interner> Fold<I> for Constraints<I> {
+impl<I: Interner> TypeFoldable<I> for Constraints<I> {
     type Result = Constraints<I>;
     fn fold_with<E>(
         self,
@@ -165,7 +165,7 @@ impl<I: Interner> Fold<I> for Constraints<I> {
 #[macro_export]
 macro_rules! copy_fold {
     ($t:ty) => {
-        impl<I: Interner> $crate::fold::Fold<I> for $t {
+        impl<I: Interner> $crate::fold::TypeFoldable<I> for $t {
             type Result = Self;
             fn fold_with<E>(
                 self,
@@ -197,7 +197,7 @@ copy_fold!(Safety);
 #[macro_export]
 macro_rules! id_fold {
     ($t:ident) => {
-        impl<I: Interner> $crate::fold::Fold<I> for $t<I> {
+        impl<I: Interner> $crate::fold::TypeFoldable<I> for $t<I> {
             type Result = $t<I>;
             fn fold_with<E>(
                 self,
@@ -243,7 +243,7 @@ impl<I: Interner> SuperFold<I> for ProgramClause<I> {
     }
 }
 
-impl<I: Interner> Fold<I> for PhantomData<I> {
+impl<I: Interner> TypeFoldable<I> for PhantomData<I> {
     type Result = PhantomData<I>;
 
     fn fold_with<E>(

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -12,7 +12,7 @@ impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Vec<T> {
     type Result = Vec<T::Result>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         in_place::fallible_map_vec(self, |e| e.fold_with(folder, outer_binder))
@@ -23,7 +23,7 @@ impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Box<T> {
     type Result = Box<T::Result>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         in_place::fallible_map_box(self, |e| e.fold_with(folder, outer_binder))
@@ -34,7 +34,7 @@ macro_rules! tuple_fold {
     ($($n:ident),*) => {
         impl<$($n: TypeFoldable<I>,)* I: Interner> TypeFoldable<I> for ($($n,)*) {
             type Result = ($($n::Result,)*);
-            fn fold_with<Error>(self, folder: &mut dyn Folder<I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self::Result, Error>
+            fn fold_with<Error>(self, folder: &mut dyn TypeFolder<I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self::Result, Error>
             {
                 #[allow(non_snake_case)]
                 let ($($n),*) = self;
@@ -53,7 +53,7 @@ impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Option<T> {
     type Result = Option<T::Result>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         match self {
@@ -67,7 +67,7 @@ impl<I: Interner> TypeFoldable<I> for GenericArg<I> {
     type Result = GenericArg<I>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let interner = folder.interner();
@@ -84,7 +84,7 @@ impl<I: Interner> TypeFoldable<I> for Substitution<I> {
     type Result = Substitution<I>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let interner = folder.interner();
@@ -101,7 +101,7 @@ impl<I: Interner> TypeFoldable<I> for Goals<I> {
     type Result = Goals<I>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let interner = folder.interner();
@@ -117,7 +117,7 @@ impl<I: Interner> TypeFoldable<I> for ProgramClauses<I> {
     type Result = ProgramClauses<I>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let interner = folder.interner();
@@ -133,7 +133,7 @@ impl<I: Interner> TypeFoldable<I> for QuantifiedWhereClauses<I> {
     type Result = QuantifiedWhereClauses<I>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let interner = folder.interner();
@@ -149,7 +149,7 @@ impl<I: Interner> TypeFoldable<I> for Constraints<I> {
     type Result = Constraints<I>;
     fn fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self::Result, E> {
         let interner = folder.interner();
@@ -169,7 +169,7 @@ macro_rules! copy_fold {
             type Result = Self;
             fn fold_with<E>(
                 self,
-                _folder: &mut dyn ($crate::fold::Folder<I, Error = E>),
+                _folder: &mut dyn ($crate::fold::TypeFolder<I, Error = E>),
                 _outer_binder: DebruijnIndex,
             ) -> ::std::result::Result<Self::Result, E> {
                 Ok(self)
@@ -201,7 +201,7 @@ macro_rules! id_fold {
             type Result = $t<I>;
             fn fold_with<E>(
                 self,
-                _folder: &mut dyn ($crate::fold::Folder<I, Error = E>),
+                _folder: &mut dyn ($crate::fold::TypeFolder<I, Error = E>),
                 _outer_binder: DebruijnIndex,
             ) -> ::std::result::Result<Self::Result, E> {
                 Ok(self)
@@ -223,7 +223,7 @@ id_fold!(ForeignDefId);
 impl<I: Interner> TypeSuperFoldable<I> for ProgramClauseData<I> {
     fn super_fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> ::std::result::Result<Self::Result, E> {
         Ok(ProgramClauseData(self.0.fold_with(folder, outer_binder)?))
@@ -233,7 +233,7 @@ impl<I: Interner> TypeSuperFoldable<I> for ProgramClauseData<I> {
 impl<I: Interner> TypeSuperFoldable<I> for ProgramClause<I> {
     fn super_fold_with<E>(
         self,
-        folder: &mut dyn Folder<I, Error = E>,
+        folder: &mut dyn TypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> ::std::result::Result<Self::Result, E> {
         let clause = self.data(folder.interner()).clone();
@@ -248,7 +248,7 @@ impl<I: Interner> TypeFoldable<I> for PhantomData<I> {
 
     fn fold_with<E>(
         self,
-        _folder: &mut dyn Folder<I, Error = E>,
+        _folder: &mut dyn TypeFolder<I, Error = E>,
         _outer_binder: DebruijnIndex,
     ) -> ::std::result::Result<Self::Result, E> {
         Ok(PhantomData)

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -220,7 +220,7 @@ id_fold!(ClosureId);
 id_fold!(GeneratorId);
 id_fold!(ForeignDefId);
 
-impl<I: Interner> SuperFold<I> for ProgramClauseData<I> {
+impl<I: Interner> TypeSuperFoldable<I> for ProgramClauseData<I> {
     fn super_fold_with<E>(
         self,
         folder: &mut dyn Folder<I, Error = E>,
@@ -230,7 +230,7 @@ impl<I: Interner> SuperFold<I> for ProgramClauseData<I> {
     }
 }
 
-impl<I: Interner> SuperFold<I> for ProgramClause<I> {
+impl<I: Interner> TypeSuperFoldable<I> for ProgramClause<I> {
     fn super_fold_with<E>(
         self,
         folder: &mut dyn Folder<I, Error = E>,

--- a/chalk-ir/src/fold/in_place.rs
+++ b/chalk-ir/src/fold/in_place.rs
@@ -1,4 +1,4 @@
-//! Subroutines to help implementers of `Fold` avoid unnecessary heap allocations.
+//! Subroutines to help implementers of `TypeFoldable` avoid unnecessary heap allocations.
 
 use std::marker::PhantomData;
 use std::{mem, ptr};

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -1,11 +1,11 @@
 //! Shifting of debruijn indices
 
-use super::Fold;
+use super::TypeFoldable;
 use crate::*;
 
 /// Methods for converting debruijn indices to move values into or out
 /// of binders.
-pub trait Shift<I: Interner>: Fold<I> {
+pub trait Shift<I: Interner>: TypeFoldable<I> {
     /// Shifts this term in one level of binders.
     fn shifted_in(self, interner: I) -> Self::Result;
 
@@ -23,7 +23,7 @@ pub trait Shift<I: Interner>: Fold<I> {
     fn shifted_out_to(self, interner: I, target_binder: DebruijnIndex) -> Fallible<Self::Result>;
 }
 
-impl<T: Fold<I>, I: Interner> Shift<I> for T {
+impl<T: TypeFoldable<I>, I: Interner> Shift<I> for T {
     fn shifted_in(self, interner: I) -> Self::Result {
         self.shifted_in_from(interner, DebruijnIndex::ONE)
     }

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -71,10 +71,10 @@ impl<I> Shifter<I> {
     }
 }
 
-impl<I: Interner> Folder<I> for Shifter<I> {
+impl<I: Interner> TypeFolder<I> for Shifter<I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 
@@ -141,10 +141,10 @@ impl<I> DownShifter<I> {
     }
 }
 
-impl<I: Interner> Folder<I> for DownShifter<I> {
+impl<I: Interner> TypeFolder<I> for DownShifter<I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -12,7 +12,11 @@ pub struct Subst<'s, I: Interner> {
 
 impl<I: Interner> Subst<'_, I> {
     /// Applies the substitution by folding
-    pub fn apply<T: Fold<I>>(interner: I, parameters: &[GenericArg<I>], value: T) -> T::Result {
+    pub fn apply<T: TypeFoldable<I>>(
+        interner: I,
+        parameters: &[GenericArg<I>],
+        value: T,
+    ) -> T::Result {
         value
             .fold_with(
                 &mut Subst {

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -29,10 +29,10 @@ impl<I: Interner> Subst<'_, I> {
     }
 }
 
-impl<I: Interner> Folder<I> for Subst<'_, I> {
+impl<I: Interner> TypeFolder<I> for Subst<'_, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-ir/src/interner.rs
+++ b/chalk-ir/src/interner.rs
@@ -647,7 +647,7 @@ pub trait Interner: Debug + Copy + Eq + Hash + Sized {
 /// are virtually all of the types in chalk-ir, for example).
 /// This lets us map from a type like `Ty<I>` to the parameter `I`.
 ///
-/// It's particularly useful for writing `Fold` impls for generic types like
+/// It's particularly useful for writing `TypeFoldable` impls for generic types like
 /// `Binder<T>`, since it allows us to figure out the interner of `T`.
 pub trait HasInterner {
     /// The interner associated with the type.

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -8,7 +8,7 @@ extern crate self as chalk_ir;
 
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
-use crate::fold::{Folder, Subst, SuperFold, TypeFoldable};
+use crate::fold::{Folder, Subst, TypeFoldable, TypeSuperFoldable};
 use crate::visit::{SuperVisit, Visit, VisitExt, Visitor};
 use chalk_derive::{HasInterner, SuperVisit, TypeFoldable, Visit, Zip};
 use std::marker::PhantomData;

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -9,8 +9,8 @@ extern crate self as chalk_ir;
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
 use crate::fold::{Folder, Subst, TypeFoldable, TypeSuperFoldable};
-use crate::visit::{SuperVisit, Visit, VisitExt, Visitor};
-use chalk_derive::{HasInterner, SuperVisit, TypeFoldable, Visit, Zip};
+use crate::visit::{SuperVisit, TypeVisitable, VisitExt, Visitor};
+use chalk_derive::{HasInterner, SuperVisit, TypeFoldable, TypeVisitable, Zip};
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
 
@@ -147,7 +147,7 @@ impl Variance {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner)]
 /// The set of assumptions we've made so far, and the current number of
 /// universal (forall) quantifiers we're within.
 pub struct Environment<I: Interner> {
@@ -197,7 +197,7 @@ impl<I: Interner> Environment<I> {
 }
 
 /// A goal with an environment to solve it in.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable)]
 #[allow(missing_docs)]
 pub struct InEnvironment<G: HasInterner> {
     pub environment: Environment<G::Interner>,
@@ -1021,7 +1021,7 @@ impl DebruijnIndex {
 /// known. It is referenced within the type using `^1.0`, indicating
 /// a bound type with debruijn index 1 (i.e., skipping through one
 /// level of binder).
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner)]
 pub struct DynTy<I: Interner> {
     /// The unknown self type.
     pub bounds: Binders<QuantifiedWhereClauses<I>>,
@@ -1084,7 +1084,7 @@ pub struct FnSig<I: Interner> {
     pub variadic: bool,
 }
 /// A wrapper for the substs on a Fn.
-#[derive(Clone, PartialEq, Eq, Hash, HasInterner, TypeFoldable, Visit)]
+#[derive(Clone, PartialEq, Eq, Hash, HasInterner, TypeFoldable, TypeVisitable)]
 pub struct FnSubst<I: Interner>(pub Substitution<I>);
 
 impl<I: Interner> Copy for FnSubst<I> where I::InternedSubstitution: Copy {}
@@ -1516,7 +1516,7 @@ impl<I: Interner> GenericArg<I> {
 }
 
 /// Generic arguments data.
-#[derive(Clone, PartialEq, Eq, Hash, Visit, TypeFoldable, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeVisitable, TypeFoldable, Zip)]
 pub enum GenericArgData<I: Interner> {
     /// Type argument
     Ty(Ty<I>),
@@ -1601,7 +1601,7 @@ impl<I: Interner, T> WithKind<I, T> {
 pub type CanonicalVarKind<I: Interner> = WithKind<I, UniverseIndex>;
 
 /// An alias, which is a trait indirection such as a projection or opaque type.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner, Zip)]
 pub enum AliasTy<I: Interner> {
     /// An associated type projection.
     Projection(ProjectionTy<I>),
@@ -1631,7 +1631,7 @@ impl<I: Interner> AliasTy<I> {
 }
 
 /// A projection `<P0 as TraitName<P1..Pn>>::AssocItem<Pn+1..Pm>`.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner)]
 pub struct ProjectionTy<I: Interner> {
     /// The id for the associated type member.
     pub associated_ty_id: AssocTypeId<I>,
@@ -1653,7 +1653,7 @@ impl<I: Interner> ProjectionTy<I> {
 }
 
 /// An opaque type `opaque type T<..>: Trait = HiddenTy`.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner)]
 pub struct OpaqueTy<I: Interner> {
     /// The id for the opaque type.
     pub opaque_ty_id: OpaqueTyId<I>,
@@ -1669,7 +1669,7 @@ impl<I: Interner> Copy for OpaqueTy<I> where I::InternedSubstitution: Copy {}
 ///   implements the trait.
 /// - `<P0 as Trait<P1..Pn>>` (e.g. `i32 as Copy`), which casts the type to
 ///   that specific trait.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner)]
 pub struct TraitRef<I: Interner> {
     /// The trait id.
     pub trait_id: TraitId<I>,
@@ -1706,7 +1706,7 @@ impl<I: Interner> TraitRef<I> {
 
 /// Lifetime outlives, which for `'a: 'b`` checks that the lifetime `'a`
 /// is a superset of the value of `'b`.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner, Zip)]
 #[allow(missing_docs)]
 pub struct LifetimeOutlives<I: Interner> {
     pub a: Lifetime<I>,
@@ -1717,7 +1717,7 @@ impl<I: Interner> Copy for LifetimeOutlives<I> where I::InternedLifetime: Copy {
 
 /// Type outlives, which for `T: 'a` checks that the type `T`
 /// lives at least as long as the lifetime `'a`
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner, Zip)]
 pub struct TypeOutlives<I: Interner> {
     /// The type which must outlive the given lifetime.
     pub ty: Ty<I>,
@@ -1754,7 +1754,7 @@ where
 }
 
 /// Checks whether a type or trait ref is well-formed.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner, Zip)]
 pub enum WellFormed<I: Interner> {
     /// A predicate which is true when some trait ref is well-formed.
     /// For example, given the following trait definitions:
@@ -1792,7 +1792,7 @@ where
 }
 
 /// Checks whether a type or trait ref can be derived from the contents of the environment.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner, Zip)]
 pub enum FromEnv<I: Interner> {
     /// A predicate which enables deriving everything which should be true if we *know* that
     /// some trait ref is well-formed. For example given the above trait definitions, we can use
@@ -1990,7 +1990,7 @@ impl<I: Interner> DomainGoal<I> {
 }
 
 /// Equality goal: tries to prove that two values are equal.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, Zip)]
 #[allow(missing_docs)]
 pub struct EqGoal<I: Interner> {
     pub a: GenericArg<I>,
@@ -2000,7 +2000,7 @@ pub struct EqGoal<I: Interner> {
 impl<I: Interner> Copy for EqGoal<I> where I::InternedGenericArg: Copy {}
 
 /// Subtype goal: tries to prove that `a` is a subtype of `b`
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, Zip)]
 #[allow(missing_docs)]
 pub struct SubtypeGoal<I: Interner> {
     pub a: Ty<I>,
@@ -2013,7 +2013,7 @@ impl<I: Interner> Copy for SubtypeGoal<I> where I::InternedType: Copy {}
 /// type. A projection `T::Foo` normalizes to the type `U` if we can
 /// **match it to an impl** and that impl has a `type Foo = V` where
 /// `U = V`.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, Zip)]
 #[allow(missing_docs)]
 pub struct Normalize<I: Interner> {
     pub alias: AliasTy<I>,
@@ -2028,7 +2028,7 @@ where
 }
 
 /// Proves **equality** between an alias and a type.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, Zip)]
 #[allow(missing_docs)]
 pub struct AliasEq<I: Interner> {
     pub alias: AliasTy<I>,
@@ -2291,7 +2291,7 @@ where
 /// Represents one clause of the form `consequence :- conditions` where
 /// `conditions = cond_1 && cond_2 && ...` is the conjunction of the individual
 /// conditions.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner, Zip)]
 pub struct ProgramClauseImplication<I: Interner> {
     /// The consequence of the clause, which holds if the conditions holds.
     pub consequence: DomainGoal<I>,
@@ -2571,7 +2571,7 @@ where
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner, Zip)]
 /// A general goal; this is the full range of questions you can pose to Chalk.
 pub enum GoalData<I: Interner> {
     /// Introduces a binding at depth 0, shifting other bindings up
@@ -2654,7 +2654,7 @@ pub enum QuantifierKind {
 /// lifetime constraints, instead gathering them up to return with our solution
 /// for later checking. This allows for decoupling between type and region
 /// checking in the compiler.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner, Zip)]
 pub enum Constraint<I: Interner> {
     /// Outlives constraint `'a: 'b`, indicating that the value of `'a` must be
     /// a superset of the value of `'b`.
@@ -3037,7 +3037,7 @@ impl<I: Interner> Variances<I> {
 /// substitution stores the values for the query's unknown variables,
 /// and the constraints represents any region constraints that must
 /// additionally be solved.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner)]
 pub struct ConstrainedSubst<I: Interner> {
     /// The substitution that is being constrained.
     ///
@@ -3049,7 +3049,7 @@ pub struct ConstrainedSubst<I: Interner> {
 }
 
 /// The resulting substitution after solving a goal.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner)]
 pub struct AnswerSubst<I: Interner> {
     /// The substitution result.
     ///

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -8,7 +8,7 @@ extern crate self as chalk_ir;
 
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
-use crate::fold::{Folder, Subst, TypeFoldable, TypeSuperFoldable};
+use crate::fold::{Subst, TypeFoldable, TypeFolder, TypeSuperFoldable};
 use crate::visit::{TypeSuperVisitable, TypeVisitable, VisitExt, Visitor};
 use chalk_derive::{HasInterner, TypeFoldable, TypeSuperVisitable, TypeVisitable, Zip};
 use std::marker::PhantomData;
@@ -2830,10 +2830,10 @@ impl<'a, I: Interner> ToGenericArg<I> for (usize, &'a VariableKind<I>) {
     }
 }
 
-impl<'i, I: Interner, A: AsParameters<I>> Folder<I> for &SubstFolder<'i, I, A> {
+impl<'i, I: Interner, A: AsParameters<I>> TypeFolder<I> for &SubstFolder<'i, I, A> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -9,7 +9,7 @@ extern crate self as chalk_ir;
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
 use crate::fold::{Subst, TypeFoldable, TypeFolder, TypeSuperFoldable};
-use crate::visit::{TypeSuperVisitable, TypeVisitable, VisitExt, Visitor};
+use crate::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitor, VisitExt};
 use chalk_derive::{HasInterner, TypeFoldable, TypeSuperVisitable, TypeVisitable, Zip};
 use std::marker::PhantomData;
 use std::ops::ControlFlow;

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -9,8 +9,8 @@ extern crate self as chalk_ir;
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
 use crate::fold::{Folder, Subst, TypeFoldable, TypeSuperFoldable};
-use crate::visit::{SuperVisit, TypeVisitable, VisitExt, Visitor};
-use chalk_derive::{HasInterner, SuperVisit, TypeFoldable, TypeVisitable, Zip};
+use crate::visit::{TypeSuperVisitable, TypeVisitable, VisitExt, Visitor};
+use chalk_derive::{HasInterner, TypeFoldable, TypeSuperVisitable, TypeVisitable, Zip};
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
 
@@ -1733,7 +1733,7 @@ where
 }
 
 /// Where clauses that can be written by a Rust programmer.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, SuperVisit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeSuperVisitable, HasInterner, Zip)]
 pub enum WhereClause<I: Interner> {
     /// Type implements a trait.
     Implemented(TraitRef<I>),
@@ -1831,7 +1831,7 @@ where
 /// A "domain goal" is a goal that is directly about Rust, rather than a pure
 /// logical statement. As much as possible, the Chalk solver should avoid
 /// decomposing this enum, and instead treat its values opaquely.
-#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, SuperVisit, HasInterner, Zip)]
+#[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeSuperVisitable, HasInterner, Zip)]
 pub enum DomainGoal<I: Interner> {
     /// Simple goal that is true if the where clause is true.
     Holds(WhereClause<I>),

--- a/chalk-ir/src/visit.rs
+++ b/chalk-ir/src/visit.rs
@@ -30,7 +30,7 @@ macro_rules! try_break {
 /// such as a `Goal`, and computes a value as a result.
 ///
 ///
-/// To **apply** a visitor, use the `Visit::visit_with` method, like so
+/// To **apply** a visitor, use the `TypeVisitable::visit_with` method, like so
 ///
 /// ```rust,ignore
 /// let result = x.visit_with(&mut visitor, 0);
@@ -188,7 +188,7 @@ pub trait Visitor<I: Interner> {
 
 /// Applies the given `visitor` to a value, producing a visited result
 /// of type `Visitor::Result`.
-pub trait Visit<I: Interner>: Debug {
+pub trait TypeVisitable<I: Interner>: Debug {
     /// Apply the given visitor `visitor` to `self`; `binders` is the
     /// number of binders that are in scope when beginning the
     /// visitor. Typically `binders` starts as 0, but is adjusted when
@@ -204,7 +204,7 @@ pub trait Visit<I: Interner>: Debug {
 /// For types where "visit" invokes a callback on the `visitor`, the
 /// `SuperVisit` trait captures the recursive behavior that visits all
 /// the contents of the type.
-pub trait SuperVisit<I: Interner>: Visit<I> {
+pub trait SuperVisit<I: Interner>: TypeVisitable<I> {
     /// Recursively visits the type contents.
     fn super_visit_with<B>(
         &self,
@@ -216,7 +216,7 @@ pub trait SuperVisit<I: Interner>: Visit<I> {
 /// "visiting" a type invokes the `visit_ty` method on the visitor; this
 /// usually (in turn) invokes `super_visit_ty` to visit the individual
 /// parts.
-impl<I: Interner> Visit<I> for Ty<I> {
+impl<I: Interner> TypeVisitable<I> for Ty<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -301,7 +301,7 @@ where
     }
 }
 
-impl<I: Interner> Visit<I> for Lifetime<I> {
+impl<I: Interner> TypeVisitable<I> for Lifetime<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -338,7 +338,7 @@ impl<I: Interner> SuperVisit<I> for Lifetime<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for Const<I> {
+impl<I: Interner> TypeVisitable<I> for Const<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -372,7 +372,7 @@ impl<I: Interner> SuperVisit<I> for Const<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for Goal<I> {
+impl<I: Interner> TypeVisitable<I> for Goal<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -393,7 +393,7 @@ impl<I: Interner> SuperVisit<I> for Goal<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for ProgramClause<I> {
+impl<I: Interner> TypeVisitable<I> for ProgramClause<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -403,7 +403,7 @@ impl<I: Interner> Visit<I> for ProgramClause<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for WhereClause<I> {
+impl<I: Interner> TypeVisitable<I> for WhereClause<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -413,7 +413,7 @@ impl<I: Interner> Visit<I> for WhereClause<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for DomainGoal<I> {
+impl<I: Interner> TypeVisitable<I> for DomainGoal<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,

--- a/chalk-ir/src/visit.rs
+++ b/chalk-ir/src/visit.rs
@@ -202,9 +202,9 @@ pub trait TypeVisitable<I: Interner>: Debug {
 }
 
 /// For types where "visit" invokes a callback on the `visitor`, the
-/// `SuperVisit` trait captures the recursive behavior that visits all
+/// `TypeSuperVisitable` trait captures the recursive behavior that visits all
 /// the contents of the type.
-pub trait SuperVisit<I: Interner>: TypeVisitable<I> {
+pub trait TypeSuperVisitable<I: Interner>: TypeVisitable<I> {
     /// Recursively visits the type contents.
     fn super_visit_with<B>(
         &self,
@@ -227,7 +227,7 @@ impl<I: Interner> TypeVisitable<I> for Ty<I> {
 }
 
 /// "Super visit" for a type invokes the more detailed callbacks on the type
-impl<I> SuperVisit<I> for Ty<I>
+impl<I> TypeSuperVisitable<I> for Ty<I>
 where
     I: Interner,
 {
@@ -311,7 +311,7 @@ impl<I: Interner> TypeVisitable<I> for Lifetime<I> {
     }
 }
 
-impl<I: Interner> SuperVisit<I> for Lifetime<I> {
+impl<I: Interner> TypeSuperVisitable<I> for Lifetime<I> {
     fn super_visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -348,7 +348,7 @@ impl<I: Interner> TypeVisitable<I> for Const<I> {
     }
 }
 
-impl<I: Interner> SuperVisit<I> for Const<I> {
+impl<I: Interner> TypeSuperVisitable<I> for Const<I> {
     fn super_visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -382,7 +382,7 @@ impl<I: Interner> TypeVisitable<I> for Goal<I> {
     }
 }
 
-impl<I: Interner> SuperVisit<I> for Goal<I> {
+impl<I: Interner> TypeSuperVisitable<I> for Goal<I> {
     fn super_visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,

--- a/chalk-ir/src/visit/binder_impls.rs
+++ b/chalk-ir/src/visit/binder_impls.rs
@@ -1,12 +1,14 @@
-//! This module contains impls of `Visit` for those types that
+//! This module contains impls of `TypeVisitable` for those types that
 //! introduce binders.
 //!
-//! The more interesting impls of `Visit` remain in the `visit` module.
+//! The more interesting impls of `TypeVisitable` remain in the `visit` module.
 
 use crate::interner::HasInterner;
-use crate::{Binders, Canonical, ControlFlow, DebruijnIndex, FnPointer, Interner, Visit, Visitor};
+use crate::{
+    Binders, Canonical, ControlFlow, DebruijnIndex, FnPointer, Interner, TypeVisitable, Visitor,
+};
 
-impl<I: Interner> Visit<I> for FnPointer<I> {
+impl<I: Interner> TypeVisitable<I> for FnPointer<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -17,9 +19,9 @@ impl<I: Interner> Visit<I> for FnPointer<I> {
     }
 }
 
-impl<T, I: Interner> Visit<I> for Binders<T>
+impl<T, I: Interner> TypeVisitable<I> for Binders<T>
 where
-    T: HasInterner + Visit<I>,
+    T: HasInterner + TypeVisitable<I>,
 {
     fn visit_with<B>(
         &self,
@@ -30,10 +32,10 @@ where
     }
 }
 
-impl<I, T> Visit<I> for Canonical<T>
+impl<I, T> TypeVisitable<I> for Canonical<T>
 where
     I: Interner,
-    T: HasInterner<Interner = I> + Visit<I>,
+    T: HasInterner<Interner = I> + TypeVisitable<I>,
 {
     fn visit_with<B>(
         &self,

--- a/chalk-ir/src/visit/binder_impls.rs
+++ b/chalk-ir/src/visit/binder_impls.rs
@@ -5,13 +5,13 @@
 
 use crate::interner::HasInterner;
 use crate::{
-    Binders, Canonical, ControlFlow, DebruijnIndex, FnPointer, Interner, TypeVisitable, Visitor,
+    Binders, Canonical, ControlFlow, DebruijnIndex, FnPointer, Interner, TypeVisitable, TypeVisitor,
 };
 
 impl<I: Interner> TypeVisitable<I> for FnPointer<I> {
     fn visit_with<B>(
         &self,
-        visitor: &mut dyn Visitor<I, BreakTy = B>,
+        visitor: &mut dyn TypeVisitor<I, BreakTy = B>,
         outer_binder: DebruijnIndex,
     ) -> ControlFlow<B> {
         self.substitution
@@ -25,7 +25,7 @@ where
 {
     fn visit_with<B>(
         &self,
-        visitor: &mut dyn Visitor<I, BreakTy = B>,
+        visitor: &mut dyn TypeVisitor<I, BreakTy = B>,
         outer_binder: DebruijnIndex,
     ) -> ControlFlow<B> {
         self.value.visit_with(visitor, outer_binder.shifted_in())
@@ -39,7 +39,7 @@ where
 {
     fn visit_with<B>(
         &self,
-        visitor: &mut dyn Visitor<I, BreakTy = B>,
+        visitor: &mut dyn TypeVisitor<I, BreakTy = B>,
         outer_binder: DebruijnIndex,
     ) -> ControlFlow<B> {
         self.value.visit_with(visitor, outer_binder.shifted_in())

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -1,15 +1,15 @@
-//! This module contains "rote and uninteresting" impls of `Visit` for
-//! various types. In general, we prefer to derive `Visit`, but
+//! This module contains "rote and uninteresting" impls of `TypeVisitable` for
+//! various types. In general, we prefer to derive `TypeVisitable`, but
 //! sometimes that doesn't work for whatever reason.
 //!
-//! The more interesting impls of `Visit` remain in the `visit` module.
+//! The more interesting impls of `TypeVisitable` remain in the `visit` module.
 
 use crate::{
     try_break, AdtId, AssocTypeId, ClausePriority, ClosureId, Constraints, ControlFlow,
     DebruijnIndex, FloatTy, FnDefId, ForeignDefId, GeneratorId, GenericArg, Goals, ImplId, IntTy,
     Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauses,
     QuantifiedWhereClauses, QuantifierKind, Safety, Scalar, Substitution, SuperVisit, TraitId,
-    UintTy, UniverseIndex, Visit, Visitor,
+    TypeVisitable, UintTy, UniverseIndex, Visitor,
 };
 use std::{marker::PhantomData, sync::Arc};
 
@@ -20,7 +20,7 @@ pub fn visit_iter<'i, T, I, B>(
     outer_binder: DebruijnIndex,
 ) -> ControlFlow<B>
 where
-    T: Visit<I>,
+    T: TypeVisitable<I>,
     I: 'i + Interner,
 {
     for e in it {
@@ -29,7 +29,7 @@ where
     ControlFlow::Continue(())
 }
 
-impl<T: Visit<I>, I: Interner> Visit<I> for &T {
+impl<T: TypeVisitable<I>, I: Interner> TypeVisitable<I> for &T {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -39,7 +39,7 @@ impl<T: Visit<I>, I: Interner> Visit<I> for &T {
     }
 }
 
-impl<T: Visit<I>, I: Interner> Visit<I> for Vec<T> {
+impl<T: TypeVisitable<I>, I: Interner> TypeVisitable<I> for Vec<T> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -49,7 +49,7 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Vec<T> {
     }
 }
 
-impl<T: Visit<I>, I: Interner> Visit<I> for &[T] {
+impl<T: TypeVisitable<I>, I: Interner> TypeVisitable<I> for &[T] {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -59,7 +59,7 @@ impl<T: Visit<I>, I: Interner> Visit<I> for &[T] {
     }
 }
 
-impl<T: Visit<I>, I: Interner> Visit<I> for Box<T> {
+impl<T: TypeVisitable<I>, I: Interner> TypeVisitable<I> for Box<T> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -69,7 +69,7 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Box<T> {
     }
 }
 
-impl<T: Visit<I>, I: Interner> Visit<I> for Arc<T> {
+impl<T: TypeVisitable<I>, I: Interner> TypeVisitable<I> for Arc<T> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -81,7 +81,7 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Arc<T> {
 
 macro_rules! tuple_visit {
     ($($n:ident),*) => {
-        impl<$($n: Visit<I>,)* I: Interner> Visit<I> for ($($n,)*) {
+        impl<$($n: TypeVisitable<I>,)* I: Interner> TypeVisitable<I> for ($($n,)*) {
             fn visit_with<BT>(&self, visitor: &mut dyn Visitor<I, BreakTy = BT>, outer_binder: DebruijnIndex) -> ControlFlow<BT> {
                 #[allow(non_snake_case)]
                 let &($(ref $n),*) = self;
@@ -99,7 +99,7 @@ tuple_visit!(A, B, C);
 tuple_visit!(A, B, C, D);
 tuple_visit!(A, B, C, D, E);
 
-impl<T: Visit<I>, I: Interner> Visit<I> for Option<T> {
+impl<T: TypeVisitable<I>, I: Interner> TypeVisitable<I> for Option<T> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -112,7 +112,7 @@ impl<T: Visit<I>, I: Interner> Visit<I> for Option<T> {
     }
 }
 
-impl<I: Interner> Visit<I> for GenericArg<I> {
+impl<I: Interner> TypeVisitable<I> for GenericArg<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -123,7 +123,7 @@ impl<I: Interner> Visit<I> for GenericArg<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for Substitution<I> {
+impl<I: Interner> TypeVisitable<I> for Substitution<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -134,7 +134,7 @@ impl<I: Interner> Visit<I> for Substitution<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for Goals<I> {
+impl<I: Interner> TypeVisitable<I> for Goals<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -149,7 +149,7 @@ impl<I: Interner> Visit<I> for Goals<I> {
 #[macro_export]
 macro_rules! const_visit {
     ($t:ty) => {
-        impl<I: Interner> $crate::visit::Visit<I> for $t {
+        impl<I: Interner> $crate::visit::TypeVisitable<I> for $t {
             fn visit_with<B>(
                 &self,
                 _visitor: &mut dyn ($crate::visit::Visitor<I, BreakTy = B>),
@@ -180,7 +180,7 @@ const_visit!(Safety);
 #[macro_export]
 macro_rules! id_visit {
     ($t:ident) => {
-        impl<I: Interner> $crate::visit::Visit<I> for $t<I> {
+        impl<I: Interner> $crate::visit::TypeVisitable<I> for $t<I> {
             fn visit_with<B>(
                 &self,
                 _visitor: &mut dyn ($crate::visit::Visitor<I, BreakTy = B>),
@@ -214,7 +214,7 @@ impl<I: Interner> SuperVisit<I> for ProgramClause<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for ProgramClauses<I> {
+impl<I: Interner> TypeVisitable<I> for ProgramClauses<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -226,7 +226,7 @@ impl<I: Interner> Visit<I> for ProgramClauses<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for Constraints<I> {
+impl<I: Interner> TypeVisitable<I> for Constraints<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -238,7 +238,7 @@ impl<I: Interner> Visit<I> for Constraints<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for QuantifiedWhereClauses<I> {
+impl<I: Interner> TypeVisitable<I> for QuantifiedWhereClauses<I> {
     fn visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,
@@ -250,7 +250,7 @@ impl<I: Interner> Visit<I> for QuantifiedWhereClauses<I> {
     }
 }
 
-impl<I: Interner> Visit<I> for PhantomData<I> {
+impl<I: Interner> TypeVisitable<I> for PhantomData<I> {
     fn visit_with<B>(
         &self,
         _visitor: &mut dyn Visitor<I, BreakTy = B>,

--- a/chalk-ir/src/visit/boring_impls.rs
+++ b/chalk-ir/src/visit/boring_impls.rs
@@ -8,8 +8,8 @@ use crate::{
     try_break, AdtId, AssocTypeId, ClausePriority, ClosureId, Constraints, ControlFlow,
     DebruijnIndex, FloatTy, FnDefId, ForeignDefId, GeneratorId, GenericArg, Goals, ImplId, IntTy,
     Interner, Mutability, OpaqueTyId, PlaceholderIndex, ProgramClause, ProgramClauses,
-    QuantifiedWhereClauses, QuantifierKind, Safety, Scalar, Substitution, SuperVisit, TraitId,
-    TypeVisitable, UintTy, UniverseIndex, Visitor,
+    QuantifiedWhereClauses, QuantifierKind, Safety, Scalar, Substitution, TraitId,
+    TypeSuperVisitable, TypeVisitable, UintTy, UniverseIndex, Visitor,
 };
 use std::{marker::PhantomData, sync::Arc};
 
@@ -202,7 +202,7 @@ id_visit!(ClosureId);
 id_visit!(GeneratorId);
 id_visit!(ForeignDefId);
 
-impl<I: Interner> SuperVisit<I> for ProgramClause<I> {
+impl<I: Interner> TypeSuperVisitable<I> for ProgramClause<I> {
     fn super_visit_with<B>(
         &self,
         visitor: &mut dyn Visitor<I, BreakTy = B>,

--- a/chalk-ir/src/visit/visitors.rs
+++ b/chalk-ir/src/visit/visitors.rs
@@ -1,9 +1,9 @@
 //! Visitor helpers
 
-use crate::{BoundVar, ControlFlow, DebruijnIndex, Interner, Visit, Visitor};
+use crate::{BoundVar, ControlFlow, DebruijnIndex, Interner, TypeVisitable, Visitor};
 
 /// Visitor extensions.
-pub trait VisitExt<I: Interner>: Visit<I> {
+pub trait VisitExt<I: Interner>: TypeVisitable<I> {
     /// Check whether there are free (non-bound) variables.
     fn has_free_vars(&self, interner: I) -> bool {
         let flow = self.visit_with(
@@ -14,7 +14,7 @@ pub trait VisitExt<I: Interner>: Visit<I> {
     }
 }
 
-impl<T, I: Interner> VisitExt<I> for T where T: Visit<I> {}
+impl<T, I: Interner> VisitExt<I> for T where T: TypeVisitable<I> {}
 
 struct FindFreeVarsVisitor<I: Interner> {
     interner: I,

--- a/chalk-ir/src/visit/visitors.rs
+++ b/chalk-ir/src/visit/visitors.rs
@@ -1,8 +1,8 @@
-//! Visitor helpers
+//! TypeVisitor helpers
 
-use crate::{BoundVar, ControlFlow, DebruijnIndex, Interner, TypeVisitable, Visitor};
+use crate::{BoundVar, ControlFlow, DebruijnIndex, Interner, TypeVisitable, TypeVisitor};
 
-/// Visitor extensions.
+/// TypeVisitor extensions.
 pub trait VisitExt<I: Interner>: TypeVisitable<I> {
     /// Check whether there are free (non-bound) variables.
     fn has_free_vars(&self, interner: I) -> bool {
@@ -20,10 +20,10 @@ struct FindFreeVarsVisitor<I: Interner> {
     interner: I,
 }
 
-impl<I: Interner> Visitor<I> for FindFreeVarsVisitor<I> {
+impl<I: Interner> TypeVisitor<I> for FindFreeVarsVisitor<I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn TypeVisitor<I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-ir/src/zip.rs
+++ b/chalk-ir/src/zip.rs
@@ -1,6 +1,6 @@
 //! Traits for "zipping" types, walking through two structures and checking that they match.
 
-use crate::fold::Fold;
+use crate::fold::TypeFoldable;
 use crate::*;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -44,7 +44,7 @@ pub trait Zipper<I: Interner> {
         b: &Binders<T>,
     ) -> Fallible<()>
     where
-        T: Clone + HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>;
+        T: Clone + HasInterner<Interner = I> + Zip<I> + TypeFoldable<I, Result = T>;
 
     /// Zips two substs
     fn zip_substs(
@@ -98,7 +98,7 @@ where
 
     fn zip_binders<T>(&mut self, variance: Variance, a: &Binders<T>, b: &Binders<T>) -> Fallible<()>
     where
-        T: Clone + HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>,
+        T: Clone + HasInterner<Interner = I> + Zip<I> + TypeFoldable<I, Result = T>,
     {
         (**self).zip_binders(variance, a, b)
     }
@@ -248,7 +248,7 @@ impl<I: Interner> Zip<I> for Const<I> {
 }
 impl<I: Interner, T> Zip<I> for Binders<T>
 where
-    T: Clone + HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>,
+    T: Clone + HasInterner<Interner = I> + Zip<I> + TypeFoldable<I, Result = T>,
 {
     fn zip_with<Z: Zipper<I>>(
         zipper: &mut Z,

--- a/chalk-recursive/src/fulfill.rs
+++ b/chalk-recursive/src/fulfill.rs
@@ -1,7 +1,7 @@
 use crate::fixed_point::Minimums;
 use crate::solve::SolveDatabase;
 use chalk_ir::cast::Cast;
-use chalk_ir::fold::Fold;
+use chalk_ir::fold::TypeFoldable;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::Visit;
 use chalk_ir::zip::Zip;
@@ -65,7 +65,7 @@ fn canonicalize<I: Interner, T>(
     value: T,
 ) -> (Canonical<T::Result>, Vec<GenericArg<I>>)
 where
-    T: Fold<I>,
+    T: TypeFoldable<I>,
     T::Result: HasInterner<Interner = I>,
 {
     let res = infer.canonicalize(interner, value);
@@ -83,7 +83,7 @@ fn u_canonicalize<I: Interner, T>(
     value0: &Canonical<T>,
 ) -> (UCanonical<T::Result>, UniverseMap)
 where
-    T: Clone + HasInterner<Interner = I> + Fold<I> + Visit<I>,
+    T: Clone + HasInterner<Interner = I> + TypeFoldable<I> + Visit<I>,
     T::Result: HasInterner<Interner = I>,
 {
     let res = InferenceTable::u_canonicalize(interner, value0);

--- a/chalk-recursive/src/fulfill.rs
+++ b/chalk-recursive/src/fulfill.rs
@@ -3,7 +3,7 @@ use crate::solve::SolveDatabase;
 use chalk_ir::cast::Cast;
 use chalk_ir::fold::TypeFoldable;
 use chalk_ir::interner::{HasInterner, Interner};
-use chalk_ir::visit::Visit;
+use chalk_ir::visit::TypeVisitable;
 use chalk_ir::zip::Zip;
 use chalk_ir::{
     Binders, BoundVar, Canonical, ConstrainedSubst, Constraint, Constraints, DomainGoal,
@@ -83,7 +83,7 @@ fn u_canonicalize<I: Interner, T>(
     value0: &Canonical<T>,
 ) -> (UCanonical<T::Result>, UniverseMap)
 where
-    T: Clone + HasInterner<Interner = I> + TypeFoldable<I> + Visit<I>,
+    T: Clone + HasInterner<Interner = I> + TypeFoldable<I> + TypeVisitable<I>,
     T::Result: HasInterner<Interner = I>,
 {
     let res = InferenceTable::u_canonicalize(interner, value0);

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -3,7 +3,7 @@ use super::fulfill::Fulfill;
 use crate::fixed_point::Minimums;
 use crate::UCanonicalGoal;
 use chalk_ir::could_match::CouldMatch;
-use chalk_ir::fold::Fold;
+use chalk_ir::fold::TypeFoldable;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::{
     Canonical, ClausePriority, DomainGoal, Fallible, Floundered, Goal, GoalData, InEnvironment,
@@ -196,7 +196,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
         }
     }
 
-    fn new_inference_table<T: Fold<I, Result = T> + HasInterner<Interner = I> + Clone>(
+    fn new_inference_table<T: TypeFoldable<I, Result = T> + HasInterner<Interner = I> + Clone>(
         &self,
         ucanonical_goal: &UCanonical<InEnvironment<T>>,
     ) -> (InferenceTable<I>, Substitution<I>, InEnvironment<T::Result>) {

--- a/chalk-solve/src/clauses/builder.rs
+++ b/chalk-solve/src/clauses/builder.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::cast::{Cast, CastTo};
 use crate::RustIrDatabase;
-use chalk_ir::fold::{Fold, Shift};
+use chalk_ir::fold::{Shift, TypeFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
 use tracing::{debug, instrument};
@@ -135,7 +135,7 @@ impl<'me, I: Interner> ClauseBuilder<'me, I> {
         op: impl FnOnce(&mut Self, V::Result) -> R,
     ) -> R
     where
-        V: Fold<I> + HasInterner<Interner = I>,
+        V: TypeFoldable<I> + HasInterner<Interner = I>,
         V::Result: std::fmt::Debug,
     {
         let old_len = self.binders.len();

--- a/chalk-solve/src/clauses/builtin_traits/unsize.rs
+++ b/chalk-solve/src/clauses/builtin_traits/unsize.rs
@@ -8,7 +8,7 @@ use crate::{Interner, RustIrDatabase, TraitRef, WellKnownTrait};
 use chalk_ir::{
     cast::Cast,
     interner::HasInterner,
-    visit::{SuperVisit, TypeVisitable, Visitor},
+    visit::{TypeSuperVisitable, TypeVisitable, Visitor},
     Binders, Const, ConstValue, DebruijnIndex, DomainGoal, DynTy, EqGoal, Goal, LifetimeOutlives,
     QuantifiedWhereClauses, Substitution, TraitId, Ty, TyKind, TypeOutlives, WhereClause,
 };

--- a/chalk-solve/src/clauses/builtin_traits/unsize.rs
+++ b/chalk-solve/src/clauses/builtin_traits/unsize.rs
@@ -8,7 +8,7 @@ use crate::{Interner, RustIrDatabase, TraitRef, WellKnownTrait};
 use chalk_ir::{
     cast::Cast,
     interner::HasInterner,
-    visit::{SuperVisit, Visit, Visitor},
+    visit::{SuperVisit, TypeVisitable, Visitor},
     Binders, Const, ConstValue, DebruijnIndex, DomainGoal, DynTy, EqGoal, Goal, LifetimeOutlives,
     QuantifiedWhereClauses, Substitution, TraitId, Ty, TyKind, TypeOutlives, WhereClause,
 };
@@ -60,7 +60,7 @@ impl<I: Interner> Visitor<I> for UnsizeParameterCollector<I> {
 
 fn outer_binder_parameters_used<I: Interner>(
     interner: I,
-    v: &Binders<impl Visit<I> + HasInterner>,
+    v: &Binders<impl TypeVisitable<I> + HasInterner>,
 ) -> HashSet<usize> {
     let mut visitor = UnsizeParameterCollector {
         interner,
@@ -124,7 +124,7 @@ impl<'p, I: Interner> Visitor<I> for ParameterOccurenceCheck<'p, I> {
 
 fn uses_outer_binder_params<I: Interner>(
     interner: I,
-    v: &Binders<impl Visit<I> + HasInterner>,
+    v: &Binders<impl TypeVisitable<I> + HasInterner>,
     parameters: &HashSet<usize>,
 ) -> bool {
     let mut visitor = ParameterOccurenceCheck {

--- a/chalk-solve/src/clauses/builtin_traits/unsize.rs
+++ b/chalk-solve/src/clauses/builtin_traits/unsize.rs
@@ -8,7 +8,7 @@ use crate::{Interner, RustIrDatabase, TraitRef, WellKnownTrait};
 use chalk_ir::{
     cast::Cast,
     interner::HasInterner,
-    visit::{TypeSuperVisitable, TypeVisitable, Visitor},
+    visit::{TypeSuperVisitable, TypeVisitable, TypeVisitor},
     Binders, Const, ConstValue, DebruijnIndex, DomainGoal, DynTy, EqGoal, Goal, LifetimeOutlives,
     QuantifiedWhereClauses, Substitution, TraitId, Ty, TyKind, TypeOutlives, WhereClause,
 };
@@ -19,10 +19,10 @@ struct UnsizeParameterCollector<I: Interner> {
     parameters: HashSet<usize>,
 }
 
-impl<I: Interner> Visitor<I> for UnsizeParameterCollector<I> {
+impl<I: Interner> TypeVisitor<I> for UnsizeParameterCollector<I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn TypeVisitor<I, BreakTy = Self::BreakTy> {
         self
     }
 
@@ -76,10 +76,10 @@ struct ParameterOccurenceCheck<'p, I: Interner> {
     parameters: &'p HashSet<usize>,
 }
 
-impl<'p, I: Interner> Visitor<I> for ParameterOccurenceCheck<'p, I> {
+impl<'p, I: Interner> TypeVisitor<I> for ParameterOccurenceCheck<'p, I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn TypeVisitor<I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -8,7 +8,7 @@ use crate::RustIrDatabase;
 use crate::Ty;
 use crate::{debug_span, TyKind};
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::{Visit, Visitor};
+use chalk_ir::visit::{TypeVisitable, Visitor};
 use chalk_ir::{DebruijnIndex, Environment};
 use rustc_hash::FxHashSet;
 use std::ops::ControlFlow;

--- a/chalk-solve/src/clauses/env_elaborator.rs
+++ b/chalk-solve/src/clauses/env_elaborator.rs
@@ -8,7 +8,7 @@ use crate::RustIrDatabase;
 use crate::Ty;
 use crate::{debug_span, TyKind};
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::{TypeVisitable, Visitor};
+use chalk_ir::visit::{TypeVisitable, TypeVisitor};
 use chalk_ir::{DebruijnIndex, Environment};
 use rustc_hash::FxHashSet;
 use std::ops::ControlFlow;
@@ -43,10 +43,10 @@ struct EnvElaborator<'me, 'builder, I: Interner> {
     environment: &'me Environment<I>,
 }
 
-impl<'me, 'builder, I: Interner> Visitor<I> for EnvElaborator<'me, 'builder, I> {
+impl<'me, 'builder, I: Interner> TypeVisitor<I> for EnvElaborator<'me, 'builder, I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn TypeVisitor<I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -7,7 +7,7 @@
 //! types passed to `program_clauses` in the clauses we generate.
 
 use chalk_ir::{
-    fold::{Folder, TypeFoldable},
+    fold::{TypeFoldable, TypeFolder},
     interner::{HasInterner, Interner},
     Binders, BoundVar, Const, ConstData, ConstValue, DebruijnIndex, Fallible, Lifetime,
     LifetimeData, NoSolution, Ty, TyKind, TyVariableKind, VariableKind, VariableKinds,
@@ -41,10 +41,10 @@ impl<I: Interner> Generalize<I> {
     }
 }
 
-impl<I: Interner> Folder<I> for Generalize<I> {
+impl<I: Interner> TypeFolder<I> for Generalize<I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -7,7 +7,7 @@
 //! types passed to `program_clauses` in the clauses we generate.
 
 use chalk_ir::{
-    fold::{Fold, Folder},
+    fold::{Folder, TypeFoldable},
     interner::{HasInterner, Interner},
     Binders, BoundVar, Const, ConstData, ConstValue, DebruijnIndex, Fallible, Lifetime,
     LifetimeData, NoSolution, Ty, TyKind, TyVariableKind, VariableKind, VariableKinds,
@@ -23,7 +23,7 @@ pub struct Generalize<I: Interner> {
 impl<I: Interner> Generalize<I> {
     pub fn apply<T>(interner: I, value: T) -> Binders<T::Result>
     where
-        T: HasInterner<Interner = I> + Fold<I>,
+        T: HasInterner<Interner = I> + TypeFoldable<I>,
         T::Result: HasInterner<Interner = I>,
     {
         let mut generalize = Generalize {

--- a/chalk-solve/src/coherence.rs
+++ b/chalk-solve/src/coherence.rs
@@ -96,7 +96,7 @@ where
 
         let forest = self.build_specialization_forest()?;
 
-        // Visit every root in the forest & set specialization
+        // TypeVisitable every root in the forest & set specialization
         // priority for the tree that is the root of.
         for root_idx in forest.externals(Direction::Incoming) {
             self.set_priorities(root_idx, &forest, 0, &mut result);
@@ -141,7 +141,7 @@ where
             map.insert(*impl_id, SpecializationPriority(p));
         }
 
-        // Visit all children of this node, setting their priority to this + 1
+        // TypeVisitable all children of this node, setting their priority to this + 1
         for child_idx in forest.neighbors(idx) {
             self.set_priorities(child_idx, forest, p + 1, map);
         }

--- a/chalk-solve/src/ext.rs
+++ b/chalk-solve/src/ext.rs
@@ -1,5 +1,5 @@
 use crate::infer::InferenceTable;
-use chalk_ir::fold::Fold;
+use chalk_ir::fold::TypeFoldable;
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
 
@@ -7,8 +7,8 @@ pub trait CanonicalExt<T: HasInterner, I: Interner> {
     fn map<OP, U>(self, interner: I, op: OP) -> Canonical<U::Result>
     where
         OP: FnOnce(T::Result) -> U,
-        T: Fold<I>,
-        U: Fold<I>,
+        T: TypeFoldable<I>,
+        U: TypeFoldable<I>,
         U::Result: HasInterner<Interner = I>;
 }
 
@@ -27,8 +27,8 @@ where
     fn map<OP, U>(self, interner: I, op: OP) -> Canonical<U::Result>
     where
         OP: FnOnce(T::Result) -> U,
-        T: Fold<I>,
-        U: Fold<I>,
+        T: TypeFoldable<I>,
+        U: TypeFoldable<I>,
         U::Result: HasInterner<Interner = I>,
     {
         // Subtle: It is only quite rarely correct to apply `op` and

--- a/chalk-solve/src/goal_builder.rs
+++ b/chalk-solve/src/goal_builder.rs
@@ -4,7 +4,7 @@ use chalk_ir::cast::Cast;
 use chalk_ir::cast::Caster;
 use chalk_ir::*;
 use fold::shift::Shift;
-use fold::Fold;
+use fold::TypeFoldable;
 use interner::{HasInterner, Interner};
 
 pub struct GoalBuilder<'i, I: Interner> {
@@ -80,7 +80,7 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
     ) -> Goal<I>
     where
         B: HasInterner<Interner = I>,
-        P: Fold<I>,
+        P: TypeFoldable<I>,
         G: CastTo<Goal<I>>,
     {
         self.quantified(QuantifierKind::ForAll, binders, passthru, body)
@@ -95,7 +95,7 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
     ) -> Goal<I>
     where
         B: HasInterner<Interner = I>,
-        P: Fold<I>,
+        P: TypeFoldable<I>,
         G: CastTo<Goal<I>>,
     {
         self.quantified(QuantifierKind::Exists, binders, passthru, body)
@@ -117,7 +117,7 @@ impl<'i, I: Interner> GoalBuilder<'i, I> {
     ) -> Goal<I>
     where
         B: HasInterner<Interner = I>,
-        P: Fold<I>,
+        P: TypeFoldable<I>,
         G: CastTo<Goal<I>>,
     {
         let interner = self.interner();

--- a/chalk-solve/src/infer.rs
+++ b/chalk-solve/src/infer.rs
@@ -1,6 +1,6 @@
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
-use chalk_ir::{cast::Cast, fold::Fold};
+use chalk_ir::{cast::Cast, fold::TypeFoldable};
 use tracing::debug;
 
 mod canonicalize;
@@ -52,7 +52,7 @@ impl<I: Interner> InferenceTable<I> {
         canonical: Canonical<T>,
     ) -> (Self, Substitution<I>, T)
     where
-        T: HasInterner<Interner = I> + Fold<I, Result = T> + Clone,
+        T: HasInterner<Interner = I> + TypeFoldable<I, Result = T> + Clone,
     {
         let mut table = InferenceTable::new();
 

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -1,6 +1,6 @@
 use crate::debug_span;
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{Folder, SuperFold, TypeFoldable};
+use chalk_ir::fold::{Folder, TypeFoldable, TypeSuperFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
 use std::cmp::max;

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -1,6 +1,6 @@
 use crate::debug_span;
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{Fold, Folder, SuperFold};
+use chalk_ir::fold::{Folder, SuperFold, TypeFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
 use std::cmp::max;
@@ -29,7 +29,7 @@ impl<I: Interner> InferenceTable<I> {
     /// also returned.
     pub fn canonicalize<T>(&mut self, interner: I, value: T) -> Canonicalized<T::Result>
     where
-        T: Fold<I>,
+        T: TypeFoldable<I>,
         T::Result: HasInterner<Interner = I>,
     {
         debug_span!("canonicalize", "{:#?}", value);

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -1,6 +1,6 @@
 use crate::debug_span;
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{Folder, TypeFoldable, TypeSuperFoldable};
+use chalk_ir::fold::{TypeFoldable, TypeFolder, TypeSuperFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
 use std::cmp::max;
@@ -101,10 +101,10 @@ impl<'q, I: Interner> Canonicalizer<'q, I> {
     }
 }
 
-impl<'i, I: Interner> Folder<I> for Canonicalizer<'i, I> {
+impl<'i, I: Interner> TypeFolder<I> for Canonicalizer<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/instantiate.rs
+++ b/chalk-solve/src/infer/instantiate.rs
@@ -28,7 +28,7 @@ impl<I: Interner> InferenceTable<I> {
     /// Variant on `instantiate` that takes a `Canonical<T>`.
     pub fn instantiate_canonical<T>(&mut self, interner: I, bound: Canonical<T>) -> T::Result
     where
-        T: HasInterner<Interner = I> + Fold<I> + Debug,
+        T: HasInterner<Interner = I> + TypeFoldable<I> + Debug,
     {
         let subst = self.fresh_subst(interner, bound.binders.as_slice(interner));
         subst.apply(bound.value, interner)
@@ -47,7 +47,7 @@ impl<I: Interner> InferenceTable<I> {
         arg: T,
     ) -> T::Result
     where
-        T: Fold<I>,
+        T: TypeFoldable<I>,
     {
         let binders: Vec<_> = binders
             .map(|pk| CanonicalVarKind::new(pk, universe))
@@ -64,7 +64,7 @@ impl<I: Interner> InferenceTable<I> {
         arg: Binders<T>,
     ) -> T::Result
     where
-        T: Fold<I> + HasInterner<Interner = I>,
+        T: TypeFoldable<I> + HasInterner<Interner = I>,
     {
         let (value, binders) = arg.into_value_and_skipped_binders();
 
@@ -80,7 +80,7 @@ impl<I: Interner> InferenceTable<I> {
     #[instrument(level = "debug", skip(self, interner))]
     pub fn instantiate_binders_universally<T>(&mut self, interner: I, arg: Binders<T>) -> T::Result
     where
-        T: Fold<I> + HasInterner<Interner = I>,
+        T: TypeFoldable<I> + HasInterner<Interner = I>,
     {
         let (value, binders) = arg.into_value_and_skipped_binders();
 

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -1,5 +1,5 @@
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{Fold, Folder};
+use chalk_ir::fold::{Folder, TypeFoldable};
 use chalk_ir::interner::HasInterner;
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
@@ -73,7 +73,7 @@ impl<I: Interner> InferenceTable<I> {
     /// `None`) until the second unification has occurred.)
     pub fn invert<T>(&mut self, interner: I, value: T) -> Option<T::Result>
     where
-        T: Fold<I, Result = T> + HasInterner<Interner = I>,
+        T: TypeFoldable<I, Result = T> + HasInterner<Interner = I>,
     {
         let Canonicalized {
             free_vars,
@@ -103,7 +103,7 @@ impl<I: Interner> InferenceTable<I> {
         value: T,
     ) -> Option<Canonical<T::Result>>
     where
-        T: Fold<I, Result = T> + HasInterner<Interner = I>,
+        T: TypeFoldable<I, Result = T> + HasInterner<Interner = I>,
     {
         let snapshot = self.snapshot();
         let result = self.invert(interner, value);

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -1,5 +1,5 @@
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{Folder, TypeFoldable};
+use chalk_ir::fold::{TypeFoldable, TypeFolder};
 use chalk_ir::interner::HasInterner;
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
@@ -131,10 +131,10 @@ impl<'q, I: Interner> Inverter<'q, I> {
     }
 }
 
-impl<'i, I: Interner> Folder<I> for Inverter<'i, I> {
+impl<'i, I: Interner> TypeFolder<I> for Inverter<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,7 +1,7 @@
 use crate::debug_span;
 use chalk_ir::fold::{TypeFoldable, TypeFolder};
 use chalk_ir::interner::{HasInterner, Interner};
-use chalk_ir::visit::{TypeVisitable, Visitor};
+use chalk_ir::visit::{TypeVisitable, TypeVisitor};
 use chalk_ir::*;
 use std::ops::ControlFlow;
 
@@ -200,10 +200,10 @@ struct UCollector<'q, I> {
     interner: I,
 }
 
-impl<I: Interner> Visitor<I> for UCollector<'_, I> {
+impl<I: Interner> TypeVisitor<I> for UCollector<'_, I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn TypeVisitor<I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,7 +1,7 @@
 use crate::debug_span;
 use chalk_ir::fold::{Folder, TypeFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
-use chalk_ir::visit::{Visit, Visitor};
+use chalk_ir::visit::{TypeVisitable, Visitor};
 use chalk_ir::*;
 use std::ops::ControlFlow;
 
@@ -10,7 +10,7 @@ use super::InferenceTable;
 impl<I: Interner> InferenceTable<I> {
     pub fn u_canonicalize<T>(interner: I, value0: &Canonical<T>) -> UCanonicalized<T::Result>
     where
-        T: Clone + HasInterner<Interner = I> + TypeFoldable<I> + Visit<I>,
+        T: Clone + HasInterner<Interner = I> + TypeFoldable<I> + TypeVisitable<I>,
         T::Result: HasInterner<Interner = I>,
     {
         debug_span!("u_canonicalize", "{:#?}", value0);

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,5 +1,5 @@
 use crate::debug_span;
-use chalk_ir::fold::{Fold, Folder};
+use chalk_ir::fold::{Folder, TypeFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::{Visit, Visitor};
 use chalk_ir::*;
@@ -10,7 +10,7 @@ use super::InferenceTable;
 impl<I: Interner> InferenceTable<I> {
     pub fn u_canonicalize<T>(interner: I, value0: &Canonical<T>) -> UCanonicalized<T::Result>
     where
-        T: Clone + HasInterner<Interner = I> + Fold<I> + Visit<I>,
+        T: Clone + HasInterner<Interner = I> + TypeFoldable<I> + Visit<I>,
         T::Result: HasInterner<Interner = I>,
     {
         debug_span!("u_canonicalize", "{:#?}", value0);
@@ -84,7 +84,7 @@ pub trait UniverseMapExt {
         canonical_value: &Canonical<T>,
     ) -> Canonical<T::Result>
     where
-        T: Clone + Fold<I> + HasInterner<Interner = I>,
+        T: Clone + TypeFoldable<I> + HasInterner<Interner = I>,
         T::Result: HasInterner<Interner = I>,
         I: Interner;
 }
@@ -163,7 +163,7 @@ impl UniverseMapExt for UniverseMap {
         canonical_value: &Canonical<T>,
     ) -> Canonical<T::Result>
     where
-        T: Clone + Fold<I> + HasInterner<Interner = I>,
+        T: Clone + TypeFoldable<I> + HasInterner<Interner = I>,
         T::Result: HasInterner<Interner = I>,
         I: Interner,
     {

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,5 +1,5 @@
 use crate::debug_span;
-use chalk_ir::fold::{Folder, TypeFoldable};
+use chalk_ir::fold::{TypeFoldable, TypeFolder};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::{TypeVisitable, Visitor};
 use chalk_ir::*;
@@ -230,10 +230,10 @@ struct UMapToCanonical<'q, I> {
     universes: &'q UniverseMap,
 }
 
-impl<'i, I: Interner> Folder<I> for UMapToCanonical<'i, I> {
+impl<'i, I: Interner> TypeFolder<I> for UMapToCanonical<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 
@@ -302,10 +302,10 @@ struct UMapFromCanonical<'q, I> {
     universes: &'q UniverseMap,
 }
 
-impl<'i, I: Interner> Folder<I> for UMapFromCanonical<'i, I> {
+impl<'i, I: Interner> TypeFolder<I> for UMapFromCanonical<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -2,7 +2,7 @@ use super::var::*;
 use super::*;
 use crate::debug_span;
 use chalk_ir::cast::Cast;
-use chalk_ir::fold::{Fold, Folder};
+use chalk_ir::fold::{Folder, TypeFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::zip::{Zip, Zipper};
 use chalk_ir::UnificationDatabase;
@@ -397,8 +397,8 @@ impl<'t, I: Interner> Unifier<'t, I> {
         b: &Binders<T>,
     ) -> Fallible<()>
     where
-        T: Clone + Fold<I, Result = R> + HasInterner<Interner = I>,
-        R: Zip<I> + Fold<I, Result = R>,
+        T: Clone + TypeFoldable<I, Result = R> + HasInterner<Interner = I>,
+        R: Zip<I> + TypeFoldable<I, Result = R>,
         't: 'a,
     {
         // for<'a...> T == for<'b...> U
@@ -1202,7 +1202,7 @@ impl<'i, I: Interner> Zipper<I> for Unifier<'i, I> {
 
     fn zip_binders<T>(&mut self, variance: Variance, a: &Binders<T>, b: &Binders<T>) -> Fallible<()>
     where
-        T: Clone + HasInterner<Interner = I> + Zip<I> + Fold<I, Result = T>,
+        T: Clone + HasInterner<Interner = I> + Zip<I> + TypeFoldable<I, Result = T>,
     {
         // The binders that appear in types (apart from quantified types, which are
         // handled in `unify_ty`) appear as part of `dyn Trait` and `impl Trait` types.

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -2,7 +2,7 @@ use super::var::*;
 use super::*;
 use crate::debug_span;
 use chalk_ir::cast::Cast;
-use chalk_ir::fold::{Folder, TypeFoldable};
+use chalk_ir::fold::{TypeFoldable, TypeFolder};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::zip::{Zip, Zipper};
 use chalk_ir::UnificationDatabase;
@@ -1247,10 +1247,10 @@ impl<'u, 't, I: Interner> OccursCheck<'u, 't, I> {
     }
 }
 
-impl<'i, I: Interner> Folder<I> for OccursCheck<'_, 'i, I> {
+impl<'i, I: Interner> TypeFolder<I> for OccursCheck<'_, 'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn Folder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -3,7 +3,7 @@ use crate::RustIrDatabase;
 use chalk_ir::{
     interner::Interner,
     visit::Visitor,
-    visit::{SuperVisit, TypeVisitable},
+    visit::{TypeSuperVisitable, TypeVisitable},
     AliasTy, DebruijnIndex, TyKind, WhereClause,
 };
 use std::ops::ControlFlow;

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -3,7 +3,7 @@ use crate::RustIrDatabase;
 use chalk_ir::{
     interner::Interner,
     visit::Visitor,
-    visit::{SuperVisit, Visit},
+    visit::{SuperVisit, TypeVisitable},
     AliasTy, DebruijnIndex, TyKind, WhereClause,
 };
 use std::ops::ControlFlow;

--- a/chalk-solve/src/logging_db/id_collector.rs
+++ b/chalk-solve/src/logging_db/id_collector.rs
@@ -2,7 +2,7 @@ use super::RecordedItemId;
 use crate::RustIrDatabase;
 use chalk_ir::{
     interner::Interner,
-    visit::Visitor,
+    visit::TypeVisitor,
     visit::{TypeSuperVisitable, TypeVisitable},
     AliasTy, DebruijnIndex, TyKind, WhereClause,
 };
@@ -116,10 +116,10 @@ impl<'i, I: Interner, DB: RustIrDatabase<I>> IdCollector<'i, I, DB> {
     }
 }
 
-impl<'i, I: Interner, DB: RustIrDatabase<I>> Visitor<I> for IdCollector<'i, I, DB> {
+impl<'i, I: Interner, DB: RustIrDatabase<I>> TypeVisitor<I> for IdCollector<'i, I, DB> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn TypeVisitor<I, BreakTy = Self::BreakTy> {
         self
     }
     fn interner(&self) -> I {

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -2,7 +2,7 @@
 //! version of the AST, roughly corresponding to [the HIR] in the Rust
 //! compiler.
 
-use chalk_derive::{Fold, HasInterner, Visit};
+use chalk_derive::{HasInterner, TypeFoldable, Visit};
 use chalk_ir::cast::Cast;
 use chalk_ir::fold::shift::Shift;
 use chalk_ir::interner::Interner;
@@ -52,7 +52,7 @@ impl<I: Interner> ImplDatum<I> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, HasInterner, Fold, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, HasInterner, TypeFoldable, Visit)]
 pub struct ImplDatumBound<I: Interner> {
     pub trait_ref: TraitRef<I>,
     pub where_clauses: Vec<QuantifiedWhereClause<I>>,
@@ -94,13 +94,13 @@ pub enum AdtKind {
 
 chalk_ir::const_visit!(AdtKind);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, HasInterner, Visit)]
 pub struct AdtDatumBound<I: Interner> {
     pub variants: Vec<AdtVariantDatum<I>>,
     pub where_clauses: Vec<QuantifiedWhereClause<I>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, HasInterner, Visit)]
 pub struct AdtVariantDatum<I: Interner> {
     pub fields: Vec<Ty<I>>,
 }
@@ -170,7 +170,7 @@ impl<I: Interner> Visit<I> for FnDefDatum<I> {
 
 /// Represents the inputs and outputs on a `FnDefDatum`. This is split
 /// from the where clauses, since these can contain bound lifetimes.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, HasInterner, Visit)]
 pub struct FnDefInputsAndOutputDatum<I: Interner> {
     /// Types of the function's arguments
     /// ```ignore
@@ -187,7 +187,7 @@ pub struct FnDefInputsAndOutputDatum<I: Interner> {
     pub return_type: Ty<I>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, HasInterner, Visit)]
 /// Represents the bounds on a `FnDefDatum`, including
 /// the function definition's type signature and where clauses.
 pub struct FnDefDatumBound<I: Interner> {
@@ -351,7 +351,7 @@ pub struct TraitFlags {
 chalk_ir::const_visit!(TraitFlags);
 
 /// An inline bound, e.g. `: Foo<K>` in `impl<K, T: Foo<K>> SomeType<T>`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, Visit, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
 pub enum InlineBound<I: Interner> {
     TraitBound(TraitBound<I>),
     AliasEqBound(AliasEqBound<I>),
@@ -395,7 +395,7 @@ impl<I: Interner> IntoWhereClauses<I> for QuantifiedInlineBound<I> {
 
 /// Represents a trait bound on e.g. a type or type parameter.
 /// Does not know anything about what it's binding.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit)]
 pub struct TraitBound<I: Interner> {
     pub trait_id: TraitId<I>,
     pub args_no_self: Vec<GenericArg<I>>,
@@ -420,7 +420,7 @@ impl<I: Interner> TraitBound<I> {
 
 /// Represents an alias equality bound on e.g. a type or type parameter.
 /// Does not know anything about what it's binding.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit)]
 pub struct AliasEqBound<I: Interner> {
     pub trait_bound: TraitBound<I>,
     pub associated_ty_id: AssocTypeId<I>,
@@ -518,7 +518,7 @@ impl<I: Interner> Visit<I> for AssociatedTyDatum<I> {
 
 /// Encodes the parts of `AssociatedTyDatum` where the parameters
 /// `P0..Pm` are in scope (`bounds` and `where_clauses`).
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, Visit, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
 pub struct AssociatedTyDatumBound<I: Interner> {
     /// Bounds on the associated type itself.
     ///
@@ -580,7 +580,7 @@ impl<I: Interner> AssociatedTyDatum<I> {
 ///     type Item = XXX; // <-- represents this line!
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit)]
 pub struct AssociatedTyValue<I: Interner> {
     /// Impl in which this associated type value is found.  You might
     /// need to look at this to find the generic parameters defined on
@@ -619,7 +619,7 @@ pub struct AssociatedTyValue<I: Interner> {
     pub value: Binders<AssociatedTyValueBound<I>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, Visit, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit, HasInterner)]
 pub struct AssociatedTyValueBound<I: Interner> {
     /// Type that we normalize to. The X in `type Foo<'a> = X`.
     pub ty: Ty<I>,
@@ -630,7 +630,7 @@ pub struct AssociatedTyValueBound<I: Interner> {
 /// ```ignore
 /// opaque type T: A + B = HiddenTy;
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, Visit)]
 pub struct OpaqueTyDatum<I: Interner> {
     /// The placeholder `!T` that corresponds to the opaque type `T`.
     pub opaque_ty_id: OpaqueTyId<I>,
@@ -639,7 +639,7 @@ pub struct OpaqueTyDatum<I: Interner> {
     pub bound: Binders<OpaqueTyDatumBound<I>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, HasInterner, Visit)]
 pub struct OpaqueTyDatumBound<I: Interner> {
     /// Trait bounds for the opaque type. These are bounds that the hidden type must meet.
     pub bounds: Binders<Vec<QuantifiedWhereClause<I>>>,
@@ -659,7 +659,7 @@ pub enum Movability {
 chalk_ir::copy_fold!(Movability);
 
 /// Represents a generator type.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, HasInterner)]
 pub struct GeneratorDatum<I: Interner> {
     // Can the generator be moved (is Unpin or not)
     pub movability: Movability,
@@ -670,7 +670,7 @@ pub struct GeneratorDatum<I: Interner> {
 }
 
 /// The nested types for a generator. This always appears inside a `GeneratorDatum`
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, HasInterner)]
 pub struct GeneratorInputOutputDatum<I: Interner> {
     /// The generator resume type - a value of this type
     /// is supplied by the caller when resuming the generator.
@@ -698,7 +698,7 @@ pub struct GeneratorInputOutputDatum<I: Interner> {
 /// `GeneratorWitnessDatum` is logically 'inside' a generator - this only
 /// matters when we treat the witness type as a 'constituent type for the
 /// purposes of determining auto trait implementations.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, HasInterner)]
 pub struct GeneratorWitnessDatum<I: Interner> {
     /// This binder is identical to the `input_output` binder in `GeneratorWitness` -
     /// it binds the types and lifetimes that the generator is generic over.
@@ -717,7 +717,7 @@ pub struct GeneratorWitnessDatum<I: Interner> {
 /// Unlike the binder in `GeneratorWitnessDatum`, this `Binder` never gets substituted
 /// via an `Ty`. Instead, we handle this `Binders` specially when determining
 /// auto trait impls. See `push_auto_trait_impls_generator_witness` for more details.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Fold, HasInterner)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, HasInterner)]
 pub struct GeneratorWitnessExistential<I: Interner> {
     pub types: Binders<Vec<Ty<I>>>,
 }

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -160,7 +160,7 @@ pub struct FnDefDatum<I: Interner> {
 impl<I: Interner> TypeVisitable<I> for FnDefDatum<I> {
     fn visit_with<B>(
         &self,
-        visitor: &mut dyn chalk_ir::visit::Visitor<I, BreakTy = B>,
+        visitor: &mut dyn chalk_ir::visit::TypeVisitor<I, BreakTy = B>,
         outer_binder: DebruijnIndex,
     ) -> ControlFlow<B> {
         try_break!(self.id.visit_with(visitor, outer_binder));
@@ -507,7 +507,7 @@ pub struct AssociatedTyDatum<I: Interner> {
 impl<I: Interner> TypeVisitable<I> for AssociatedTyDatum<I> {
     fn visit_with<B>(
         &self,
-        visitor: &mut dyn chalk_ir::visit::Visitor<I, BreakTy = B>,
+        visitor: &mut dyn chalk_ir::visit::TypeVisitor<I, BreakTy = B>,
         outer_binder: DebruijnIndex,
     ) -> ControlFlow<B> {
         try_break!(self.trait_id.visit_with(visitor, outer_binder));

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -2,7 +2,7 @@
 
 use crate::infer::InferenceTable;
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::{TypeSuperVisitable, TypeVisitable, Visitor};
+use chalk_ir::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitor};
 use chalk_ir::*;
 use std::cmp::max;
 use std::ops::ControlFlow;
@@ -51,10 +51,10 @@ impl<'infer, I: Interner> TySizeVisitor<'infer, I> {
     }
 }
 
-impl<'infer, I: Interner> Visitor<I> for TySizeVisitor<'infer, I> {
+impl<'infer, I: Interner> TypeVisitor<I> for TySizeVisitor<'infer, I> {
     type BreakTy = ();
 
-    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn TypeVisitor<I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -2,7 +2,7 @@
 
 use crate::infer::InferenceTable;
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::{SuperVisit, TypeVisitable, Visitor};
+use chalk_ir::visit::{TypeSuperVisitable, TypeVisitable, Visitor};
 use chalk_ir::*;
 use std::cmp::max;
 use std::ops::ControlFlow;

--- a/chalk-solve/src/solve/truncate.rs
+++ b/chalk-solve/src/solve/truncate.rs
@@ -2,7 +2,7 @@
 
 use crate::infer::InferenceTable;
 use chalk_ir::interner::Interner;
-use chalk_ir::visit::{SuperVisit, Visit, Visitor};
+use chalk_ir::visit::{SuperVisit, TypeVisitable, Visitor};
 use chalk_ir::*;
 use std::cmp::max;
 use std::ops::ControlFlow;
@@ -23,7 +23,7 @@ pub fn needs_truncation<I: Interner>(
     interner: I,
     infer: &mut InferenceTable<I>,
     max_size: usize,
-    value: impl Visit<I>,
+    value: impl TypeVisitable<I>,
 ) -> bool {
     let mut visitor = TySizeVisitor::new(interner, infer);
     value.visit_with(&mut visitor, DebruijnIndex::INNERMOST);

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -8,7 +8,7 @@ use chalk_ir::{
     cast::*,
     fold::shift::Shift,
     interner::Interner,
-    visit::{TypeVisitable, Visitor},
+    visit::{TypeVisitable, TypeVisitor},
     *,
 };
 use tracing::debug;
@@ -69,9 +69,9 @@ impl<I: Interner> InputTypeCollector<I> {
     }
 }
 
-impl<I: Interner> Visitor<I> for InputTypeCollector<I> {
+impl<I: Interner> TypeVisitor<I> for InputTypeCollector<I> {
     type BreakTy = ();
-    fn as_dyn(&mut self) -> &mut dyn Visitor<I, BreakTy = Self::BreakTy> {
+    fn as_dyn(&mut self) -> &mut dyn TypeVisitor<I, BreakTy = Self::BreakTy> {
         self
     }
 

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -8,7 +8,7 @@ use chalk_ir::{
     cast::*,
     fold::shift::Shift,
     interner::Interner,
-    visit::{Visit, Visitor},
+    visit::{TypeVisitable, Visitor},
     *,
 };
 use tracing::debug;
@@ -62,7 +62,7 @@ impl<I: Interner> InputTypeCollector<I> {
         }
     }
 
-    fn types_in(interner: I, value: impl Visit<I>) -> Vec<Ty<I>> {
+    fn types_in(interner: I, value: impl TypeVisitable<I>) -> Vec<Ty<I>> {
         let mut collector = Self::new(interner);
         value.visit_with(&mut collector, DebruijnIndex::INNERMOST);
         collector.types

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -571,9 +571,9 @@ fn compute_assoc_ty_goal<I: Interner>(
             let interner = gb.interner();
             let db = gb.db();
 
-            // Hmm, because `Arc<AssociatedTyValue>` does not implement `Fold`, we can't pass this value through,
+            // Hmm, because `Arc<AssociatedTyValue>` does not implement `TypeFoldable`, we can't pass this value through,
             // just the id, so we have to fetch `assoc_ty` from the database again.
-            // Implementing `Fold` for `AssociatedTyValue` doesn't *quite* seem right though, as that
+            // Implementing `TypeFoldable` for `AssociatedTyValue` doesn't *quite* seem right though, as that
             // would result in a deep clone, and the value is inert. We could do some more refatoring
             // (move the `Arc` behind a newtype, for example) to fix this, but for now doesn't
             // seem worth it.


### PR DESCRIPTION
Align the names of chalk's folding/visiting traits with those in rustc (especially once rust-lang/rust#98206) is merged.

r? @jackh726