### PR TITLE
Split fallible infallible folding

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -117,6 +117,7 @@ enum DeriveKind {
     FromInterner,
 }
 
+decl_derive!([FallibleTypeFolder, attributes(has_interner)] => derive_fallible_type_folder);
 decl_derive!([HasInterner, attributes(has_interner)] => derive_has_interner);
 decl_derive!([TypeVisitable, attributes(has_interner)] => derive_type_visitable);
 decl_derive!([TypeSuperVisitable, attributes(has_interner)] => derive_type_super_visitable);
@@ -291,6 +292,153 @@ fn derive_type_foldable(mut s: synstructure::Structure) -> TokenStream {
                 outer_binder: ::chalk_ir::DebruijnIndex,
             ) -> ::std::result::Result<Self, E> {
                 Ok(match self { #body })
+            }
+        },
+    )
+}
+
+fn derive_fallible_type_folder(mut s: synstructure::Structure) -> TokenStream {
+    let (interner, _) = find_interner(&mut s);
+    s.underscore_const(true);
+    s.unbound_impl(
+        quote!(::chalk_ir::fold::FallibleTypeFolder<#interner>),
+        quote! {
+            type Error = ::core::convert::Infallible;
+
+            fn as_dyn(&mut self) -> &mut dyn ::chalk_ir::fold::FallibleTypeFolder<I, Error = Self::Error> {
+                self
+            }
+
+            fn try_fold_ty(
+                &mut self,
+                ty: ::chalk_ir::Ty<#interner>,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Ty<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_ty(self, ty, outer_binder))
+            }
+
+            fn try_fold_lifetime(
+                &mut self,
+                lifetime: ::chalk_ir::Lifetime<#interner>,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Lifetime<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_lifetime(self, lifetime, outer_binder))
+            }
+
+            fn try_fold_const(
+                &mut self,
+                constant: ::chalk_ir::Const<#interner>,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Const<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_const(self, constant, outer_binder))
+            }
+
+            fn try_fold_program_clause(
+                &mut self,
+                clause: ::chalk_ir::ProgramClause<#interner>,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::ProgramClause<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_program_clause(self, clause, outer_binder))
+            }
+
+            fn try_fold_goal(
+                &mut self,
+                goal: ::chalk_ir::Goal<#interner>,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Goal<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_goal(self, goal, outer_binder))
+            }
+
+            fn forbid_free_vars(&self) -> bool {
+                ::chalk_ir::fold::TypeFolder::forbid_free_vars(self)
+            }
+
+            fn try_fold_free_var_ty(
+                &mut self,
+                bound_var: ::chalk_ir::BoundVar,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Ty<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_free_var_ty(self, bound_var, outer_binder))
+            }
+
+            fn try_fold_free_var_lifetime(
+                &mut self,
+                bound_var: ::chalk_ir::BoundVar,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Lifetime<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_free_var_lifetime(self, bound_var, outer_binder))
+            }
+
+            fn try_fold_free_var_const(
+                &mut self,
+                ty: ::chalk_ir::Ty<#interner>,
+                bound_var: ::chalk_ir::BoundVar,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Const<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_free_var_const(self, ty, bound_var, outer_binder))
+            }
+
+            fn forbid_free_placeholders(&self) -> bool {
+                ::chalk_ir::fold::TypeFolder::forbid_free_placeholders(self)
+            }
+
+            fn try_fold_free_placeholder_ty(
+                &mut self,
+                universe: ::chalk_ir::PlaceholderIndex,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Ty<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_free_placeholder_ty(self, universe, outer_binder))
+            }
+
+            fn try_fold_free_placeholder_lifetime(
+                &mut self,
+                universe: ::chalk_ir::PlaceholderIndex,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Lifetime<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_free_placeholder_lifetime(self, universe, outer_binder))
+            }
+
+            fn try_fold_free_placeholder_const(
+                &mut self,
+                ty: ::chalk_ir::Ty<#interner>,
+                universe: ::chalk_ir::PlaceholderIndex,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Const<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_free_placeholder_const(self, ty, universe, outer_binder))
+            }
+
+            fn forbid_inference_vars(&self) -> bool {
+                ::chalk_ir::fold::TypeFolder::forbid_inference_vars(self)
+            }
+
+            fn try_fold_inference_ty(
+                &mut self,
+                var: ::chalk_ir::InferenceVar,
+                kind: ::chalk_ir::TyVariableKind,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Ty<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_inference_ty(self, var, kind, outer_binder))
+            }
+
+            fn try_fold_inference_lifetime(
+                &mut self,
+                var: ::chalk_ir::InferenceVar,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Lifetime<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_inference_lifetime(self, var, outer_binder))
+            }
+
+            fn try_fold_inference_const(
+                &mut self,
+                ty: ::chalk_ir::Ty<#interner>,
+                var: ::chalk_ir::InferenceVar,
+                outer_binder: ::chalk_ir::DebruijnIndex,
+            ) -> ::core::result::Result<::chalk_ir::Const<#interner>, Self::Error> {
+                ::core::result::Result::Ok(::chalk_ir::fold::TypeFolder::fold_inference_const(self, ty, var, outer_binder))
+            }
+
+            fn interner(&self) -> #interner {
+                ::chalk_ir::fold::TypeFolder::interner(self)
             }
         },
     )

