### PR TITLE
Fix parameter for `Interner` in `derive(FallibleTypeFolder)` macro

### DIFF
--- a/chalk-derive/src/lib.rs
+++ b/chalk-derive/src/lib.rs
@@ -313,7 +313,7 @@ fn derive_fallible_type_folder(mut s: synstructure::Structure) -> TokenStream {
         quote! {
             type Error = ::core::convert::Infallible;
 
-            fn as_dyn(&mut self) -> &mut dyn ::chalk_ir::fold::FallibleTypeFolder<I, Error = Self::Error> {
+            fn as_dyn(&mut self) -> &mut dyn ::chalk_ir::fold::FallibleTypeFolder<#interner, Error = Self::Error> {
                 self
             }
 


### PR DESCRIPTION
In custom derive macro for `FallibleTypeFolder` introduced in #772, there's one occurrence of raw type parameter that is not guaranteed to exist. This patch replaces it with `#interner` to be interpolated at proc macro runtime like in other methods.