### PR TITLE
Add `associated_ty_from_impl` to Chalk db to avoid computing associated types eagerly

### DIFF
--- a/book/src/clauses/coherence.md
+++ b/book/src/clauses/coherence.md
@@ -19,7 +19,7 @@ To check for coherence, the Rust compiler completes two separate but related che
 - [Coherence - talk by withoutboats](https://www.youtube.com/watch?v=AI7SLCubTnk&t=43m19s)
 - [Little Orphan Impls](https://smallcultfollowing.com/babysteps/blog/2015/01/14/little-orphan-impls/)
 - [RFC 1023 Rebalancing Coherence](https://rust-lang.github.io/rfcs/1023-rebalancing-coherence.html)
-- [Type classes: confluence, coherence and global uniqueness](http://blog.ezyang.com/2014/07/type-classes-confluence-coherence-global-uniqueness/)
+- [Type classes: confluence, coherence and global uniqueness](https://web.archive.org/web/20250308110404/https://blog.ezyang.com/2014/07/type-classes-confluence-coherence-global-uniqueness/)
 ## Axioms & Properties of Coherence
 > Historical Note: We used to use the term “external” instead of “upstream”.
 

--- a/chalk-integration/src/db.rs
+++ b/chalk-integration/src/db.rs
@@ -99,6 +99,19 @@ impl RustIrDatabase<ChalkIr> for ChalkDatabase {
         self.program_ir().unwrap().impl_datum(id)
     }
 
+    fn associated_ty_from_impl(
+        &self,
+        impl_id: ImplId<ChalkIr>,
+        assoc_type_id: AssocTypeId<ChalkIr>,
+    ) -> Option<AssociatedTyValueId<ChalkIr>> {
+        let ir = self.program_ir().unwrap();
+        ir.impl_data[&impl_id]
+            .associated_ty_value_ids
+            .iter()
+            .copied()
+            .find(|id| ir.associated_ty_values[id].associated_ty_id == assoc_type_id)
+    }
+
     fn associated_ty_value(
         &self,
         id: AssociatedTyValueId<ChalkIr>,

--- a/chalk-integration/src/program.rs
+++ b/chalk-integration/src/program.rs
@@ -398,6 +398,18 @@ impl RustIrDatabase<ChalkIr> for Program {
         self.impl_data[&id].clone()
     }
 
+    fn associated_ty_from_impl(
+        &self,
+        impl_id: ImplId<ChalkIr>,
+        assoc_type_id: AssocTypeId<ChalkIr>,
+    ) -> Option<AssociatedTyValueId<ChalkIr>> {
+        self.impl_data[&impl_id]
+            .associated_ty_value_ids
+            .iter()
+            .copied()
+            .find(|id| self.associated_ty_values[id].associated_ty_id == assoc_type_id)
+    }
+
     fn associated_ty_value(
         &self,
         id: AssociatedTyValueId<ChalkIr>,

--- a/chalk-solve/src/clauses.rs
+++ b/chalk-solve/src/clauses.rs
@@ -639,6 +639,7 @@ pub fn program_clauses_that_could_match<I: Interner>(
                     builder,
                     environment,
                     trait_id,
+                    proj.associated_ty_id,
                     trait_parameters,
                     binders,
                 );
@@ -749,6 +750,7 @@ fn push_program_clauses_for_associated_type_values_in_impls_of<I: Interner>(
     builder: &mut ClauseBuilder<'_, I>,
     environment: &Environment<I>,
     trait_id: TraitId<I>,
+    assoc_id: AssocTypeId<I>,
     trait_parameters: &[GenericArg<I>],
     binders: &CanonicalVarKinds<I>,
 ) {
@@ -763,7 +765,7 @@ fn push_program_clauses_for_associated_type_values_in_impls_of<I: Interner>(
 
         debug!(?impl_id);
 
-        for &atv_id in &impl_datum.associated_ty_value_ids {
+        if let Some(atv_id) = builder.db.associated_ty_from_impl(impl_id, assoc_id) {
             let atv = builder.db.associated_ty_value(atv_id);
             debug!(?atv_id, ?atv);
             atv.to_program_clauses(builder, environment);

--- a/chalk-solve/src/display/stub.rs
+++ b/chalk-solve/src/display/stub.rs
@@ -116,6 +116,14 @@ impl<I: Interner, DB: RustIrDatabase<I>> RustIrDatabase<I> for StubWrapper<'_, D
         unreachable!("impl items should never be stubbed")
     }
 
+    fn associated_ty_from_impl(
+        &self,
+        _impl_id: chalk_ir::ImplId<I>,
+        _assoc_type_id: chalk_ir::AssocTypeId<I>,
+    ) -> Option<crate::rust_ir::AssociatedTyValueId<I>> {
+        unreachable!("should never reach projection if impl datum is not stubbed")
+    }
+
     fn associated_ty_value(
         &self,
         _id: crate::rust_ir::AssociatedTyValueId<I>,

--- a/chalk-solve/src/lib.rs
+++ b/chalk-solve/src/lib.rs
@@ -76,6 +76,12 @@ pub trait RustIrDatabase<I: Interner>: Debug {
     /// Returns the datum for the impl with the given id.
     fn impl_datum(&self, impl_id: ImplId<I>) -> Arc<ImplDatum<I>>;
 
+    fn associated_ty_from_impl(
+        &self,
+        impl_id: ImplId<I>,
+        assoc_type_id: AssocTypeId<I>,
+    ) -> Option<AssociatedTyValueId<I>>;
+
     /// Returns the `AssociatedTyValue` with the given id.
     fn associated_ty_value(&self, id: AssociatedTyValueId<I>) -> Arc<AssociatedTyValue<I>>;
 

--- a/chalk-solve/src/logging_db.rs
+++ b/chalk-solve/src/logging_db.rs
@@ -171,6 +171,14 @@ where
         self.ws.db().hidden_opaque_type(id)
     }
 
+    fn associated_ty_from_impl(
+        &self,
+        impl_id: ImplId<I>,
+        assoc_type_id: AssocTypeId<I>,
+    ) -> Option<AssociatedTyValueId<I>> {
+        self.ws.db().associated_ty_from_impl(impl_id, assoc_type_id)
+    }
+
     fn associated_ty_value(
         &self,
         id: crate::rust_ir::AssociatedTyValueId<I>,
@@ -432,6 +440,14 @@ where
 
     fn impl_datum(&self, impl_id: ImplId<I>) -> Arc<ImplDatum<I>> {
         self.db.impl_datum(impl_id)
+    }
+
+    fn associated_ty_from_impl(
+        &self,
+        impl_id: ImplId<I>,
+        assoc_type_id: AssocTypeId<I>,
+    ) -> Option<AssociatedTyValueId<I>> {
+        self.db.associated_ty_from_impl(impl_id, assoc_type_id)
     }
 
     fn associated_ty_value(

--- a/tests/display/unique_names.rs
+++ b/tests/display/unique_names.rs
@@ -94,6 +94,13 @@ where
     ) -> std::sync::Arc<chalk_solve::rust_ir::ImplDatum<I>> {
         self.db.impl_datum(impl_id)
     }
+    fn associated_ty_from_impl(
+        &self,
+        impl_id: chalk_ir::ImplId<I>,
+        assoc_type_id: chalk_ir::AssocTypeId<I>,
+    ) -> Option<chalk_solve::rust_ir::AssociatedTyValueId<I>> {
+        self.db.associated_ty_from_impl(impl_id, assoc_type_id)
+    }
     fn associated_ty_value(
         &self,
         id: chalk_solve::rust_ir::AssociatedTyValueId<I>,

--- a/tests/integration/panic.rs
+++ b/tests/integration/panic.rs
@@ -118,6 +118,14 @@ impl RustIrDatabase<ChalkIr> for MockDatabase {
         })
     }
 
+    fn associated_ty_from_impl(
+        &self,
+        _impl_id: ImplId<ChalkIr>,
+        _assoc_type_id: AssocTypeId<ChalkIr>,
+    ) -> Option<AssociatedTyValueId<ChalkIr>> {
+        unimplemented!()
+    }
+
     fn associated_ty_value(
         &self,
         id: AssociatedTyValueId<ChalkIr>,


### PR DESCRIPTION
Right now we compute *all* associated types' values in `push_program_clauses_for_associated_type_values_in_impls_of`. This results in a cycle in rust-analyzer's implementation of RPITITs, since we need to be able to compute *some* associated type values before others. For example in:

```
trait Trait {
    type Assoc;
    fn foo() -> impl Sized;
}
impl Trait for () {
    type Assoc = ();
    fn foo() -> Self::Assoc;
}
```

When solving for the hidden type of `fn fooI() -> impl Sized`, we need to be able to normalize `Self::Assoc` *before* we know the value of the RPITIT in `fn foo() -> impl Sized`, which we are currently solving for :D

This PR adds `associated_ty_from_impl`, which will compute that the associated type that is actually the one we're assembling clauses for, rather than iterating through all associated types in the impl. 

This should break the cycle and should be reasonably easy to implement in chalk, though I'd like to know if this method would be difficult to implement: cc @ChayimFriedman2