### PR TITLE
Generate clauses for placeholder associated types

### DIFF
--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -440,6 +440,11 @@ pub fn program_clauses_that_could_match<I: Interner>(
                         .to_program_clauses(builder, environment);
                 }
 
+                TyKind::AssociatedType(assoc_ty_id, _) => {
+                    db.associated_ty_data(*assoc_ty_id)
+                        .to_program_clauses(builder, environment);
+                }
+
                 TyKind::Dyn(_) => {
                     // If the self type is a `dyn trait` type, generate program-clauses
                     // that indicates that it implements its own traits.
@@ -517,6 +522,10 @@ pub fn program_clauses_that_could_match<I: Interner>(
                     }
                     TyKind::OpaqueType(opaque_ty_id, _) => {
                         db.opaque_ty_data(*opaque_ty_id)
+                            .to_program_clauses(builder, environment);
+                    }
+                    TyKind::AssociatedType(assoc_ty_id, _) => {
+                        db.associated_ty_data(*assoc_ty_id)
                             .to_program_clauses(builder, environment);
                     }
                     // If the self type is a `dyn trait` type, generate program-clauses

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -1226,3 +1226,50 @@ fn nested_proj_eq_nested_proj_should_flounder() {
         }
     }
 }
+
+#[test]
+fn clauses_for_placeholder_projection_types() {
+    test! {
+        program {
+            trait Iterator { type Item; }
+            trait IntoIterator {
+                type Item;
+                type IntoIter: Iterator<Item = <Self as IntoIterator>::Item>;
+            }
+
+            struct Vec<T> { }
+            impl<T> IntoIterator for Vec<T> {
+                type Item = T;
+                type IntoIter = Iter<T>;
+            }
+
+            struct Iter<T> { }
+            impl<T> Iterator for Iter<T> {
+                type Item = T;
+            }
+
+            opaque type Opaque<T>: IntoIterator<Item = T> = Vec<T>;
+        }
+
+        goal {
+            forall<T> {
+                <Opaque<T> as IntoIterator>::IntoIter: Iterator
+            }
+        } yields {
+            expect![[r#"Unique"#]]
+        }
+
+        goal {
+            forall<T> {
+                exists<U> {
+                    <<Opaque<T> as IntoIterator>::IntoIter as Iterator>::Item = U
+                }
+            }
+        } yields[SolverChoice::slg_default()] {
+            // FIXME: chalk#234?
+            expect![[r#"Ambiguous; no inference guidance"#]]
+        } yields[SolverChoice::recursive_default()] {
+            expect![[r#"Unique; substitution [?0 := !1_0]"#]]
+        }
+    }
+}


### PR DESCRIPTION
Currently, we don't generate clauses for placeholder associated types (`TyKind::AssociatedType`) except for some `FromEnv`s. This leads to `NoSolution` for goals like `(IntoIterator::IntoIter)<Opaque>: Iterator` where `Opaque = impl IntoIterator`.

For every associated type in a trait definition

```rust
trait Foo {
    type Assoc<'a, T>: Bar<U = Ty> where WC;
}
```

chalk with this patch generates

```rust
forall<Self, 'a, T> {
    Implemented((Foo::Assoc<'a, T>)<Self>: Bar) :- WC.
    AliasEq(<<(Foo::Assoc<'a, T>)<Self>> as Bar>::U = Ty) :- WC.
}
```

To be honest, I'm not entirely sure if `AssociatedTyDatum::to_program_clauses()` is the best place to generate those clauses in, but analogous clauses for placeholder opaque types are generated in `OpaqueTyDatum::to_program_clauses()`, which I modeled after.

Spotted in rust-lang/rust-analyzer#14680.