### PR TITLE
Remove empty lifetime

### DIFF
--- a/chalk-engine/src/slg/resolvent.rs
+++ b/chalk-engine/src/slg/resolvent.rs
@@ -614,8 +614,7 @@ impl<'i, I: Interner> Zipper<I> for AnswerSubstitutor<'i, I> {
 
             (LifetimeData::Static, LifetimeData::Static)
             | (LifetimeData::Placeholder(_), LifetimeData::Placeholder(_))
-            | (LifetimeData::Erased, LifetimeData::Erased)
-            | (LifetimeData::Empty(_), LifetimeData::Empty(_)) => {
+            | (LifetimeData::Erased, LifetimeData::Erased) => {
                 assert_eq!(answer, pending);
                 Ok(())
             }
@@ -628,8 +627,7 @@ impl<'i, I: Interner> Zipper<I> for AnswerSubstitutor<'i, I> {
             (LifetimeData::Static, _)
             | (LifetimeData::BoundVar(_), _)
             | (LifetimeData::Placeholder(_), _)
-            | (LifetimeData::Erased, _)
-            | (LifetimeData::Empty(_), _) => panic!(
+            | (LifetimeData::Erased, _) => panic!(
                 "structural mismatch between answer `{:?}` and pending goal `{:?}`",
                 answer, pending,
             ),

--- a/chalk-integration/src/lowering.rs
+++ b/chalk-integration/src/lowering.rs
@@ -880,10 +880,6 @@ impl LowerWithEnv for Lifetime {
                 interner,
                 chalk_ir::LifetimeData::Static,
             )),
-            Lifetime::Empty => Ok(chalk_ir::Lifetime::new(
-                interner,
-                chalk_ir::LifetimeData::Empty(chalk_ir::UniverseIndex { counter: 0 }),
-            )),
             Lifetime::Erased => Ok(chalk_ir::Lifetime::new(
                 interner,
                 chalk_ir::LifetimeData::Erased,

--- a/chalk-ir/src/debug.rs
+++ b/chalk-ir/src/debug.rs
@@ -306,8 +306,6 @@ impl<I: Interner> Debug for LifetimeData<I> {
             LifetimeData::InferenceVar(var) => write!(fmt, "'{:?}", var),
             LifetimeData::Placeholder(index) => write!(fmt, "'{:?}", index),
             LifetimeData::Static => write!(fmt, "'static"),
-            LifetimeData::Empty(UniverseIndex::ROOT) => write!(fmt, "'<empty>"),
-            LifetimeData::Empty(universe) => write!(fmt, "'<empty:{:?}>", universe),
             LifetimeData::Erased => write!(fmt, "'<erased>"),
             LifetimeData::Phantom(..) => unreachable!(),
         }

--- a/chalk-ir/src/fold.rs
+++ b/chalk-ir/src/fold.rs
@@ -821,7 +821,6 @@ where
                 folder.try_fold_free_placeholder_lifetime(*universe, outer_binder)
             }
             LifetimeData::Static => Ok(LifetimeData::<I>::Static.intern(folder.interner())),
-            LifetimeData::Empty(ui) => Ok(LifetimeData::<I>::Empty(*ui).intern(folder.interner())),
             LifetimeData::Erased => Ok(LifetimeData::<I>::Erased.intern(folder.interner())),
             LifetimeData::Phantom(void, ..) => match *void {},
         }

--- a/chalk-ir/src/lib.rs
+++ b/chalk-ir/src/lib.rs
@@ -1278,7 +1278,6 @@ impl<I: Interner> Lifetime<I> {
             LifetimeData::InferenceVar(_) => false,
             LifetimeData::Placeholder(_) => false,
             LifetimeData::Static => false,
-            LifetimeData::Empty(_) => false,
             LifetimeData::Erased => false,
             LifetimeData::Phantom(..) => unreachable!(),
         }
@@ -1297,7 +1296,7 @@ impl<I: Interner> Lifetime<I> {
                     | TypeFlags::HAS_FREE_LOCAL_REGIONS
                     | TypeFlags::HAS_FREE_REGIONS
             }
-            LifetimeData::Static | LifetimeData::Empty(_) => TypeFlags::HAS_FREE_REGIONS,
+            LifetimeData::Static => TypeFlags::HAS_FREE_REGIONS,
             LifetimeData::Phantom(_, _) => TypeFlags::empty(),
             LifetimeData::BoundVar(_) => TypeFlags::HAS_RE_LATE_BOUND,
             LifetimeData::Erased => TypeFlags::HAS_RE_ERASED,
@@ -1316,11 +1315,6 @@ pub enum LifetimeData<I: Interner> {
     Placeholder(PlaceholderIndex),
     /// Static lifetime
     Static,
-    /// An empty lifetime: a lifetime shorter than any other lifetime in a
-    /// universe with a lesser or equal index. The universe only non-zero in
-    /// lexical region resolve in rustc, so chalk shouldn't ever see a non-zero
-    /// index.
-    Empty(UniverseIndex),
     /// An erased lifetime, used by rustc to improve caching when we doesn't
     /// care about lifetimes
     Erased,

--- a/chalk-ir/src/visit.rs
+++ b/chalk-ir/src/visit.rs
@@ -330,9 +330,7 @@ impl<I: Interner> TypeSuperVisitable<I> for Lifetime<I> {
             LifetimeData::Placeholder(universe) => {
                 visitor.visit_free_placeholder(*universe, outer_binder)
             }
-            LifetimeData::Static | LifetimeData::Empty(_) | LifetimeData::Erased => {
-                ControlFlow::Continue(())
-            }
+            LifetimeData::Static | LifetimeData::Erased => ControlFlow::Continue(()),
             LifetimeData::Phantom(void, ..) => match *void {},
         }
     }

--- a/chalk-parse/src/ast.rs
+++ b/chalk-parse/src/ast.rs
@@ -391,7 +391,6 @@ pub enum Lifetime {
     Id { name: Identifier },
     Static,
     Erased,
-    Empty,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/chalk-parse/src/parser.lalrpop
+++ b/chalk-parse/src/parser.lalrpop
@@ -492,7 +492,6 @@ Lifetime: Lifetime = {
     <n:LifetimeId> => Lifetime::Id { name: n },
     "'static" => Lifetime::Static,
     "'erased" => Lifetime::Erased,
-    "'empty" => Lifetime::Empty,
 };
 
 ConstWithoutId: Const = {

--- a/chalk-solve/src/display/ty.rs
+++ b/chalk-solve/src/display/ty.rs
@@ -240,7 +240,6 @@ impl<I: Interner> RenderAsRust<I> for LifetimeData<I> {
                 write!(f, "'_placeholder_{}_{}", ix.ui.counter, ix.idx)
             }
             LifetimeData::Static => write!(f, "'static"),
-            LifetimeData::Empty(_) => write!(f, "'<empty>"),
             LifetimeData::Erased => write!(f, "'_"),
             // Matching the void ensures at compile time that this code is
             // unreachable

--- a/chalk-solve/src/infer/canonicalize.rs
+++ b/chalk-solve/src/infer/canonicalize.rs
@@ -1,7 +1,7 @@
 use crate::debug_span;
 use chalk_derive::FallibleTypeFolder;
 use chalk_ir::fold::shift::Shift;
-use chalk_ir::fold::{TypeFoldable, TypeFolder, TypeSuperFoldable};
+use chalk_ir::fold::{TypeFoldable, TypeFolder};
 use chalk_ir::interner::{HasInterner, Interner};
 use chalk_ir::*;
 use std::cmp::max;
@@ -228,17 +228,6 @@ impl<'i, I: Interner> TypeFolder<I> for Canonicalizer<'i, I> {
                     .shifted_in_from(outer_binder)
                     .to_const(interner, ty)
             }
-        }
-    }
-
-    fn fold_lifetime(&mut self, lifetime: Lifetime<I>, outer_binder: DebruijnIndex) -> Lifetime<I> {
-        match *lifetime.data(self.interner) {
-            LifetimeData::Empty(ui) if ui.counter != 0 => {
-                // ReEmpty in non-root universes is only used by lexical region
-                // inference. We shouldn't see it in canonicalization.
-                panic!("Cannot canonicalize ReEmpty in non-root universe")
-            }
-            _ => lifetime.super_fold_with(self, outer_binder),
         }
     }
 

--- a/chalk-solve/src/infer/unify.rs
+++ b/chalk-solve/src/infer/unify.rs
@@ -955,18 +955,12 @@ impl<'t, I: Interner> Unifier<'t, I> {
             (
                 &LifetimeData::InferenceVar(a_var),
                 &LifetimeData::Placeholder(PlaceholderIndex { ui, .. }),
-            )
-            | (&LifetimeData::InferenceVar(a_var), &LifetimeData::Empty(ui)) => {
-                self.unify_lifetime_var(variance, a_var, b, ui)
-            }
+            ) => self.unify_lifetime_var(variance, a_var, b, ui),
 
             (
                 &LifetimeData::Placeholder(PlaceholderIndex { ui, .. }),
                 &LifetimeData::InferenceVar(b_var),
-            )
-            | (&LifetimeData::Empty(ui), &LifetimeData::InferenceVar(b_var)) => {
-                self.unify_lifetime_var(variance.invert(), b_var, a, ui)
-            }
+            ) => self.unify_lifetime_var(variance.invert(), b_var, a, ui),
 
             (&LifetimeData::InferenceVar(a_var), &LifetimeData::Erased)
             | (&LifetimeData::InferenceVar(a_var), &LifetimeData::Static) => {
@@ -982,19 +976,12 @@ impl<'t, I: Interner> Unifier<'t, I> {
             | (&LifetimeData::Erased, &LifetimeData::Erased) => Ok(()),
 
             (&LifetimeData::Static, &LifetimeData::Placeholder(_))
-            | (&LifetimeData::Static, &LifetimeData::Empty(_))
             | (&LifetimeData::Static, &LifetimeData::Erased)
             | (&LifetimeData::Placeholder(_), &LifetimeData::Static)
             | (&LifetimeData::Placeholder(_), &LifetimeData::Placeholder(_))
-            | (&LifetimeData::Placeholder(_), &LifetimeData::Empty(_))
             | (&LifetimeData::Placeholder(_), &LifetimeData::Erased)
-            | (&LifetimeData::Empty(_), &LifetimeData::Static)
-            | (&LifetimeData::Empty(_), &LifetimeData::Placeholder(_))
-            | (&LifetimeData::Empty(_), &LifetimeData::Empty(_))
-            | (&LifetimeData::Empty(_), &LifetimeData::Erased)
             | (&LifetimeData::Erased, &LifetimeData::Static)
-            | (&LifetimeData::Erased, &LifetimeData::Placeholder(_))
-            | (&LifetimeData::Erased, &LifetimeData::Empty(_)) => {
+            | (&LifetimeData::Erased, &LifetimeData::Placeholder(_)) => {
                 if a != b {
                     self.push_lifetime_outlives_goals(variance, a.clone(), b.clone());
                     Ok(())

--- a/tests/test/lifetimes.rs
+++ b/tests/test/lifetimes.rs
@@ -25,17 +25,6 @@ fn erased_lowering() {
 }
 
 #[test]
-fn empty_lowering() {
-    lowering_success! {
-        program {
-            struct A<'a> where 'a: 'empty {}
-            trait B<'a> where 'a: 'empty {}
-            fn foo(a: &'empty ());
-        }
-    }
-}
-
-#[test]
 fn static_outlives() {
     test! {
         program {
@@ -59,34 +48,6 @@ fn static_outlives() {
             }
         } yields {
             expect![["Unique; lifetime constraints [InEnvironment { environment: Env([]), goal: '!1_0: 'static }]"]]
-        }
-    }
-}
-
-#[test]
-fn empty_outlives() {
-    test! {
-        program {
-            trait Foo<'a> where 'a: 'empty {}
-            struct Bar {}
-
-            impl<'a> Foo<'a> for Bar where 'a: 'empty {}
-        }
-
-        goal {
-            exists<'a> {
-                Bar: Foo<'a>
-            }
-        } yields {
-            expect![["Unique; for<?U0> { substitution [?0 := '^0.0], lifetime constraints [InEnvironment { environment: Env([]), goal: '^0.0: '<empty> }] }"]]
-        }
-
-        goal {
-            forall<'a> {
-                Bar: Foo<'a>
-            }
-        } yields {
-            expect![["Unique; lifetime constraints [InEnvironment { environment: Env([]), goal: '!1_0: '<empty> }]"]]
         }
     }
 }
@@ -159,23 +120,6 @@ fn erased_impls() {
 
         goal {
             &'erased Foo: Bar
-        } yields {
-            expect![["Unique"]]
-        }
-    }
-}
-
-#[test]
-fn empty_impls() {
-    test! {
-        program {
-            struct Foo {}
-            trait Bar {}
-            impl<'a> Bar for &'a Foo {}
-        }
-
-        goal {
-            &'empty Foo: Bar
         } yields {
             expect![["Unique"]]
         }


### PR DESCRIPTION
It's no longer present in rustc, so we probably don't need it in Chalk either.