### PR TITLE
Push DiscriminantKind implementation fact unconditionally

### DIFF
--- a/tests/test/discriminant_kind.rs
+++ b/tests/test/discriminant_kind.rs
@@ -156,11 +156,11 @@ fn discriminant_kind_assoc() {
         goal {
             forall<T> {
                 exists<U> {
-                    Normalize(<T as DiscriminantKind>::Discriminant -> U)
+                    <T as DiscriminantKind>::Discriminant = U
                 }
             }
         } yields {
-            expect![["Ambiguous; no inference guidance"]]
+            expect![["Unique; substitution [?0 := (DiscriminantKind::Discriminant)<!1_0>]"]]
         }
     }
 }


### PR DESCRIPTION
This makes r-a infer the output type of `discriminant_value` intrinsic as `<T as DiscriminantKind>::Discriminant` instead of unknown.