### PR TITLE
Pin cargo-workspaces to 0.2.44

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-workspaces
+          version: 0.2.44
 
       - name: Install Node (for changelog generation)
         uses: actions/setup-node@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
The publish action was failing due some problem in the `cargo-workspaces` (see [this zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/Chalk.20release.20failure)). The problem is now solved, so this PR is not necessary and just triggering the publish again should work, but this PR pin it to the current version to prevent similar problems in future.