### PR TITLE
Implement should_continue in chalk-recursive 

### DIFF
--- a/chalk-engine/src/slg/aggregate.rs
+++ b/chalk-engine/src/slg/aggregate.rs
@@ -17,7 +17,7 @@ pub trait AggregateOps<I: Interner> {
         &self,
         root_goal: &UCanonical<InEnvironment<Goal<I>>>,
         answers: impl context::AnswerStream<I>,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Option<Solution<I>>;
 }
 
@@ -28,7 +28,7 @@ impl<I: Interner> AggregateOps<I> for SlgContextOps<'_, I> {
         &self,
         root_goal: &UCanonical<InEnvironment<Goal<I>>>,
         mut answers: impl context::AnswerStream<I>,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Option<Solution<I>> {
         let interner = self.program.interner();
         let CompleteAnswer { subst, ambiguous } = match answers.next_answer(&should_continue) {

--- a/chalk-recursive/src/fixed_point.rs
+++ b/chalk-recursive/src/fixed_point.rs
@@ -43,7 +43,7 @@ where
         context: &mut RecursiveContext<K, V>,
         goal: &K,
         minimums: &mut Minimums,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> V;
     fn reached_fixed_point(self, old_value: &V, new_value: &V) -> bool;
     fn error_value(self) -> V;
@@ -105,7 +105,7 @@ where
         &mut self,
         canonical_goal: &K,
         solver_stuff: impl SolverStuff<K, V>,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> V {
         debug!("solve_root_goal(canonical_goal={:?})", canonical_goal);
         assert!(self.stack.is_empty());
@@ -122,7 +122,7 @@ where
         goal: &K,
         minimums: &mut Minimums,
         solver_stuff: impl SolverStuff<K, V>,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> V {
         // First check the cache.
         if let Some(cache) = &self.cache {
@@ -201,7 +201,7 @@ where
         depth: StackDepth,
         dfn: DepthFirstNumber,
         solver_stuff: impl SolverStuff<K, V>,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Minimums {
         // We start with `answer = None` and try to solve the goal. At the end of the iteration,
         // `answer` will be updated with the result of the solving process. If we detect a cycle
@@ -214,8 +214,12 @@ where
         // so this function will eventually be constant and the loop terminates.
         loop {
             let minimums = &mut Minimums::new();
-            let current_answer =
-                solver_stuff.solve_iteration(self, canonical_goal, minimums, &should_continue);
+            let current_answer = solver_stuff.solve_iteration(
+                self,
+                canonical_goal,
+                minimums,
+                should_continue.clone(),
+            );
 
             debug!(
                 "solve_new_subgoal: loop iteration result = {:?} with minimums {:?}",

--- a/chalk-recursive/src/fixed_point.rs
+++ b/chalk-recursive/src/fixed_point.rs
@@ -218,7 +218,7 @@ where
                 self,
                 canonical_goal,
                 minimums,
-                should_continue.clone(),
+                should_continue.clone(), // Note: cloning required as workaround for https://github.com/rust-lang/rust/issues/95734
             );
 
             debug!(

--- a/chalk-recursive/src/fixed_point.rs
+++ b/chalk-recursive/src/fixed_point.rs
@@ -43,6 +43,7 @@ where
         context: &mut RecursiveContext<K, V>,
         goal: &K,
         minimums: &mut Minimums,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> V;
     fn reached_fixed_point(self, old_value: &V, new_value: &V) -> bool;
     fn error_value(self) -> V;
@@ -104,22 +105,24 @@ where
         &mut self,
         canonical_goal: &K,
         solver_stuff: impl SolverStuff<K, V>,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> V {
         debug!("solve_root_goal(canonical_goal={:?})", canonical_goal);
         assert!(self.stack.is_empty());
         let minimums = &mut Minimums::new();
-        self.solve_goal(canonical_goal, minimums, solver_stuff)
+        self.solve_goal(canonical_goal, minimums, solver_stuff, should_continue)
     }
 
     /// Attempt to solve a goal that has been fully broken down into leaf form
     /// and canonicalized. This is where the action really happens, and is the
     /// place where we would perform caching in rustc (and may eventually do in Chalk).
-    #[instrument(level = "info", skip(self, minimums, solver_stuff,))]
+    #[instrument(level = "info", skip(self, minimums, solver_stuff, should_continue))]
     pub fn solve_goal(
         &mut self,
         goal: &K,
         minimums: &mut Minimums,
         solver_stuff: impl SolverStuff<K, V>,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> V {
         // First check the cache.
         if let Some(cache) = &self.cache {
@@ -159,7 +162,8 @@ where
             let depth = self.stack.push(coinductive_goal);
             let dfn = self.search_graph.insert(goal, depth, initial_solution);
 
-            let subgoal_minimums = self.solve_new_subgoal(goal, depth, dfn, solver_stuff);
+            let subgoal_minimums =
+                self.solve_new_subgoal(goal, depth, dfn, solver_stuff, should_continue);
 
             self.search_graph[dfn].links = subgoal_minimums;
             self.search_graph[dfn].stack_depth = None;
@@ -190,13 +194,14 @@ where
         }
     }
 
-    #[instrument(level = "debug", skip(self, solver_stuff))]
+    #[instrument(level = "debug", skip(self, solver_stuff, should_continue))]
     fn solve_new_subgoal(
         &mut self,
         canonical_goal: &K,
         depth: StackDepth,
         dfn: DepthFirstNumber,
         solver_stuff: impl SolverStuff<K, V>,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> Minimums {
         // We start with `answer = None` and try to solve the goal. At the end of the iteration,
         // `answer` will be updated with the result of the solving process. If we detect a cycle
@@ -209,7 +214,8 @@ where
         // so this function will eventually be constant and the loop terminates.
         loop {
             let minimums = &mut Minimums::new();
-            let current_answer = solver_stuff.solve_iteration(self, canonical_goal, minimums);
+            let current_answer =
+                solver_stuff.solve_iteration(self, canonical_goal, minimums, &should_continue);
 
             debug!(
                 "solve_new_subgoal: loop iteration result = {:?} with minimums {:?}",

--- a/chalk-recursive/src/recursive.rs
+++ b/chalk-recursive/src/recursive.rs
@@ -143,7 +143,6 @@ impl<I: Interner> chalk_solve::Solver<I> for RecursiveSolver<I> {
         goal: &UCanonical<InEnvironment<Goal<I>>>,
         should_continue: &dyn std::ops::Fn() -> bool,
     ) -> Option<chalk_solve::Solution<I>> {
-        // TODO support should_continue in recursive solver
         self.ctx
             .solve_root_goal(goal, program, should_continue)
             .ok()

--- a/chalk-recursive/src/recursive.rs
+++ b/chalk-recursive/src/recursive.rs
@@ -76,8 +76,9 @@ impl<I: Interner> SolverStuff<UCanonicalGoal<I>, Fallible<Solution<I>>> for &dyn
         context: &mut RecursiveContext<UCanonicalGoal<I>, Fallible<Solution<I>>>,
         goal: &UCanonicalGoal<I>,
         minimums: &mut Minimums,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> Fallible<Solution<I>> {
-        Solver::new(context, self).solve_iteration(goal, minimums)
+        Solver::new(context, self).solve_iteration(goal, minimums, should_continue)
     }
 
     fn reached_fixed_point(
@@ -108,8 +109,10 @@ impl<'me, I: Interner> SolveDatabase<I> for Solver<'me, I> {
         &mut self,
         goal: UCanonicalGoal<I>,
         minimums: &mut Minimums,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> Fallible<Solution<I>> {
-        self.context.solve_goal(&goal, minimums, self.program)
+        self.context
+            .solve_goal(&goal, minimums, self.program, should_continue)
     }
 
     fn interner(&self) -> I {
@@ -131,17 +134,19 @@ impl<I: Interner> chalk_solve::Solver<I> for RecursiveSolver<I> {
         program: &dyn RustIrDatabase<I>,
         goal: &UCanonical<InEnvironment<Goal<I>>>,
     ) -> Option<chalk_solve::Solution<I>> {
-        self.ctx.solve_root_goal(goal, program).ok()
+        self.ctx.solve_root_goal(goal, program, || true).ok()
     }
 
     fn solve_limited(
         &mut self,
         program: &dyn RustIrDatabase<I>,
         goal: &UCanonical<InEnvironment<Goal<I>>>,
-        _should_continue: &dyn std::ops::Fn() -> bool,
+        should_continue: &dyn std::ops::Fn() -> bool,
     ) -> Option<chalk_solve::Solution<I>> {
         // TODO support should_continue in recursive solver
-        self.ctx.solve_root_goal(goal, program).ok()
+        self.ctx
+            .solve_root_goal(goal, program, should_continue)
+            .ok()
     }
 
     fn solve_multiple(

--- a/chalk-recursive/src/recursive.rs
+++ b/chalk-recursive/src/recursive.rs
@@ -76,7 +76,7 @@ impl<I: Interner> SolverStuff<UCanonicalGoal<I>, Fallible<Solution<I>>> for &dyn
         context: &mut RecursiveContext<UCanonicalGoal<I>, Fallible<Solution<I>>>,
         goal: &UCanonicalGoal<I>,
         minimums: &mut Minimums,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Fallible<Solution<I>> {
         Solver::new(context, self).solve_iteration(goal, minimums, should_continue)
     }
@@ -109,7 +109,7 @@ impl<'me, I: Interner> SolveDatabase<I> for Solver<'me, I> {
         &mut self,
         goal: UCanonicalGoal<I>,
         minimums: &mut Minimums,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Fallible<Solution<I>> {
         self.context
             .solve_goal(&goal, minimums, self.program, should_continue)

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -20,6 +20,7 @@ pub(super) trait SolveDatabase<I: Interner>: Sized {
         &mut self,
         goal: UCanonical<InEnvironment<Goal<I>>>,
         minimums: &mut Minimums,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> Fallible<Solution<I>>;
 
     fn max_size(&self) -> usize;
@@ -35,11 +36,12 @@ pub(super) trait SolveIteration<I: Interner>: SolveDatabase<I> {
     /// Executes one iteration of the recursive solver, computing the current
     /// solution to the given canonical goal. This is used as part of a loop in
     /// the case of cyclic goals.
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, should_continue))]
     fn solve_iteration(
         &mut self,
         canonical_goal: &UCanonicalGoal<I>,
         minimums: &mut Minimums,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> Fallible<Solution<I>> {
         let UCanonical {
             universes,
@@ -72,7 +74,7 @@ pub(super) trait SolveIteration<I: Interner>: SolveDatabase<I> {
                 let prog_solution = {
                     debug_span!("prog_clauses");
 
-                    self.solve_from_clauses(&canonical_goal, minimums)
+                    self.solve_from_clauses(&canonical_goal, minimums, should_continue)
                 };
                 debug!(?prog_solution);
 
@@ -88,7 +90,7 @@ pub(super) trait SolveIteration<I: Interner>: SolveDatabase<I> {
                     },
                 };
 
-                self.solve_via_simplification(&canonical_goal, minimums)
+                self.solve_via_simplification(&canonical_goal, minimums, should_continue)
             }
         }
     }
@@ -103,15 +105,16 @@ where
 
 /// Helper methods for `solve_iteration`, private to this module.
 trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
-    #[instrument(level = "debug", skip(self, minimums))]
+    #[instrument(level = "debug", skip(self, minimums, should_continue))]
     fn solve_via_simplification(
         &mut self,
         canonical_goal: &UCanonicalGoal<I>,
         minimums: &mut Minimums,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> Fallible<Solution<I>> {
         let (infer, subst, goal) = self.new_inference_table(canonical_goal);
         match Fulfill::new_with_simplification(self, infer, subst, goal) {
-            Ok(fulfill) => fulfill.solve(minimums),
+            Ok(fulfill) => fulfill.solve(minimums, should_continue),
             Err(e) => Err(e),
         }
     }
@@ -123,6 +126,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
         &mut self,
         canonical_goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
         minimums: &mut Minimums,
+        should_continue: impl std::ops::Fn() -> bool,
     ) -> Fallible<Solution<I>> {
         let mut clauses = vec![];
 
@@ -159,7 +163,10 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
             let subst = subst.clone();
             let goal = goal.clone();
             let res = match Fulfill::new_with_clause(self, infer, subst, goal, implication) {
-                Ok(fulfill) => (fulfill.solve(minimums), implication.skip_binders().priority),
+                Ok(fulfill) => (
+                    fulfill.solve(minimums, &should_continue),
+                    implication.skip_binders().priority,
+                ),
                 Err(e) => (Err(e), ClausePriority::High),
             };
 

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -44,7 +44,7 @@ pub(super) trait SolveIteration<I: Interner>: SolveDatabase<I> {
         should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Fallible<Solution<I>> {
         if !should_continue() {
-            return Err(NoSolution);
+            return Ok(Solution::Ambig(Guidance::Unknown));
         }
 
         let UCanonical {

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -20,7 +20,7 @@ pub(super) trait SolveDatabase<I: Interner>: Sized {
         &mut self,
         goal: UCanonical<InEnvironment<Goal<I>>>,
         minimums: &mut Minimums,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Fallible<Solution<I>>;
 
     fn max_size(&self) -> usize;
@@ -41,7 +41,7 @@ pub(super) trait SolveIteration<I: Interner>: SolveDatabase<I> {
         &mut self,
         canonical_goal: &UCanonicalGoal<I>,
         minimums: &mut Minimums,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Fallible<Solution<I>> {
         let UCanonical {
             universes,
@@ -110,7 +110,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
         &mut self,
         canonical_goal: &UCanonicalGoal<I>,
         minimums: &mut Minimums,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Fallible<Solution<I>> {
         let (infer, subst, goal) = self.new_inference_table(canonical_goal);
         match Fulfill::new_with_simplification(self, infer, subst, goal) {
@@ -126,7 +126,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
         &mut self,
         canonical_goal: &UCanonical<InEnvironment<DomainGoal<I>>>,
         minimums: &mut Minimums,
-        should_continue: impl std::ops::Fn() -> bool,
+        should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Fallible<Solution<I>> {
         let mut clauses = vec![];
 
@@ -164,7 +164,7 @@ trait SolveIterationHelpers<I: Interner>: SolveDatabase<I> {
             let goal = goal.clone();
             let res = match Fulfill::new_with_clause(self, infer, subst, goal, implication) {
                 Ok(fulfill) => (
-                    fulfill.solve(minimums, &should_continue),
+                    fulfill.solve(minimums, should_continue.clone()),
                     implication.skip_binders().priority,
                 ),
                 Err(e) => (Err(e), ClausePriority::High),

--- a/chalk-recursive/src/solve.rs
+++ b/chalk-recursive/src/solve.rs
@@ -43,6 +43,10 @@ pub(super) trait SolveIteration<I: Interner>: SolveDatabase<I> {
         minimums: &mut Minimums,
         should_continue: impl std::ops::Fn() -> bool + Clone,
     ) -> Fallible<Solution<I>> {
+        if !should_continue() {
+            return Err(NoSolution);
+        }
+
         let UCanonical {
             universes,
             canonical:


### PR DESCRIPTION
This just returns `NoSolution` if it shouldn't continue, but that should already be useful to rust-analyzer.

Note: Cloning of `should_continue` is a workaround to a rustc bug ([#95734](https://github.com/rust-lang/rust/issues/95734))