### PR TITLE
Detect dark theme for mermaid diagrams

### DIFF
--- a/book/mermaid-init.js
+++ b/book/mermaid-init.js
@@ -1,1 +1,4 @@
-mermaid.initialize({startOnLoad:true});
+mermaid.initialize({
+    startOnLoad: true,
+    theme: ['coal', 'navy', 'ayu'].includes(theme) ? 'dark' : 'default',
+});


### PR DESCRIPTION
Fixes #761 for the case where you've set your theme beforehand.
Changing the theme doesn't change the diagrams until you refresh, I tried adding an event listener to the theme switch but `mermaid.initialize()` doesn't update the diagrams when called twice.