--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -287,7 +287,7 @@ fn derive_type_foldable(mut s: synstructure::Structure) -> TokenStream {
         quote! {
             fn fold_with<E>(
                 self,
-                folder: &mut dyn ::chalk_ir::fold::TypeFolder < #interner, Error = E >,
+                folder: &mut dyn ::chalk_ir::fold::FallibleTypeFolder < #interner, Error = E >,
                 outer_binder: ::chalk_ir::DebruijnIndex,
             ) -> ::std::result::Result<Self, E> {
                 Ok(match self { #body })

--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -269,7 +269,7 @@ fn derive_type_foldable(mut s: synstructure::Structure) -> TokenStream {
         vi.construct(|_, index| {
             let bind = &bindings[index];
             quote! {
-                ::chalk_ir::fold::TypeFoldable::fold_with(#bind, folder, outer_binder)?
+                ::chalk_ir::fold::TypeFoldable::try_fold_with(#bind, folder, outer_binder)?
             }
         })
     });
@@ -285,7 +285,7 @@ fn derive_type_foldable(mut s: synstructure::Structure) -> TokenStream {
     s.bound_impl(
         quote!(::chalk_ir::fold::TypeFoldable<#interner>),
         quote! {
-            fn fold_with<E>(
+            fn try_fold_with<E>(
                 self,
                 folder: &mut dyn ::chalk_ir::fold::FallibleTypeFolder < #interner, Error = E >,
                 outer_binder: ::chalk_ir::DebruijnIndex,

--- a/chalk-engine/src/normalize_deep.rs
+++ b/chalk-engine/src/normalize_deep.rs
@@ -27,7 +27,7 @@ impl<I: Interner> DeepNormalizer<'_, I> {
         value: T,
     ) -> T {
         value
-            .fold_with(
+            .try_fold_with(
                 &mut DeepNormalizer { interner, table },
                 DebruijnIndex::INNERMOST,
             )
@@ -42,7 +42,7 @@ impl<I: Interner> FallibleTypeFolder<I> for DeepNormalizer<'_, I> {
         self
     }
 
-    fn fold_inference_ty(
+    fn try_fold_inference_ty(
         &mut self,
         var: InferenceVar,
         kind: TyVariableKind,
@@ -53,7 +53,7 @@ impl<I: Interner> FallibleTypeFolder<I> for DeepNormalizer<'_, I> {
             Some(ty) => Ok(ty
                 .assert_ty_ref(interner)
                 .clone()
-                .fold_with(self, DebruijnIndex::INNERMOST)?
+                .try_fold_with(self, DebruijnIndex::INNERMOST)?
                 .shifted_in(interner)), // FIXME shift
             None => {
                 // Normalize all inference vars which have been unified into a
@@ -63,7 +63,7 @@ impl<I: Interner> FallibleTypeFolder<I> for DeepNormalizer<'_, I> {
         }
     }
 
-    fn fold_inference_lifetime(
+    fn try_fold_inference_lifetime(
         &mut self,
         var: InferenceVar,
         _outer_binder: DebruijnIndex,
@@ -73,13 +73,13 @@ impl<I: Interner> FallibleTypeFolder<I> for DeepNormalizer<'_, I> {
             Some(l) => Ok(l
                 .assert_lifetime_ref(interner)
                 .clone()
-                .fold_with(self, DebruijnIndex::INNERMOST)?
+                .try_fold_with(self, DebruijnIndex::INNERMOST)?
                 .shifted_in(interner)),
             None => Ok(var.to_lifetime(interner)), // FIXME shift
         }
     }
 
-    fn fold_inference_const(
+    fn try_fold_inference_const(
         &mut self,
         ty: Ty<I>,
         var: InferenceVar,
@@ -90,7 +90,7 @@ impl<I: Interner> FallibleTypeFolder<I> for DeepNormalizer<'_, I> {
             Some(c) => Ok(c
                 .assert_const_ref(interner)
                 .clone()
-                .fold_with(self, DebruijnIndex::INNERMOST)?
+                .try_fold_with(self, DebruijnIndex::INNERMOST)?
                 .shifted_in(interner)),
             None => Ok(var.to_const(interner, ty)), // FIXME shift
         }

--- a/chalk-engine/src/normalize_deep.rs
+++ b/chalk-engine/src/normalize_deep.rs
@@ -1,5 +1,5 @@
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{TypeFoldable, TypeFolder};
+use chalk_ir::fold::{FallibleTypeFolder, TypeFoldable};
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
 use chalk_solve::infer::InferenceTable;
@@ -35,10 +35,10 @@ impl<I: Interner> DeepNormalizer<'_, I> {
     }
 }
 
-impl<I: Interner> TypeFolder<I> for DeepNormalizer<'_, I> {
+impl<I: Interner> FallibleTypeFolder<I> for DeepNormalizer<'_, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -3,7 +3,7 @@ use crate::{ExClause, TableIndex, TimeStamp};
 use std::fmt::Debug;
 
 use chalk_derive::HasInterner;
-use chalk_ir::fold::{TypeFoldable, TypeFolder};
+use chalk_ir::fold::{FallibleTypeFolder, TypeFoldable};
 use chalk_ir::interner::Interner;
 use chalk_ir::{Canonical, DebruijnIndex, UniverseMap};
 
@@ -38,7 +38,7 @@ pub(crate) struct SelectedSubgoal {
 impl<I: Interner> TypeFoldable<I> for Strand<I> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         Ok(Strand {

--- a/chalk-engine/src/strand.rs
+++ b/chalk-engine/src/strand.rs
@@ -36,13 +36,13 @@ pub(crate) struct SelectedSubgoal {
 }
 
 impl<I: Interner> TypeFoldable<I> for Strand<I> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         Ok(Strand {
-            ex_clause: self.ex_clause.fold_with(folder, outer_binder)?,
+            ex_clause: self.ex_clause.try_fold_with(folder, outer_binder)?,
             last_pursued_time: self.last_pursued_time,
             selected_subgoal: self.selected_subgoal,
         })

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -6,7 +6,7 @@
 use crate::*;
 
 impl<I: Interner> TypeFoldable<I> for FnPointer<I> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
@@ -18,7 +18,7 @@ impl<I: Interner> TypeFoldable<I> for FnPointer<I> {
         } = self;
         Ok(FnPointer {
             num_binders,
-            substitution: substitution.fold_with(folder, outer_binder.shifted_in())?,
+            substitution: substitution.try_fold_with(folder, outer_binder.shifted_in())?,
             sig: FnSig {
                 abi: sig.abi,
                 safety: sig.safety,
@@ -33,7 +33,7 @@ where
     T: HasInterner<Interner = I> + TypeFoldable<I>,
     I: Interner,
 {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
@@ -42,7 +42,7 @@ where
             binders: self_binders,
             value: self_value,
         } = self;
-        let value = self_value.fold_with(folder, outer_binder.shifted_in())?;
+        let value = self_value.try_fold_with(folder, outer_binder.shifted_in())?;
         let binders = VariableKinds {
             interned: self_binders.interned().clone(),
         };
@@ -55,7 +55,7 @@ where
     I: Interner,
     T: HasInterner<Interner = I> + TypeFoldable<I>,
 {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
@@ -64,7 +64,7 @@ where
             binders: self_binders,
             value: self_value,
         } = self;
-        let value = self_value.fold_with(folder, outer_binder.shifted_in())?;
+        let value = self_value.try_fold_with(folder, outer_binder.shifted_in())?;
         let binders = CanonicalVarKinds {
             interned: self_binders.interned().clone(),
         };

--- a/chalk-ir/src/fold/binder_impls.rs
+++ b/chalk-ir/src/fold/binder_impls.rs
@@ -8,7 +8,7 @@ use crate::*;
 impl<I: Interner> TypeFoldable<I> for FnPointer<I> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         let FnPointer {
@@ -35,7 +35,7 @@ where
 {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         let Binders {
@@ -57,7 +57,7 @@ where
 {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         let Canonical {

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Vec<T> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         in_place::fallible_map_vec(self, |e| e.fold_with(folder, outer_binder))
@@ -21,7 +21,7 @@ impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Vec<T> {
 impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Box<T> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         in_place::fallible_map_box(self, |e| e.fold_with(folder, outer_binder))
@@ -31,7 +31,7 @@ impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Box<T> {
 macro_rules! tuple_fold {
     ($($n:ident),*) => {
         impl<$($n: TypeFoldable<I>,)* I: Interner> TypeFoldable<I> for ($($n,)*) {
-            fn fold_with<Error>(self, folder: &mut dyn TypeFolder<I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self, Error>
+            fn fold_with<Error>(self, folder: &mut dyn FallibleTypeFolder<I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self, Error>
             {
                 #[allow(non_snake_case)]
                 let ($($n),*) = self;
@@ -49,7 +49,7 @@ tuple_fold!(A, B, C, D, E);
 impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Option<T> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         match self {
@@ -62,7 +62,7 @@ impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Option<T> {
 impl<I: Interner> TypeFoldable<I> for GenericArg<I> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         let interner = folder.interner();
@@ -78,7 +78,7 @@ impl<I: Interner> TypeFoldable<I> for GenericArg<I> {
 impl<I: Interner> TypeFoldable<I> for Substitution<I> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         let interner = folder.interner();
@@ -94,7 +94,7 @@ impl<I: Interner> TypeFoldable<I> for Substitution<I> {
 impl<I: Interner> TypeFoldable<I> for Goals<I> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         let interner = folder.interner();
@@ -109,7 +109,7 @@ impl<I: Interner> TypeFoldable<I> for Goals<I> {
 impl<I: Interner> TypeFoldable<I> for ProgramClauses<I> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         let interner = folder.interner();
@@ -124,7 +124,7 @@ impl<I: Interner> TypeFoldable<I> for ProgramClauses<I> {
 impl<I: Interner> TypeFoldable<I> for QuantifiedWhereClauses<I> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         let interner = folder.interner();
@@ -139,7 +139,7 @@ impl<I: Interner> TypeFoldable<I> for QuantifiedWhereClauses<I> {
 impl<I: Interner> TypeFoldable<I> for Constraints<I> {
     fn fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         let interner = folder.interner();
@@ -158,7 +158,7 @@ macro_rules! copy_fold {
         impl<I: Interner> $crate::fold::TypeFoldable<I> for $t {
             fn fold_with<E>(
                 self,
-                _folder: &mut dyn ($crate::fold::TypeFolder<I, Error = E>),
+                _folder: &mut dyn ($crate::fold::FallibleTypeFolder<I, Error = E>),
                 _outer_binder: DebruijnIndex,
             ) -> ::std::result::Result<Self, E> {
                 Ok(self)
@@ -189,7 +189,7 @@ macro_rules! id_fold {
         impl<I: Interner> $crate::fold::TypeFoldable<I> for $t<I> {
             fn fold_with<E>(
                 self,
-                _folder: &mut dyn ($crate::fold::TypeFolder<I, Error = E>),
+                _folder: &mut dyn ($crate::fold::FallibleTypeFolder<I, Error = E>),
                 _outer_binder: DebruijnIndex,
             ) -> ::std::result::Result<Self, E> {
                 Ok(self)
@@ -211,7 +211,7 @@ id_fold!(ForeignDefId);
 impl<I: Interner> TypeSuperFoldable<I> for ProgramClauseData<I> {
     fn super_fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> ::std::result::Result<Self, E> {
         Ok(ProgramClauseData(self.0.fold_with(folder, outer_binder)?))
@@ -221,7 +221,7 @@ impl<I: Interner> TypeSuperFoldable<I> for ProgramClauseData<I> {
 impl<I: Interner> TypeSuperFoldable<I> for ProgramClause<I> {
     fn super_fold_with<E>(
         self,
-        folder: &mut dyn TypeFolder<I, Error = E>,
+        folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> ::std::result::Result<Self, E> {
         let clause = self.data(folder.interner()).clone();
@@ -234,7 +234,7 @@ impl<I: Interner> TypeSuperFoldable<I> for ProgramClause<I> {
 impl<I: Interner> TypeFoldable<I> for PhantomData<I> {
     fn fold_with<E>(
         self,
-        _folder: &mut dyn TypeFolder<I, Error = E>,
+        _folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         _outer_binder: DebruijnIndex,
     ) -> ::std::result::Result<Self, E> {
         Ok(PhantomData)

--- a/chalk-ir/src/fold/boring_impls.rs
+++ b/chalk-ir/src/fold/boring_impls.rs
@@ -9,33 +9,33 @@ use crate::*;
 use std::marker::PhantomData;
 
 impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Vec<T> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
-        in_place::fallible_map_vec(self, |e| e.fold_with(folder, outer_binder))
+        in_place::fallible_map_vec(self, |e| e.try_fold_with(folder, outer_binder))
     }
 }
 
 impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Box<T> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
-        in_place::fallible_map_box(self, |e| e.fold_with(folder, outer_binder))
+        in_place::fallible_map_box(self, |e| e.try_fold_with(folder, outer_binder))
     }
 }
 
 macro_rules! tuple_fold {
     ($($n:ident),*) => {
         impl<$($n: TypeFoldable<I>,)* I: Interner> TypeFoldable<I> for ($($n,)*) {
-            fn fold_with<Error>(self, folder: &mut dyn FallibleTypeFolder<I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self, Error>
+            fn try_fold_with<Error>(self, folder: &mut dyn FallibleTypeFolder<I, Error = Error>, outer_binder: DebruijnIndex) -> Result<Self, Error>
             {
                 #[allow(non_snake_case)]
                 let ($($n),*) = self;
-                Ok(($($n.fold_with(folder, outer_binder)?,)*))
+                Ok(($($n.try_fold_with(folder, outer_binder)?,)*))
             }
         }
     }
@@ -47,20 +47,20 @@ tuple_fold!(A, B, C, D);
 tuple_fold!(A, B, C, D, E);
 
 impl<T: TypeFoldable<I>, I: Interner> TypeFoldable<I> for Option<T> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> Result<Self, E> {
         match self {
             None => Ok(None),
-            Some(e) => Ok(Some(e.fold_with(folder, outer_binder)?)),
+            Some(e) => Ok(Some(e.try_fold_with(folder, outer_binder)?)),
         }
     }
 }
 
 impl<I: Interner> TypeFoldable<I> for GenericArg<I> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
@@ -70,13 +70,13 @@ impl<I: Interner> TypeFoldable<I> for GenericArg<I> {
         let data = self
             .data(interner)
             .clone()
-            .fold_with(folder, outer_binder)?;
+            .try_fold_with(folder, outer_binder)?;
         Ok(GenericArg::new(interner, data))
     }
 }
 
 impl<I: Interner> TypeFoldable<I> for Substitution<I> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
@@ -86,13 +86,13 @@ impl<I: Interner> TypeFoldable<I> for Substitution<I> {
         let folded = self
             .iter(interner)
             .cloned()
-            .map(|p| p.fold_with(folder, outer_binder));
+            .map(|p| p.try_fold_with(folder, outer_binder));
         Substitution::from_fallible(interner, folded)
     }
 }
 
 impl<I: Interner> TypeFoldable<I> for Goals<I> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
@@ -101,13 +101,13 @@ impl<I: Interner> TypeFoldable<I> for Goals<I> {
         let folded = self
             .iter(interner)
             .cloned()
-            .map(|p| p.fold_with(folder, outer_binder));
+            .map(|p| p.try_fold_with(folder, outer_binder));
         Goals::from_fallible(interner, folded)
     }
 }
 
 impl<I: Interner> TypeFoldable<I> for ProgramClauses<I> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
@@ -116,13 +116,13 @@ impl<I: Interner> TypeFoldable<I> for ProgramClauses<I> {
         let folded = self
             .iter(interner)
             .cloned()
-            .map(|p| p.fold_with(folder, outer_binder));
+            .map(|p| p.try_fold_with(folder, outer_binder));
         ProgramClauses::from_fallible(interner, folded)
     }
 }
 
 impl<I: Interner> TypeFoldable<I> for QuantifiedWhereClauses<I> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
@@ -131,13 +131,13 @@ impl<I: Interner> TypeFoldable<I> for QuantifiedWhereClauses<I> {
         let folded = self
             .iter(interner)
             .cloned()
-            .map(|p| p.fold_with(folder, outer_binder));
+            .map(|p| p.try_fold_with(folder, outer_binder));
         QuantifiedWhereClauses::from_fallible(interner, folded)
     }
 }
 
 impl<I: Interner> TypeFoldable<I> for Constraints<I> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
@@ -146,7 +146,7 @@ impl<I: Interner> TypeFoldable<I> for Constraints<I> {
         let folded = self
             .iter(interner)
             .cloned()
-            .map(|p| p.fold_with(folder, outer_binder));
+            .map(|p| p.try_fold_with(folder, outer_binder));
         Constraints::from_fallible(interner, folded)
     }
 }
@@ -156,7 +156,7 @@ impl<I: Interner> TypeFoldable<I> for Constraints<I> {
 macro_rules! copy_fold {
     ($t:ty) => {
         impl<I: Interner> $crate::fold::TypeFoldable<I> for $t {
-            fn fold_with<E>(
+            fn try_fold_with<E>(
                 self,
                 _folder: &mut dyn ($crate::fold::FallibleTypeFolder<I, Error = E>),
                 _outer_binder: DebruijnIndex,
@@ -187,7 +187,7 @@ copy_fold!(Safety);
 macro_rules! id_fold {
     ($t:ident) => {
         impl<I: Interner> $crate::fold::TypeFoldable<I> for $t<I> {
-            fn fold_with<E>(
+            fn try_fold_with<E>(
                 self,
                 _folder: &mut dyn ($crate::fold::FallibleTypeFolder<I, Error = E>),
                 _outer_binder: DebruijnIndex,
@@ -209,30 +209,32 @@ id_fold!(GeneratorId);
 id_fold!(ForeignDefId);
 
 impl<I: Interner> TypeSuperFoldable<I> for ProgramClauseData<I> {
-    fn super_fold_with<E>(
+    fn try_super_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> ::std::result::Result<Self, E> {
-        Ok(ProgramClauseData(self.0.fold_with(folder, outer_binder)?))
+        Ok(ProgramClauseData(
+            self.0.try_fold_with(folder, outer_binder)?,
+        ))
     }
 }
 
 impl<I: Interner> TypeSuperFoldable<I> for ProgramClause<I> {
-    fn super_fold_with<E>(
+    fn try_super_fold_with<E>(
         self,
         folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         outer_binder: DebruijnIndex,
     ) -> ::std::result::Result<Self, E> {
         let clause = self.data(folder.interner()).clone();
         Ok(clause
-            .super_fold_with(folder, outer_binder)?
+            .try_super_fold_with(folder, outer_binder)?
             .intern(folder.interner()))
     }
 }
 
 impl<I: Interner> TypeFoldable<I> for PhantomData<I> {
-    fn fold_with<E>(
+    fn try_fold_with<E>(
         self,
         _folder: &mut dyn FallibleTypeFolder<I, Error = E>,
         _outer_binder: DebruijnIndex,

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -29,7 +29,7 @@ impl<T: TypeFoldable<I>, I: Interner> Shift<I> for T {
     }
 
     fn shifted_in_from(self, interner: I, source_binder: DebruijnIndex) -> T {
-        self.fold_with(
+        self.try_fold_with(
             &mut Shifter {
                 source_binder,
                 interner,
@@ -40,7 +40,7 @@ impl<T: TypeFoldable<I>, I: Interner> Shift<I> for T {
     }
 
     fn shifted_out_to(self, interner: I, target_binder: DebruijnIndex) -> Fallible<T> {
-        self.fold_with(
+        self.try_fold_with(
             &mut DownShifter {
                 target_binder,
                 interner,
@@ -78,7 +78,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Shifter<I> {
         self
     }
 
-    fn fold_free_var_ty(
+    fn try_fold_free_var_ty(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
@@ -86,7 +86,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Shifter<I> {
         Ok(TyKind::<I>::BoundVar(self.adjust(bound_var, outer_binder)).intern(self.interner()))
     }
 
-    fn fold_free_var_lifetime(
+    fn try_fold_free_var_lifetime(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
@@ -97,7 +97,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Shifter<I> {
         )
     }
 
-    fn fold_free_var_const(
+    fn try_fold_free_var_const(
         &mut self,
         ty: Ty<I>,
         bound_var: BoundVar,
@@ -148,7 +148,7 @@ impl<I: Interner> FallibleTypeFolder<I> for DownShifter<I> {
         self
     }
 
-    fn fold_free_var_ty(
+    fn try_fold_free_var_ty(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
@@ -156,7 +156,7 @@ impl<I: Interner> FallibleTypeFolder<I> for DownShifter<I> {
         Ok(TyKind::<I>::BoundVar(self.adjust(bound_var, outer_binder)?).intern(self.interner()))
     }
 
-    fn fold_free_var_lifetime(
+    fn try_fold_free_var_lifetime(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
@@ -167,7 +167,7 @@ impl<I: Interner> FallibleTypeFolder<I> for DownShifter<I> {
         )
     }
 
-    fn fold_free_var_const(
+    fn try_fold_free_var_const(
         &mut self,
         ty: Ty<I>,
         bound_var: BoundVar,

--- a/chalk-ir/src/fold/shift.rs
+++ b/chalk-ir/src/fold/shift.rs
@@ -71,10 +71,10 @@ impl<I> Shifter<I> {
     }
 }
 
-impl<I: Interner> TypeFolder<I> for Shifter<I> {
+impl<I: Interner> FallibleTypeFolder<I> for Shifter<I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 
@@ -141,10 +141,10 @@ impl<I> DownShifter<I> {
     }
 }
 
-impl<I: Interner> TypeFolder<I> for DownShifter<I> {
+impl<I: Interner> FallibleTypeFolder<I> for DownShifter<I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -14,7 +14,7 @@ impl<I: Interner> Subst<'_, I> {
     /// Applies the substitution by folding
     pub fn apply<T: TypeFoldable<I>>(interner: I, parameters: &[GenericArg<I>], value: T) -> T {
         value
-            .fold_with(
+            .try_fold_with(
                 &mut Subst {
                     parameters,
                     interner,
@@ -51,7 +51,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Subst<'_, I> {
     /// for<A, B> { [A, u32] }
     ///              ^ represented as `^0.0`
     /// ```
-    fn fold_free_var_ty(
+    fn try_fold_free_var_ty(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
@@ -73,7 +73,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Subst<'_, I> {
     }
 
     /// see `fold_free_var_ty`
-    fn fold_free_var_lifetime(
+    fn try_fold_free_var_lifetime(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
@@ -95,7 +95,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Subst<'_, I> {
     }
 
     /// see `fold_free_var_ty`
-    fn fold_free_var_const(
+    fn try_fold_free_var_const(
         &mut self,
         ty: Ty<I>,
         bound_var: BoundVar,

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::fold::shift::Shift;
 
 /// Substitution used during folding
+#[derive(FallibleTypeFolder)]
 pub struct Subst<'s, I: Interner> {
     /// Values to substitute. A reference to a free variable with
     /// index `i` will be mapped to `parameters[i]` -- if `i >
@@ -25,10 +26,8 @@ impl<I: Interner> Subst<'_, I> {
     }
 }
 
-impl<I: Interner> FallibleTypeFolder<I> for Subst<'_, I> {
-    type Error = NoSolution;
-
-    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
+impl<I: Interner> TypeFolder<I> for Subst<'_, I> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I> {
         self
     }
 
@@ -51,69 +50,65 @@ impl<I: Interner> FallibleTypeFolder<I> for Subst<'_, I> {
     /// for<A, B> { [A, u32] }
     ///              ^ represented as `^0.0`
     /// ```
-    fn try_fold_free_var_ty(
-        &mut self,
-        bound_var: BoundVar,
-        outer_binder: DebruijnIndex,
-    ) -> Fallible<Ty<I>> {
+    fn fold_free_var_ty(&mut self, bound_var: BoundVar, outer_binder: DebruijnIndex) -> Ty<I> {
         if let Some(index) = bound_var.index_if_innermost() {
-            match self.parameters[index].data(self.interner()) {
-                GenericArgData::Ty(t) => {
-                    Ok(t.clone().shifted_in_from(self.interner(), outer_binder))
-                }
+            match self.parameters[index].data(TypeFolder::interner(self)) {
+                GenericArgData::Ty(t) => t
+                    .clone()
+                    .shifted_in_from(TypeFolder::interner(self), outer_binder),
                 _ => panic!("mismatched kinds in substitution"),
             }
         } else {
-            Ok(bound_var
+            bound_var
                 .shifted_out()
                 .expect("cannot fail because this is not the innermost")
                 .shifted_in_from(outer_binder)
-                .to_ty(self.interner()))
+                .to_ty(TypeFolder::interner(self))
         }
     }
 
     /// see `fold_free_var_ty`
-    fn try_fold_free_var_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Lifetime<I>> {
+    ) -> Lifetime<I> {
         if let Some(index) = bound_var.index_if_innermost() {
-            match self.parameters[index].data(self.interner()) {
-                GenericArgData::Lifetime(l) => {
-                    Ok(l.clone().shifted_in_from(self.interner(), outer_binder))
-                }
+            match self.parameters[index].data(TypeFolder::interner(self)) {
+                GenericArgData::Lifetime(l) => l
+                    .clone()
+                    .shifted_in_from(TypeFolder::interner(self), outer_binder),
                 _ => panic!("mismatched kinds in substitution"),
             }
         } else {
-            Ok(bound_var
+            bound_var
                 .shifted_out()
                 .unwrap()
                 .shifted_in_from(outer_binder)
-                .to_lifetime(self.interner()))
+                .to_lifetime(TypeFolder::interner(self))
         }
     }
 
     /// see `fold_free_var_ty`
-    fn try_fold_free_var_const(
+    fn fold_free_var_const(
         &mut self,
         ty: Ty<I>,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Const<I>> {
+    ) -> Const<I> {
         if let Some(index) = bound_var.index_if_innermost() {
-            match self.parameters[index].data(self.interner()) {
-                GenericArgData::Const(c) => {
-                    Ok(c.clone().shifted_in_from(self.interner(), outer_binder))
-                }
+            match self.parameters[index].data(TypeFolder::interner(self)) {
+                GenericArgData::Const(c) => c
+                    .clone()
+                    .shifted_in_from(TypeFolder::interner(self), outer_binder),
                 _ => panic!("mismatched kinds in substitution"),
             }
         } else {
-            Ok(bound_var
+            bound_var
                 .shifted_out()
                 .unwrap()
                 .shifted_in_from(outer_binder)
-                .to_const(self.interner(), ty))
+                .to_const(TypeFolder::interner(self), ty)
         }
     }
 

--- a/chalk-ir/src/fold/subst.rs
+++ b/chalk-ir/src/fold/subst.rs
@@ -25,10 +25,10 @@ impl<I: Interner> Subst<'_, I> {
     }
 }
 
-impl<I: Interner> TypeFolder<I> for Subst<'_, I> {
+impl<I: Interner> FallibleTypeFolder<I> for Subst<'_, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -2791,7 +2791,7 @@ impl<I: Interner, A: AsParameters<I>> Substitute<I> for A {
         T: TypeFoldable<I>,
     {
         value
-            .fold_with(
+            .try_fold_with(
                 &mut &SubstFolder {
                     interner,
                     subst: self,
@@ -2832,7 +2832,7 @@ impl<'i, I: Interner, A: AsParameters<I>> FallibleTypeFolder<I> for &SubstFolder
         self
     }
 
-    fn fold_free_var_ty(
+    fn try_fold_free_var_ty(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
@@ -2843,7 +2843,7 @@ impl<'i, I: Interner, A: AsParameters<I>> FallibleTypeFolder<I> for &SubstFolder
         Ok(ty.clone().shifted_in_from(self.interner(), outer_binder))
     }
 
-    fn fold_free_var_lifetime(
+    fn try_fold_free_var_lifetime(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
@@ -2854,7 +2854,7 @@ impl<'i, I: Interner, A: AsParameters<I>> FallibleTypeFolder<I> for &SubstFolder
         Ok(l.clone().shifted_in_from(self.interner(), outer_binder))
     }
 
-    fn fold_free_var_const(
+    fn try_fold_free_var_const(
         &mut self,
         _ty: Ty<I>,
         bound_var: BoundVar,

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -8,9 +8,11 @@ extern crate self as chalk_ir;
 
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
-use crate::fold::{FallibleTypeFolder, Subst, TypeFoldable, TypeSuperFoldable};
+use crate::fold::{FallibleTypeFolder, Subst, TypeFoldable, TypeFolder, TypeSuperFoldable};
 use crate::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitor, VisitExt};
-use chalk_derive::{HasInterner, TypeFoldable, TypeSuperVisitable, TypeVisitable, Zip};
+use chalk_derive::{
+    FallibleTypeFolder, HasInterner, TypeFoldable, TypeSuperVisitable, TypeVisitable, Zip,
+};
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
 
@@ -2725,6 +2727,7 @@ impl<I: Interner> Substitution<I> {
     }
 }
 
+#[derive(FallibleTypeFolder)]
 struct SubstFolder<'i, I: Interner, A: AsParameters<I>> {
     interner: I,
     subst: &'i A,
@@ -2792,7 +2795,7 @@ impl<I: Interner, A: AsParameters<I>> Substitute<I> for A {
     {
         value
             .try_fold_with(
-                &mut &SubstFolder {
+                &mut SubstFolder {
                     interner,
                     subst: self,
                 },
@@ -2825,45 +2828,42 @@ impl<'a, I: Interner> ToGenericArg<I> for (usize, &'a VariableKind<I>) {
     }
 }
 
-impl<'i, I: Interner, A: AsParameters<I>> FallibleTypeFolder<I> for &SubstFolder<'i, I, A> {
-    type Error = NoSolution;
-
-    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
+impl<'i, I: Interner, A: AsParameters<I>> TypeFolder<I> for SubstFolder<'i, I, A> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I> {
         self
     }
 
-    fn try_fold_free_var_ty(
-        &mut self,
-        bound_var: BoundVar,
-        outer_binder: DebruijnIndex,
-    ) -> Fallible<Ty<I>> {
+    fn fold_free_var_ty(&mut self, bound_var: BoundVar, outer_binder: DebruijnIndex) -> Ty<I> {
         assert_eq!(bound_var.debruijn, DebruijnIndex::INNERMOST);
         let ty = self.at(bound_var.index);
-        let ty = ty.assert_ty_ref(self.interner());
-        Ok(ty.clone().shifted_in_from(self.interner(), outer_binder))
+        let ty = ty.assert_ty_ref(TypeFolder::interner(self));
+        ty.clone()
+            .shifted_in_from(TypeFolder::interner(self), outer_binder)
     }
 
-    fn try_fold_free_var_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Lifetime<I>> {
+    ) -> Lifetime<I> {
         assert_eq!(bound_var.debruijn, DebruijnIndex::INNERMOST);
         let l = self.at(bound_var.index);
-        let l = l.assert_lifetime_ref(self.interner());
-        Ok(l.clone().shifted_in_from(self.interner(), outer_binder))
+        let l = l.assert_lifetime_ref(TypeFolder::interner(self));
+        l.clone()
+            .shifted_in_from(TypeFolder::interner(self), outer_binder)
     }
 
-    fn try_fold_free_var_const(
+    fn fold_free_var_const(
         &mut self,
         _ty: Ty<I>,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Const<I>> {
+    ) -> Const<I> {
         assert_eq!(bound_var.debruijn, DebruijnIndex::INNERMOST);
         let c = self.at(bound_var.index);
-        let c = c.assert_const_ref(self.interner());
-        Ok(c.clone().shifted_in_from(self.interner(), outer_binder))
+        let c = c.assert_const_ref(TypeFolder::interner(self));
+        c.clone()
+            .shifted_in_from(TypeFolder::interner(self), outer_binder)
     }
 
     fn interner(&self) -> I {

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -8,7 +8,7 @@ extern crate self as chalk_ir;
 
 use crate::cast::{Cast, CastTo, Caster};
 use crate::fold::shift::Shift;
-use crate::fold::{Subst, TypeFoldable, TypeFolder, TypeSuperFoldable};
+use crate::fold::{FallibleTypeFolder, Subst, TypeFoldable, TypeSuperFoldable};
 use crate::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitor, VisitExt};
 use chalk_derive::{HasInterner, TypeFoldable, TypeSuperVisitable, TypeVisitable, Zip};
 use std::marker::PhantomData;
@@ -2825,10 +2825,10 @@ impl<'a, I: Interner> ToGenericArg<I> for (usize, &'a VariableKind<I>) {
     }
 }
 
-impl<'i, I: Interner, A: AsParameters<I>> TypeFolder<I> for &SubstFolder<'i, I, A> {
+impl<'i, I: Interner, A: AsParameters<I>> FallibleTypeFolder<I> for &SubstFolder<'i, I, A> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -7,7 +7,7 @@
 //! types passed to `program_clauses` in the clauses we generate.
 
 use chalk_ir::{
-    fold::{TypeFoldable, TypeFolder},
+    fold::{FallibleTypeFolder, TypeFoldable},
     interner::{HasInterner, Interner},
     Binders, BoundVar, Const, ConstData, ConstValue, DebruijnIndex, Fallible, Lifetime,
     LifetimeData, NoSolution, Ty, TyKind, TyVariableKind, VariableKind, VariableKinds,
@@ -40,10 +40,10 @@ impl<I: Interner> Generalize<I> {
     }
 }
 
-impl<I: Interner> TypeFolder<I> for Generalize<I> {
+impl<I: Interner> FallibleTypeFolder<I> for Generalize<I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -6,14 +6,16 @@
 //! happen with `dyn Trait` currently; that's the only case where we use the
 //! types passed to `program_clauses` in the clauses we generate.
 
+use chalk_derive::FallibleTypeFolder;
 use chalk_ir::{
-    fold::{FallibleTypeFolder, TypeFoldable},
+    fold::{TypeFoldable, TypeFolder},
     interner::{HasInterner, Interner},
-    Binders, BoundVar, Const, ConstData, ConstValue, DebruijnIndex, Fallible, Lifetime,
-    LifetimeData, NoSolution, Ty, TyKind, TyVariableKind, VariableKind, VariableKinds,
+    Binders, BoundVar, Const, ConstData, ConstValue, DebruijnIndex, Lifetime, LifetimeData, Ty,
+    TyKind, TyVariableKind, VariableKind, VariableKinds,
 };
 use rustc_hash::FxHashMap;
 
+#[derive(FallibleTypeFolder)]
 pub struct Generalize<I: Interner> {
     binders: Vec<VariableKind<I>>,
     mapping: FxHashMap<BoundVar, usize>,
@@ -40,18 +42,12 @@ impl<I: Interner> Generalize<I> {
     }
 }
 
-impl<I: Interner> FallibleTypeFolder<I> for Generalize<I> {
-    type Error = NoSolution;
-
-    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
+impl<I: Interner> TypeFolder<I> for Generalize<I> {
+    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I> {
         self
     }
 
-    fn try_fold_free_var_ty(
-        &mut self,
-        bound_var: BoundVar,
-        outer_binder: DebruijnIndex,
-    ) -> Fallible<Ty<I>> {
+    fn fold_free_var_ty(&mut self, bound_var: BoundVar, outer_binder: DebruijnIndex) -> Ty<I> {
         let binder_vec = &mut self.binders;
         let new_index = self.mapping.entry(bound_var).or_insert_with(|| {
             let i = binder_vec.len();
@@ -59,15 +55,15 @@ impl<I: Interner> FallibleTypeFolder<I> for Generalize<I> {
             i
         });
         let new_var = BoundVar::new(outer_binder, *new_index);
-        Ok(TyKind::BoundVar(new_var).intern(self.interner()))
+        TyKind::BoundVar(new_var).intern(TypeFolder::interner(self))
     }
 
-    fn try_fold_free_var_const(
+    fn fold_free_var_const(
         &mut self,
         ty: Ty<I>,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Const<I>> {
+    ) -> Const<I> {
         let binder_vec = &mut self.binders;
         let new_index = self.mapping.entry(bound_var).or_insert_with(|| {
             let i = binder_vec.len();
@@ -75,18 +71,18 @@ impl<I: Interner> FallibleTypeFolder<I> for Generalize<I> {
             i
         });
         let new_var = BoundVar::new(outer_binder, *new_index);
-        Ok(ConstData {
+        ConstData {
             ty,
             value: ConstValue::BoundVar(new_var),
         }
-        .intern(self.interner()))
+        .intern(TypeFolder::interner(self))
     }
 
-    fn try_fold_free_var_lifetime(
+    fn fold_free_var_lifetime(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
-    ) -> Fallible<Lifetime<I>> {
+    ) -> Lifetime<I> {
         let binder_vec = &mut self.binders;
         let new_index = self.mapping.entry(bound_var).or_insert_with(|| {
             let i = binder_vec.len();
@@ -94,7 +90,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Generalize<I> {
             i
         });
         let new_var = BoundVar::new(outer_binder, *new_index);
-        Ok(LifetimeData::BoundVar(new_var).intern(self.interner()))
+        LifetimeData::BoundVar(new_var).intern(TypeFolder::interner(self))
     }
 
     fn interner(&self) -> I {

--- a/chalk-solve/src/clauses/generalize.rs
+++ b/chalk-solve/src/clauses/generalize.rs
@@ -31,7 +31,7 @@ impl<I: Interner> Generalize<I> {
             interner,
         };
         let value = value
-            .fold_with(&mut generalize, DebruijnIndex::INNERMOST)
+            .try_fold_with(&mut generalize, DebruijnIndex::INNERMOST)
             .unwrap();
         Binders::new(
             VariableKinds::from_iter(interner, generalize.binders),
@@ -47,7 +47,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Generalize<I> {
         self
     }
 
-    fn fold_free_var_ty(
+    fn try_fold_free_var_ty(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,
@@ -62,7 +62,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Generalize<I> {
         Ok(TyKind::BoundVar(new_var).intern(self.interner()))
     }
 
-    fn fold_free_var_const(
+    fn try_fold_free_var_const(
         &mut self,
         ty: Ty<I>,
         bound_var: BoundVar,
@@ -82,7 +82,7 @@ impl<I: Interner> FallibleTypeFolder<I> for Generalize<I> {
         .intern(self.interner()))
     }
 
-    fn fold_free_var_lifetime(
+    fn try_fold_free_var_lifetime(
         &mut self,
         bound_var: BoundVar,
         outer_binder: DebruijnIndex,

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -39,7 +39,9 @@ impl<I: Interner> InferenceTable<I> {
             max_universe: UniverseIndex::root(),
             interner,
         };
-        let value = value.fold_with(&mut q, DebruijnIndex::INNERMOST).unwrap();
+        let value = value
+            .try_fold_with(&mut q, DebruijnIndex::INNERMOST)
+            .unwrap();
         let free_vars = q.free_vars.clone();
 
         Canonicalized {
@@ -108,7 +110,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
         self
     }
 
-    fn fold_free_placeholder_ty(
+    fn try_fold_free_placeholder_ty(
         &mut self,
         universe: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
@@ -118,7 +120,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
         Ok(universe.to_ty(interner))
     }
 
-    fn fold_free_placeholder_lifetime(
+    fn try_fold_free_placeholder_lifetime(
         &mut self,
         universe: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
@@ -128,7 +130,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
         Ok(universe.to_lifetime(interner))
     }
 
-    fn fold_free_placeholder_const(
+    fn try_fold_free_placeholder_const(
         &mut self,
         ty: Ty<I>,
         universe: PlaceholderIndex,
@@ -144,7 +146,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn fold_inference_ty(
+    fn try_fold_inference_ty(
         &mut self,
         var: InferenceVar,
         kind: TyVariableKind,
@@ -157,7 +159,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
                 debug!("bound to {:?}", ty);
                 Ok(ty
                     .clone()
-                    .fold_with(self, DebruijnIndex::INNERMOST)?
+                    .try_fold_with(self, DebruijnIndex::INNERMOST)?
                     .shifted_in_from(interner, outer_binder))
             }
             None => {
@@ -176,7 +178,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn fold_inference_lifetime(
+    fn try_fold_inference_lifetime(
         &mut self,
         var: InferenceVar,
         outer_binder: DebruijnIndex,
@@ -187,7 +189,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
                 let l = l.assert_lifetime_ref(interner);
                 debug!("bound to {:?}", l);
                 Ok(l.clone()
-                    .fold_with(self, DebruijnIndex::INNERMOST)?
+                    .try_fold_with(self, DebruijnIndex::INNERMOST)?
                     .shifted_in_from(interner, outer_binder))
             }
             None => {
@@ -204,7 +206,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
     }
 
     #[instrument(level = "debug", skip(self, ty))]
-    fn fold_inference_const(
+    fn try_fold_inference_const(
         &mut self,
         ty: Ty<I>,
         var: InferenceVar,
@@ -216,7 +218,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
                 let c = c.assert_const_ref(interner);
                 debug!("bound to {:?}", c);
                 Ok(c.clone()
-                    .fold_with(self, DebruijnIndex::INNERMOST)?
+                    .try_fold_with(self, DebruijnIndex::INNERMOST)?
                     .shifted_in_from(interner, outer_binder))
             }
             None => {
@@ -233,7 +235,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
         }
     }
 
-    fn fold_lifetime(
+    fn try_fold_lifetime(
         &mut self,
         lifetime: Lifetime<I>,
         outer_binder: DebruijnIndex,
@@ -244,7 +246,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
                 // inference. We shouldn't see it in canonicalization.
                 panic!("Cannot canonicalize ReEmpty in non-root universe")
             }
-            _ => lifetime.super_fold_with(self, outer_binder),
+            _ => lifetime.try_super_fold_with(self, outer_binder),
         }
     }
 

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -1,6 +1,6 @@
 use crate::debug_span;
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{TypeFoldable, TypeFolder, TypeSuperFoldable};
+use chalk_ir::fold::{FallibleTypeFolder, TypeFoldable, TypeSuperFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
 use std::cmp::max;
@@ -101,10 +101,10 @@ impl<'q, I: Interner> Canonicalizer<'q, I> {
     }
 }
 
-impl<'i, I: Interner> TypeFolder<I> for Canonicalizer<'i, I> {
+impl<'i, I: Interner> FallibleTypeFolder<I> for Canonicalizer<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -1,5 +1,5 @@
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{TypeFoldable, TypeFolder};
+use chalk_ir::fold::{FallibleTypeFolder, TypeFoldable};
 use chalk_ir::interner::HasInterner;
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
@@ -127,10 +127,10 @@ impl<'q, I: Interner> Inverter<'q, I> {
     }
 }
 
-impl<'i, I: Interner> TypeFolder<I> for Inverter<'i, I> {
+impl<'i, I: Interner> FallibleTypeFolder<I> for Inverter<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/invert.rs
+++ b/chalk-solve/src/infer/invert.rs
@@ -90,7 +90,7 @@ impl<I: Interner> InferenceTable<I> {
         assert!(quantified.binders.is_empty(interner));
         let inverted = quantified
             .value
-            .fold_with(&mut Inverter::new(interner, self), DebruijnIndex::INNERMOST)
+            .try_fold_with(&mut Inverter::new(interner, self), DebruijnIndex::INNERMOST)
             .unwrap();
         Some(inverted)
     }
@@ -134,7 +134,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Inverter<'i, I> {
         self
     }
 
-    fn fold_free_placeholder_ty(
+    fn try_fold_free_placeholder_ty(
         &mut self,
         universe: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
@@ -148,7 +148,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for Inverter<'i, I> {
             .shifted_in(self.interner()))
     }
 
-    fn fold_free_placeholder_lifetime(
+    fn try_fold_free_placeholder_lifetime(
         &mut self,
         universe: PlaceholderIndex,
         _outer_binder: DebruijnIndex,

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -36,7 +36,7 @@ impl<I: Interner> InferenceTable<I> {
         let value1 = value0
             .value
             .clone()
-            .fold_with(
+            .try_fold_with(
                 &mut UMapToCanonical {
                     universes: &universes,
                     interner,
@@ -169,7 +169,7 @@ impl UniverseMapExt for UniverseMap {
         let value = canonical_value
             .value
             .clone()
-            .fold_with(
+            .try_fold_with(
                 &mut UMapFromCanonical {
                     interner,
                     universes: self,
@@ -233,7 +233,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for UMapToCanonical<'i, I> {
         true
     }
 
-    fn fold_free_placeholder_ty(
+    fn try_fold_free_placeholder_ty(
         &mut self,
         universe0: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
@@ -249,7 +249,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for UMapToCanonical<'i, I> {
         .to_ty(self.interner()))
     }
 
-    fn fold_free_placeholder_lifetime(
+    fn try_fold_free_placeholder_lifetime(
         &mut self,
         universe0: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
@@ -266,7 +266,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for UMapToCanonical<'i, I> {
         .to_lifetime(self.interner()))
     }
 
-    fn fold_free_placeholder_const(
+    fn try_fold_free_placeholder_const(
         &mut self,
         ty: Ty<I>,
         universe0: PlaceholderIndex,
@@ -301,7 +301,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for UMapFromCanonical<'i, I> {
         self
     }
 
-    fn fold_free_placeholder_ty(
+    fn try_fold_free_placeholder_ty(
         &mut self,
         universe0: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
@@ -314,7 +314,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for UMapFromCanonical<'i, I> {
         .to_ty(self.interner()))
     }
 
-    fn fold_free_placeholder_lifetime(
+    fn try_fold_free_placeholder_lifetime(
         &mut self,
         universe0: PlaceholderIndex,
         _outer_binder: DebruijnIndex,

--- a/chalk-solve/src/infer/ucanonicalize.rs
+++ b/chalk-solve/src/infer/ucanonicalize.rs
@@ -1,5 +1,5 @@
 use crate::debug_span;
-use chalk_ir::fold::{TypeFoldable, TypeFolder};
+use chalk_ir::fold::{FallibleTypeFolder, TypeFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::visit::{TypeVisitable, TypeVisitor};
 use chalk_ir::*;
@@ -222,10 +222,10 @@ struct UMapToCanonical<'q, I> {
     universes: &'q UniverseMap,
 }
 
-impl<'i, I: Interner> TypeFolder<I> for UMapToCanonical<'i, I> {
+impl<'i, I: Interner> FallibleTypeFolder<I> for UMapToCanonical<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 
@@ -294,10 +294,10 @@ struct UMapFromCanonical<'q, I> {
     universes: &'q UniverseMap,
 }
 
-impl<'i, I: Interner> TypeFolder<I> for UMapFromCanonical<'i, I> {
+impl<'i, I: Interner> FallibleTypeFolder<I> for UMapFromCanonical<'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -2,7 +2,7 @@ use super::var::*;
 use super::*;
 use crate::debug_span;
 use chalk_ir::cast::Cast;
-use chalk_ir::fold::{TypeFoldable, TypeFolder};
+use chalk_ir::fold::{FallibleTypeFolder, TypeFoldable};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::zip::{Zip, Zipper};
 use chalk_ir::UnificationDatabase;
@@ -1246,10 +1246,10 @@ impl<'u, 't, I: Interner> OccursCheck<'u, 't, I> {
     }
 }
 
-impl<'i, I: Interner> TypeFolder<I> for OccursCheck<'_, 'i, I> {
+impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
     type Error = NoSolution;
 
-    fn as_dyn(&mut self) -> &mut dyn TypeFolder<I, Error = Self::Error> {
+    fn as_dyn(&mut self) -> &mut dyn FallibleTypeFolder<I, Error = Self::Error> {
         self
     }
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -876,7 +876,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
         debug!("trying fold_with on {:?}", ty);
         let ty1 = ty
             .clone()
-            .fold_with(
+            .try_fold_with(
                 &mut OccursCheck::new(self, var, universe_index),
                 DebruijnIndex::INNERMOST,
             )
@@ -1133,7 +1133,7 @@ impl<'t, I: Interner> Unifier<'t, I> {
         // as the variable is unified.
         let universe_index = self.table.universe_of_unbound_var(var);
 
-        let c1 = c.clone().fold_with(
+        let c1 = c.clone().try_fold_with(
             &mut OccursCheck::new(self, var, universe_index),
             DebruijnIndex::INNERMOST,
         )?;
@@ -1253,7 +1253,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
         self
     }
 
-    fn fold_free_placeholder_ty(
+    fn try_fold_free_placeholder_ty(
         &mut self,
         universe: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
@@ -1270,7 +1270,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
         }
     }
 
-    fn fold_free_placeholder_const(
+    fn try_fold_free_placeholder_const(
         &mut self,
         ty: Ty<I>,
         universe: PlaceholderIndex,
@@ -1285,7 +1285,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn fold_free_placeholder_lifetime(
+    fn try_fold_free_placeholder_lifetime(
         &mut self,
         ui: PlaceholderIndex,
         _outer_binder: DebruijnIndex,
@@ -1319,7 +1319,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
         }
     }
 
-    fn fold_inference_ty(
+    fn try_fold_inference_ty(
         &mut self,
         var: InferenceVar,
         kind: TyVariableKind,
@@ -1333,7 +1333,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
                 let normalized_ty = normalized_ty.assert_ty_ref(interner);
                 let normalized_ty = normalized_ty
                     .clone()
-                    .fold_with(self, DebruijnIndex::INNERMOST)?;
+                    .try_fold_with(self, DebruijnIndex::INNERMOST)?;
                 assert!(!normalized_ty.needs_shift(interner));
                 Ok(normalized_ty)
             }
@@ -1369,7 +1369,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
         }
     }
 
-    fn fold_inference_const(
+    fn try_fold_inference_const(
         &mut self,
         ty: Ty<I>,
         var: InferenceVar,
@@ -1383,7 +1383,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
                 let normalized_const = normalized_const.assert_const_ref(interner);
                 let normalized_const = normalized_const
                     .clone()
-                    .fold_with(self, DebruijnIndex::INNERMOST)?;
+                    .try_fold_with(self, DebruijnIndex::INNERMOST)?;
                 assert!(!normalized_const.needs_shift(interner));
                 Ok(normalized_const)
             }
@@ -1415,7 +1415,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
         }
     }
 
-    fn fold_inference_lifetime(
+    fn try_fold_inference_lifetime(
         &mut self,
         var: InferenceVar,
         outer_binder: DebruijnIndex,
@@ -1444,7 +1444,7 @@ impl<'i, I: Interner> FallibleTypeFolder<I> for OccursCheck<'_, 'i, I> {
 
             InferenceValue::Bound(l) => {
                 let l = l.assert_lifetime_ref(interner);
-                let l = l.clone().fold_with(self, outer_binder)?;
+                let l = l.clone().try_fold_with(self, outer_binder)?;
                 assert!(!l.needs_shift(interner));
                 Ok(l)
             }


### PR DESCRIPTION
For folding operations that cannot fail, the existing fallible folding trait is a little unergonomic.  This PR introduces an infallible folder trait that can be used as a more ergonomic alternative in such cases, reflecting the status quo in rustc.

Infallible folders must however also implement the fallible trait (it's a supertrait of the infallible one), but such implementation should merely delegate to the infallible trait.  Coherence rules unfortunately do not permit this to be provided by blanket implementation, however delegating implementations can be simply derived on infallible folders via the `chalk_derive::FallibleTypeFolder` macro.

r? @jackh726