### PR TITLE
Fix dyn program clause generation and make returning a ClosureKind optional

### DIFF
--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -199,7 +199,7 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         &self,
         closure_id: ClosureId<ChalkIr>,
         substs: &Substitution<ChalkIr>,
-    ) -> ClosureKind {
+    ) -> Option<ClosureKind> {
         self.program_ir().unwrap().closure_kind(closure_id, substs)
     }
 

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -557,7 +557,7 @@ impl RustIrDatabase<ChalkIr> for Program {
         &self,
         closure_id: ClosureId<ChalkIr>,
         _substs: &Substitution<ChalkIr>,
-    ) -> ClosureKind {
+    ) -> Option<ClosureKind> {
         self.closure_closure_kind[&closure_id]
     }
 

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -1062,9 +1062,12 @@ fn match_ty<I: Interner>(
             let generalized_ty =
                 generalize::Generalize::apply(builder.db.interner(), dyn_ty.clone());
             builder.push_binders(generalized_ty, |builder, dyn_ty| {
-                let bounds = dyn_ty
-                    .bounds
-                    .substitute(interner, &[ty.clone().cast::<GenericArg<I>>(interner)]);
+                let dyn_ty_ty = chalk_ir::Ty::new(interner, TyKind::Dyn(dyn_ty.clone()));
+                let arg: chalk_ir::GenericArg<I> = chalk_ir::GenericArg::new(
+                    interner,
+                    chalk_ir::GenericArgData::Ty(dyn_ty_ty.clone()),
+                );
+                let bounds = dyn_ty.bounds.substitute(interner, &[arg.clone()]);
 
                 let mut wf_goals = Vec::new();
 
@@ -1081,7 +1084,7 @@ fn match_ty<I: Interner>(
                     })
                 }));
 
