### PR TITLE
Fix `Self` type retrieval from `ProjectionTy`

### DIFF
--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1643,17 +1643,6 @@ pub struct ProjectionTy<I: Interner> {
 
 impl<I: Interner> Copy for ProjectionTy<I> where I::InternedSubstitution: Copy {}
 
-impl<I: Interner> ProjectionTy<I> {
-    /// Gets the type parameters of the `Self` type in this alias type.
-    pub fn self_type_parameter(&self, interner: I) -> Ty<I> {
-        self.substitution
-            .iter(interner)
-            .find_map(move |p| p.ty(interner))
-            .unwrap()
-            .clone()
-    }
-}
-
 /// An opaque type `opaque type T<..>: Trait = HiddenTy`.
 #[derive(Clone, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable, HasInterner)]
 pub struct OpaqueTy<I: Interner> {

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -214,10 +214,11 @@ pub struct FnDefDatumBound<I: Interner> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+// FIXME: unignore the doctest below when GATs hit stable.
 /// A rust intermediate representation (rust_ir) of a Trait Definition. For
 /// example, given the following rust code:
 ///
-/// ```compile_fail
+/// ```ignore
 /// use std::fmt::Debug;
 ///
 /// trait Foo<T>

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -688,6 +688,33 @@ fn forall_projection_gat() {
 }
 
 #[test]
+fn gat_in_non_enumerable_trait() {
+    test! {
+        program {
+            #[non_enumerable]
+            trait Deref { }
+
+            #[non_enumerable]
+            trait PointerFamily {
+                type Pointer<T>: Deref;
+            }
+        }
+
+        goal {
+            forall<T> {
+                forall<U> {
+                    if (T: PointerFamily) {
+                        <T as PointerFamily>::Pointer<U>: Deref
+                    }
+                }
+            }
+        } yields {
+            expect![[r#"Unique"#]]
+        }
+    }
+}
+
+#[test]
 fn normalize_under_binder() {
     test! {
         program {


### PR DESCRIPTION
As I understand it, a `ProjectionTy`'s substitution is in the order of the args for the associated type, and then the args for its parent (i.e. impl or trait). `ProjectionTy::self_type_parameter()` has been returning the first type argument in the substitution, which is not the `Self` type its callers would expect when the associated type has its own type parameters.

The added test shows the problem: it fails in current master as the recursive solver reports ambiguity after it gets wrong `Self` type and flounders in [here](https://github.com/rust-lang/chalk/blob/c8bc9aae199d5c424044f6608eb1e553648bce2c/chalk-solve/src/clauses.rs#L615-L622). It hasn't been uncovered because all the traits in tests for GATs are not `#[non_enumerable]` (and rust-analyzer hasn't implemented GATs yet).