### PR TITLE
Fix program clause generation for GATs

### DIFF
--- a/chalk-solve/src/rust_ir.rs
+++ b/chalk-solve/src/rust_ir.rs
@@ -442,10 +442,11 @@ impl<I: Interner> AliasEqBound<I> {
 
         let substitution = Substitution::from_iter(
             interner,
-            self.parameters
-                .iter()
+            trait_ref
+                .substitution
+                .iter(interner)
                 .cloned()
-                .chain(trait_ref.substitution.iter(interner).cloned()),
+                .chain(self.parameters.iter().cloned()),
         );
 
         vec![

--- a/tests/test/projection.rs
+++ b/tests/test/projection.rs
@@ -634,6 +634,33 @@ fn gat_in_alias_in_alias_eq() {
 }
 
 #[test]
+fn gat_bound_for_self_type() {
+    test! {
+        program {
+            struct I32 { }
+            trait Trait {
+                type Assoc: Another<Gat<i32> = usize>;
+            }
+            trait Another {
+                type Gat<T>;
+            }
+        }
+
+        goal {
+            forall<T> {
+                exists<U> {
+                    if (T: Trait) {
+                        <<T as Trait>::Assoc as Another>::Gat<i32> = U
+                    }
+                }
+            }
+        } yields[SolverChoice::recursive_default()] {
+            expect![[r#"Unique; substitution [?0 := Uint(Usize)]"#]]
+        }
+    }
+}
+
+#[test]
 fn forall_projection() {
     test! {
         program {


### PR DESCRIPTION
Followup of #827

Found this when updating rust-analyzer