### PR TITLE
chalk-solve: upgrade petgraph to version 0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
  "chalk-parse",
  "chalk-recursive",
  "chalk-solve",
- "indexmap",
+ "indexmap 1.8.0",
  "salsa",
  "string_cache",
  "tracing",
@@ -188,9 +188,9 @@ dependencies = [
  "chalk-integration",
  "chalk-ir",
  "ena",
- "indexmap",
+ "indexmap 1.8.0",
  "itertools",
- "petgraph",
+ "petgraph 0.6.4",
  "rustc-hash",
  "tracing",
  "tracing-subscriber",
@@ -289,6 +289,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "expect-test"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +309,12 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fs2"
@@ -332,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,7 +374,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -390,7 +418,7 @@ dependencies = [
  "ena",
  "itertools",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.5.1",
  "pico-args",
  "regex",
  "regex-syntax",
@@ -524,8 +552,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset",
- "indexmap",
+ "fixedbitset 0.2.0",
+ "indexmap 1.8.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.0.0",
 ]
 
 [[package]]
@@ -669,7 +707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b84d9f96071f3f3be0dc818eae3327625d8ebc95b58da37d6850724f31d3403"
 dependencies = [
  "crossbeam-utils",
- "indexmap",
+ "indexmap 1.8.0",
  "lock_api",
  "log",
  "oorandom",

--- a/chalk-solve/Cargo.toml
+++ b/chalk-solve/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 ena = "0.14.0"
 itertools = "0.10.0"
-petgraph = "0.5.1"
+petgraph = "0.6.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter"] }
 tracing-tree = { version = "0.2", optional = true }


### PR DESCRIPTION
Version 0.5.1 contained a soundness bug that has since been fixed: https://github.com/petgraph/petgraph/commit/618af3d5d53dd613036629dd78fb5ffe34aefb50.