### PR TITLE
fix: generalize types before generating built-in `Normalize` clauses

### DIFF
--- a/chalk-solve/src/clauses/builtin_traits.rs
+++ b/chalk-solve/src/clauses/builtin_traits.rs
@@ -78,39 +78,21 @@ pub fn add_builtin_assoc_program_clauses<I: Interner>(
     well_known: WellKnownTrait,
     self_ty: Ty<I>,
 ) -> Result<(), Floundered> {
-    match well_known {
+    // If `self_ty` contains bound vars, we want to universally quantify them.
+    // `Generalize` collects them for us.
+    let generalized = generalize::Generalize::apply(db.interner(), self_ty);
+    builder.push_binders(generalized, |builder, self_ty| match well_known {
         WellKnownTrait::FnOnce => {
-            // If `self_ty` contains bound vars, we want to universally quantify them.
-            // `Generalize` collects them for us.
-            let generalized = generalize::Generalize::apply(db.interner(), self_ty);
-
-            builder.push_binders(generalized, |builder, self_ty| {
-                fn_family::add_fn_trait_program_clauses(db, builder, well_known, self_ty);
-                Ok(())
-            })
+            fn_family::add_fn_trait_program_clauses(db, builder, well_known, self_ty);
+            Ok(())
         }
-        WellKnownTrait::Pointee => {
-            // If `self_ty` contains bound vars, we want to universally quantify them.
-            // `Generalize` collects them for us.
-            let generalized = generalize::Generalize::apply(db.interner(), self_ty);
-
-            builder.push_binders(generalized, |builder, self_ty| {
-                pointee::add_pointee_program_clauses(db, builder, self_ty)?;
-                Ok(())
-            })
-        }
+        WellKnownTrait::Pointee => pointee::add_pointee_program_clauses(db, builder, self_ty),
         WellKnownTrait::DiscriminantKind => {
             discriminant_kind::add_discriminant_clauses(db, builder, self_ty)
         }
-        WellKnownTrait::Generator => {
-            let generalized = generalize::Generalize::apply(db.interner(), self_ty);
-
-            builder.push_binders(generalized, |builder, self_ty| {
-                generator::add_generator_program_clauses(db, builder, self_ty)
-            })
-        }
+        WellKnownTrait::Generator => generator::add_generator_program_clauses(db, builder, self_ty),
         _ => Ok(()),
-    }
+    })
 }
 
 /// Returns type of the last field of the input struct, which is useful for `Sized` and related

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -196,7 +196,7 @@ pub trait RustIrDatabase<I: Interner>: Debug {
         sanitize_debug_name(|f| I::debug_fn_def_id(fn_def_id, f))
     }
 
-    // Retrieves the discriminant type for a type (mirror of rustc `TyS::discriminant_ty`)
+    // Retrieves the discriminant type for a type (mirror of rustc `Ty::discriminant_ty`)
     fn discriminant_type(&self, ty: Ty<I>) -> Ty<I>;
 }
 

--- a/tests/test/discriminant_kind.rs
+++ b/tests/test/discriminant_kind.rs
@@ -164,3 +164,25 @@ fn discriminant_kind_assoc() {
         }
     }
 }
+
+#[test]
+fn discriminant_kind_with_infer_var() {
+    test! {
+        program {
+            #[lang(discriminant_kind)]
+            trait DiscriminantKind {
+                type Discriminant;
+            }
+
+            enum Option<T> {}
+        }
+
+        goal {
+            exists<T> {
+                Normalize(<Option<T> as DiscriminantKind>::Discriminant -> isize)
+            }
+        } yields {
+            expect![[r#"Unique; for<?U0> { substitution [?0 := ^0.0] }"#]]
+        }
+    }
+}


### PR DESCRIPTION
When we generate built-in `Normalize` clauses, `self_ty` in the original goal may contain bound variables that prevent us from using it as-is. We need to universally quantify over the bound variables before passing it to trait-specific clause generators, which we've been failing to do for `DiscriminantKind`.

cc rust-lang/rust-analyzer#15113