### PR TITLE
bump version -> 0.99.0-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chalk"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 dependencies = [
  "chalk-derive",
  "chalk-engine",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-derive"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 dependencies = [
  "chalk-derive",
  "chalk-integration",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-integration"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 dependencies = [
  "chalk-derive",
  "chalk-engine",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-ir"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 dependencies = [
  "bitflags 2.4.1",
  "chalk-derive",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-parse"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-recursive"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 dependencies = [
  "chalk-derive",
  "chalk-integration",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 dependencies = [
  "chalk-derive",
  "chalk-integration",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 description = "Model of the Rust trait system"
 license = "MIT OR Apache-2.0"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -21,13 +21,13 @@ salsa = "0.16.0"
 serde = "1.0"
 serde_derive = "1.0"
 
-chalk-derive = { version = "0.98.0-dev.0", path = "chalk-derive" }
-chalk-engine = { version = "0.98.0-dev.0", path = "chalk-engine" }
-chalk-ir = { version = "0.98.0-dev.0", path = "chalk-ir" }
-chalk-solve = { version = "0.98.0-dev.0", path = "chalk-solve" }
-chalk-recursive = { version = "0.98.0-dev.0", path = "chalk-recursive" }
-chalk-parse = { version = "0.98.0-dev.0", path = "chalk-parse" }
-chalk-integration = { version = "0.98.0-dev.0", path = "chalk-integration" }
+chalk-derive = { version = "0.99.0-dev.0", path = "chalk-derive" }
+chalk-engine = { version = "0.99.0-dev.0", path = "chalk-engine" }
+chalk-ir = { version = "0.99.0-dev.0", path = "chalk-ir" }
+chalk-solve = { version = "0.99.0-dev.0", path = "chalk-solve" }
+chalk-recursive = { version = "0.99.0-dev.0", path = "chalk-recursive" }
+chalk-parse = { version = "0.99.0-dev.0", path = "chalk-parse" }
+chalk-integration = { version = "0.99.0-dev.0", path = "chalk-integration" }
 
 [workspace]
 

--- a/chalk-derive/Cargo.toml
+++ b/chalk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-derive"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 description = "A helper crate for use by chalk crates for `derive` macros."
 license = "MIT OR Apache-2.0"
 authors = ["Rust Compiler Team", "Chalk developers"]

--- a/chalk-engine/Cargo.toml
+++ b/chalk-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-engine"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 description = "Core trait engine from Chalk project"
 license = "MIT OR Apache-2.0"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -16,9 +16,9 @@ default = []
 rustc-hash = { version = "1.1.0" }
 tracing = "0.1"
 
-chalk-derive = { version = "0.98.0-dev.0", path = "../chalk-derive" }
-chalk-ir = { version = "0.98.0-dev.0", path = "../chalk-ir" }
-chalk-solve = { version = "0.98.0-dev.0", path = "../chalk-solve" }
+chalk-derive = { version = "0.99.0-dev.0", path = "../chalk-derive" }
+chalk-ir = { version = "0.99.0-dev.0", path = "../chalk-ir" }
+chalk-solve = { version = "0.99.0-dev.0", path = "../chalk-solve" }
 
 [dev-dependencies]
 chalk-integration = { path = "../chalk-integration" }

--- a/chalk-integration/Cargo.toml
+++ b/chalk-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-integration"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 license = "MIT OR Apache-2.0"
 description = "Sample solver setup for Chalk"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -14,10 +14,10 @@ string_cache = "0.8.0"
 salsa = "0.16.0"
 tracing = "0.1"
 
-chalk-derive = { version = "0.98.0-dev.0", path = "../chalk-derive" }
-chalk-ir = { version = "0.98.0-dev.0", path = "../chalk-ir" }
-chalk-solve = { version = "0.98.0-dev.0", path = "../chalk-solve" }
-chalk-recursive = { version = "0.98.0-dev.0", path = "../chalk-recursive" }
-chalk-engine = { version = "0.98.0-dev.0", path = "../chalk-engine" }
-chalk-parse = { version = "0.98.0-dev.0", path = "../chalk-parse" }
+chalk-derive = { version = "0.99.0-dev.0", path = "../chalk-derive" }
+chalk-ir = { version = "0.99.0-dev.0", path = "../chalk-ir" }
+chalk-solve = { version = "0.99.0-dev.0", path = "../chalk-solve" }
+chalk-recursive = { version = "0.99.0-dev.0", path = "../chalk-recursive" }
+chalk-engine = { version = "0.99.0-dev.0", path = "../chalk-engine" }
+chalk-parse = { version = "0.99.0-dev.0", path = "../chalk-parse" }
 indexmap = "2"

--- a/chalk-ir/Cargo.toml
+++ b/chalk-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-ir"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 description = "Chalk's internal representation of types, goals, and clauses"
 license = "MIT OR Apache-2.0"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -11,4 +11,4 @@ edition = "2018"
 
 [dependencies]
 bitflags = "2.4.1"
-chalk-derive = { version = "0.98.0-dev.0", path = "../chalk-derive" }
+chalk-derive = { version = "0.99.0-dev.0", path = "../chalk-derive" }

--- a/chalk-parse/Cargo.toml
+++ b/chalk-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-parse"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 description = "Parser for the Chalk project"
 license = "MIT OR Apache-2.0"
 authors = ["Rust Compiler Team", "Chalk developers"]

--- a/chalk-recursive/Cargo.toml
+++ b/chalk-recursive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-recursive"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 description = "Recursive solver for the Chalk project"
 license = "MIT OR Apache-2.0"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -13,9 +13,9 @@ edition = "2018"
 rustc-hash = { version = "1.1.0" }
 tracing = "0.1"
 
-chalk-derive = { version = "0.98.0-dev.0", path = "../chalk-derive" }
-chalk-ir = { version = "0.98.0-dev.0", path = "../chalk-ir" }
-chalk-solve = { version = "0.98.0-dev.0", path = "../chalk-solve", default-features = false }
+chalk-derive = { version = "0.99.0-dev.0", path = "../chalk-derive" }
+chalk-ir = { version = "0.99.0-dev.0", path = "../chalk-ir" }
+chalk-solve = { version = "0.99.0-dev.0", path = "../chalk-solve", default-features = false }
 
 [dev-dependencies]
 chalk-integration = { path = "../chalk-integration" }

--- a/chalk-solve/Cargo.toml
+++ b/chalk-solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chalk-solve"
-version = "0.98.0-dev.0"
+version = "0.99.0-dev.0"
 description = "Combines the chalk-engine with chalk-ir"
 license = "MIT OR Apache-2.0"
 authors = ["Rust Compiler Team", "Chalk developers"]
@@ -18,8 +18,8 @@ tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter
 tracing-tree = { version = "0.3", optional = true }
 rustc-hash = { version = "1.1.0" }
 
-chalk-derive = { version = "0.98.0-dev.0", path = "../chalk-derive" }
-chalk-ir = { version = "0.98.0-dev.0", path = "../chalk-ir" }
+chalk-derive = { version = "0.99.0-dev.0", path = "../chalk-derive" }
+chalk-ir = { version = "0.99.0-dev.0", path = "../chalk-ir" }
 indexmap = "2"
 
 [dev-dependencies]


### PR DESCRIPTION
Similarly to https://github.com/rust-lang/chalk/pull/813.
The release is needed to allow r-a to use #821.