-                builder.push_clause(WellFormed::Ty(ty.clone()), wf_goals);
+                builder.push_clause(WellFormed::Ty(dyn_ty_ty), wf_goals);
             });
         }
     }

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -164,6 +164,7 @@ pub fn push_auto_trait_impls<I: Interner>(
         TyKind::Closure(closure_id, substs) => {
             let closure_fn_substitution = builder.db.closure_fn_substitution(*closure_id, substs);
             let binders = builder.db.closure_upvars(*closure_id, substs);
+            debug!(?binders, ?closure_fn_substitution);
             let upvars = binders.substitute(builder.db.interner(), &closure_fn_substitution);
 
             // in a same behavior as for non-auto traits (reuse the code) we can require that

--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -1,6 +1,8 @@
 use super::{builder::ClauseBuilder, generalize};
 use crate::{CanonicalVarKinds, Interner, RustIrDatabase, TraitRef, WellKnownTrait};
 use chalk_ir::{Floundered, Substitution, Ty};
+use tracing::instrument;
+
 
 mod clone;
 mod copy;
@@ -99,6 +101,7 @@ pub fn add_builtin_assoc_program_clauses<I: Interner>(
 
 /// Given a trait ref `T0: Trait` and a list of types `U0..Un`, pushes a clause of the form
 /// `Implemented(T0: Trait) :- Implemented(U0: Trait) .. Implemented(Un: Trait)`
+#[instrument(level = "debug", skip(db, builder, tys))]
 pub fn needs_impl_for_tys<I: Interner>(
     db: &dyn RustIrDatabase<I>,
     builder: &mut ClauseBuilder<'_, I>,

--- a/chalk-solve/src/clauses/builtin_traits/fn_family.rs
+++ b/chalk-solve/src/clauses/builtin_traits/fn_family.rs
@@ -109,6 +109,12 @@ pub fn add_fn_trait_program_clauses<I: Interner>(
         }
         TyKind::Closure(closure_id, substitution) => {
             let closure_kind = db.closure_kind(*closure_id, substitution);
+            let closure_kind = match  closure_kind{
+                Some(k) => k,
+                // If we haven't resolved the closure kind yet, don't add any program clauses.
+                // Really, we *could* add `FnOnce`, since closures will always at least be that.
+                None => return,
+            };
             let trait_matches = matches!(
                 (well_known, closure_kind),
                 (WellKnownTrait::Fn, ClosureKind::Fn)

--- a/chalk-solve/src/clauses/program_clauses.rs
+++ b/chalk-solve/src/clauses/program_clauses.rs
@@ -5,7 +5,7 @@ use chalk_ir::cast::{Cast, Caster};
 use chalk_ir::interner::Interner;
 use chalk_ir::*;
 use std::iter;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 /// Trait for lowering a given piece of rust-ir source (e.g., an impl
 /// or struct definition) into its associated "program clauses" --

--- a/chalk-solve/src/display/stub.rs
+++ b/chalk-solve/src/display/stub.rs
@@ -199,7 +199,7 @@ impl<I: Interner, DB: RustIrDatabase<I>> RustIrDatabase<I> for StubWrapper<'_, D
         &self,
         _closure_id: chalk_ir::ClosureId<I>,
         _substs: &chalk_ir::Substitution<I>,
-    ) -> crate::rust_ir::ClosureKind {
+    ) -> Option<crate::rust_ir::ClosureKind> {
         unimplemented!("cannot stub closures")
     }
 

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -132,7 +132,10 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     fn is_object_safe(&self, trait_id: TraitId<I>) -> bool;
 
     /// Gets the `ClosureKind` for a given closure and substitution.
-    fn closure_kind(&self, closure_id: ClosureId<I>, substs: &Substitution<I>) -> ClosureKind;
+    ///
+    /// Sometimes we don't know the `ClosureKind` yet. In that case, we return `None`.
+    /// This probably isn't right and should probably be changed back to be infallible later.
+    fn closure_kind(&self, closure_id: ClosureId<I>, substs: &Substitution<I>) -> Option<ClosureKind>;
 
     /// Gets the inputs and output for a given closure id and substitution. We
     /// pass both the `ClosureId` and it's `Substituion` to give implementors

--- a/chalk-solve/src/logging_db.rs
+++ b/chalk-solve/src/logging_db.rs
@@ -262,7 +262,7 @@ where
         self.ws.db().fn_def_name(fn_def_id)
     }
 
-    fn closure_kind(&self, closure_id: ClosureId<I>, substs: &Substitution<I>) -> ClosureKind {
+    fn closure_kind(&self, closure_id: ClosureId<I>, substs: &Substitution<I>) -> Option<ClosureKind> {
         // TODO: record closure IDs
         self.ws.db().closure_kind(closure_id, substs)
     }
@@ -516,7 +516,7 @@ where
         self.db.fn_def_name(fn_def_id)
     }
 
-    fn closure_kind(&self, closure_id: ClosureId<I>, substs: &Substitution<I>) -> ClosureKind {
+    fn closure_kind(&self, closure_id: ClosureId<I>, substs: &Substitution<I>) -> Option<ClosureKind> {
         // TODO: record closure IDs
         self.db.closure_kind(closure_id, substs)
     }

--- a/tests/display/unique_names.rs
+++ b/tests/display/unique_names.rs
@@ -164,7 +164,7 @@ where
         &self,
         closure_id: chalk_ir::ClosureId<I>,
         substs: &chalk_ir::Substitution<I>,
-    ) -> chalk_solve::rust_ir::ClosureKind {
+    ) -> Option<chalk_solve::rust_ir::ClosureKind> {
         self.db.closure_kind(closure_id, substs)
     }
     fn closure_inputs_and_output(

--- a/tests/integration/panic.rs
+++ b/tests/integration/panic.rs
@@ -238,7 +238,7 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
         &self,
         closure_id: ClosureId<ChalkIr>,
         substs: &Substitution<ChalkIr>,
-    ) -> ClosureKind {
+    ) -> Option<ClosureKind> {
         unimplemented!()
     }
 


### PR DESCRIPTION
When creating dyn ty program clauses, we need to use the ty returned from the builder, not the original self type.

ClosureKind change is iffy - likely not correct, but it changes some rustc integration ICEs to errors.