### PR TITLE
Configure CI for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,7 @@
 name: CI
 on:
-  push:
-    branches:
-      - master
-      - auto
-      - try
+  merge_group:
   pull_request:
-    branches:
-      - "**"
 
 jobs:
   test:
@@ -111,22 +105,15 @@ jobs:
       - name: Build Chalk book
         run: cd book && ./mdbook build
 
-  end-success:
-    name: bors build finished
-    if: success()
-    runs-on: ubuntu-latest
+  conclusion:
     needs: [test, fmt]
-
-    steps:
-      - name: Mark the job as successful
-        run: exit 0
-
-  end-failure:
-    name: bors build finished
-    if: "!success()"
+    # !cancelled() executes the job regardless of whether the previous jobs passed, failed or get skipped.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    needs: [test, fmt]
-
     steps:
-      - name: Mark the job as a failure
-        run: exit 1
+      - name: Conclusion
+        run: |
+          # Print the dependent jobs to see them in the CI log
+          jq -C <<< '${{ toJson(needs) }}'
+          # Check if all jobs that we depend on (in the needs array) were successful.
+          jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'


### PR DESCRIPTION
To remove bors, which is not really needed for this repo.

The `mdbook-linkcheck` job wasn't required before for bors, so I also did not add it as required for the merge queue checks.

This PR should be merged with cooperation from an infra-admin.