### PR TITLE
Implement support for the `Tuple` trait

### DIFF
--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -1143,6 +1143,7 @@ impl Lower for WellKnownTrait {
             WellKnownTrait::DiscriminantKind => rust_ir::WellKnownTrait::DiscriminantKind,
             WellKnownTrait::Generator => rust_ir::WellKnownTrait::Generator,
             WellKnownTrait::DispatchFromDyn => rust_ir::WellKnownTrait::DispatchFromDyn,
+            WellKnownTrait::Tuple => rust_ir::WellKnownTrait::Tuple,
         }
     }
 }

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -161,6 +161,7 @@ pub enum WellKnownTrait {
     DiscriminantKind,
     Generator,
     DispatchFromDyn,
+    Tuple,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -69,6 +69,7 @@ WellKnownTrait: WellKnownTrait = {
      "#" "[" "lang" "(" "discriminant_kind" ")" "]" => WellKnownTrait::DiscriminantKind,
      "#" "[" "lang" "(" "generator" ")" "]" => WellKnownTrait::Generator,
      "#" "[" "lang" "(" "dispatch_from_dyn" ")" "]" => WellKnownTrait::DispatchFromDyn,
+     "#" "[" "lang" "(" "tuple_trait" ")" "]" => WellKnownTrait::Tuple,
 };
 
 AdtReprAttr: AdtReprAttr = {

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -8,6 +8,7 @@ mod discriminant_kind;
 mod fn_family;
 mod generator;
 mod sized;
+mod tuple;
 mod unsize;
 
 /// For well known traits we have special hard-coded impls, either as an
@@ -49,6 +50,9 @@ pub fn add_builtin_program_clauses<I: Interner>(
             WellKnownTrait::DiscriminantKind => builder.push_fact(trait_ref),
             WellKnownTrait::Generator => {
                 generator::add_generator_program_clauses(db, builder, self_ty)?;
+            }
+            WellKnownTrait::Tuple => {
+                tuple::add_tuple_program_clauses(db, builder, self_ty)?;
             }
             // There are no builtin impls provided for the following traits:
             WellKnownTrait::Unpin

--- a/chalk-solve/src/clauses/builtin_traits/tuple.rs
+++ b/chalk-solve/src/clauses/builtin_traits/tuple.rs
@@ -1,0 +1,30 @@
+use crate::clauses::ClauseBuilder;
+use crate::rust_ir::WellKnownTrait;
+use crate::{Interner, RustIrDatabase, TraitRef};
+use chalk_ir::{Floundered, Substitution, Ty, TyKind};
+
+/// Add implicit impl for the `Tuple` trait for all tuples
+pub fn add_tuple_program_clauses<I: Interner>(
+    db: &dyn RustIrDatabase<I>,
+    builder: &mut ClauseBuilder<'_, I>,
+    self_ty: Ty<I>,
+) -> Result<(), Floundered> {
+    let interner = db.interner();
+
+    match self_ty.kind(interner) {
+        TyKind::Tuple(..) => {
+            let trait_id = db.well_known_trait_id(WellKnownTrait::Tuple).unwrap();
+
+            builder.push_fact(TraitRef {
+                trait_id,
+                substitution: Substitution::from1(interner, self_ty),
+            });
+
+            Ok(())
+        }
+
+        // Tuple trait is non-enumerable
+        TyKind::InferenceVar(..) | TyKind::BoundVar(_) | TyKind::Alias(..) => Err(Floundered),
+        _ => Ok(()),
+    }
+}

--- a/chalk-solve/src/display/items.rs
+++ b/chalk-solve/src/display/items.rs
@@ -205,6 +205,7 @@ impl<I: Interner> RenderAsRust<I> for TraitDatum<I> {
                 WellKnownTrait::DiscriminantKind => "discriminant_kind",
                 WellKnownTrait::Generator => "generator",
                 WellKnownTrait::DispatchFromDyn => "dispatch_from_dyn",
+                WellKnownTrait::Tuple => "tuple_trait",
             };
             writeln!(f, "#[lang({})]", name)?;
         }

--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -277,6 +277,7 @@ pub enum WellKnownTrait {
     DiscriminantKind,
     Generator,
     DispatchFromDyn,
+    Tuple,
 }
 
 chalk_ir::const_visit!(WellKnownTrait);

--- a/chalk-solve/src/wf.rs
+++ b/chalk-solve/src/wf.rs
@@ -435,7 +435,8 @@ where
             | WellKnownTrait::Unsize
             | WellKnownTrait::Sized
             | WellKnownTrait::DiscriminantKind
-            | WellKnownTrait::Generator => false,
+            | WellKnownTrait::Generator
+            | WellKnownTrait::Tuple => false,
         };
 
         if is_legal {

--- a/tests/test/tuples.rs
+++ b/tests/test/tuples.rs
@@ -294,3 +294,55 @@ fn tuples_are_wf() {
         }
     }
 }
+
+#[test]
+fn tuples_implement_tuple_trait() {
+    test! {
+        program {
+            #[lang(tuple_trait)]
+            trait Tuple { }
+        }
+
+        goal {
+            (): Tuple
+        } yields {
+            expect![["Unique"]]
+        }
+
+        goal {
+            (u8,): Tuple
+        } yields {
+            expect![["Unique"]]
+        }
+
+        goal {
+            (i32, i32): Tuple
+        } yields {
+            expect![["Unique"]]
+        }
+
+        goal {
+            ([u8],): Tuple
+        } yields {
+            expect![["Unique"]]
+        }
+
+        goal {
+            forall<T> { (T,): Tuple }
+        } yields {
+            expect![["Unique"]]
+        }
+
+        goal {
+            i32: Tuple
+        } yields {
+            expect![["No possible solution"]]
+        }
+
+        goal {
+            exists<T> { T: Tuple }
+        } yields {
+            expect![["Ambiguous; no inference guidance"]]
+        }
+    }
+}


### PR DESCRIPTION
Necessary to due to new trait bounds required by rust-lang/compiler-team#537 / rust-lang/rust#99943.

r? @jackh726 